### PR TITLE
fix the appveyor CI for h5py 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,18 @@
-Windows: [![Build status](https://ci.appveyor.com/api/projects/status/4pdlvsj2grtk0hel?svg=true)](https://ci.appveyor.com/project/jonwright/imaged11)
 
-Linux: [![CircleCI](https://circleci.com/gh/jonwright/ImageD11.svg?style=svg)](https://circleci.com/gh/jonwright/ImageD11)
 
-Macos + Linux [![Build Status](https://travis-ci.com/jonwright/ImageD11.svg?branch=master)](https://travis-ci.com/jonwright/ImageD11)
+ImageD11 is a python code for identifying individual grains in spotty area detector X-ray diffraction images.
 
-ImageD11
-Version 1.9.8
-Jon Wright
-wright@esrf.fr
+Version 1.9.8, Jon Wright, wright@esrf.fr
 
 This is the source code for ImageD11. Probably you wanted a compiled version.
 
-Perhaps you can try to get it via:
+You can try to get it via:
 
  `pip install ImageD11`
 
 Some (dated) documentation is here: https://imaged11.readthedocs.io/
 
-If you are at ESRF on a linux computer you could try "module load fable"
+If you are at ESRF on an old linux computer you can try "module load fable". 
 
 To use from git, try this:
 
@@ -32,7 +27,6 @@ If you want the sources then checkout like this:
  Followed by installation in your virtual or conda environment:
  $ pip install dist/ImageD11_[version you built].whl
  ```
- 
 
 After it is installed, you should find a script ImageD11_gui.py, somewhere in your path.
 
@@ -44,7 +38,10 @@ Bug reports are always welcome!
 
 Good luck!
 
+## CI Status
 
+Windows: [![Build status](https://ci.appveyor.com/api/projects/status/4pdlvsj2grtk0hel?svg=true)](https://ci.appveyor.com/project/jonwright/imaged11)
 
+Linux: [![CircleCI](https://circleci.com/gh/jonwright/ImageD11.svg?style=svg)](https://circleci.com/gh/jonwright/ImageD11)
 
-
+Macos + Linux [![Build Status](https://travis-ci.com/jonwright/ImageD11.svg?branch=master)](https://travis-ci.com/jonwright/ImageD11)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,10 @@ install:
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%CONDA%\\Library\\bin;%CONDA%\\DLLS;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
   - conda info -a
+  - python -m pip install --upgrade pip
   - python -m pip install numpy h5py==2.10.0 --only-binary=h5py
   - python setup.py build
-  - python -m pip install .  --ignore-installed certifi --upgrade --upgrade-strategy only-if-needed mypackage
+  - python -m pip install --ignore-installed certifi --upgrade --upgrade-strategy only-if-needed .
 
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - python -m pip install --upgrade pip
   - python -m pip install numpy h5py==2.10.0 --only-binary=h5py
   - python setup.py build
-  - python -m pip install --ignore-installed certifi --upgrade --upgrade-strategy only-if-needed .
+  - python -m pip install --ignore-installed certifi --upgrade-strategy to-satisfy-only .
 
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - python -m pip install --upgrade pip
   - python -m pip install numpy h5py==2.10.0 --only-binary=h5py
   - python setup.py build
-  - python -m pip install --ignore-installed certifi --upgrade-strategy to-satisfy-only .
+  - python -m pip install --ignore-installed certifi --upgrade-strategy only-if-needed --only-binary=h5py .
 
 
 test_script:


### PR DESCRIPTION
Use h5py version 2.10 for windows CI (binary wheels are available for 32bit platform).