### PR TITLE
Add pyproject.toml to avoid pre-installs with pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "six", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
An attempt to make `ImageD11`  installable with `pip` in a clean environment, without any prerequisites.

On a windows 10 using conda (as below) this installs with `pip` and passes `pytest` without any pre-installed packages such as `numpy` or the like. To replicate:

     conda create -n dev_ImageD11 python=3.8
     conda activate dev_ImageD11 
     git clone https://github.com/FABLE-3DXRD/ImageD11.git
     cd ImageD11
     pip install -e .
     conda install pytest
     pytest

