### PR TITLE
Trying to fix pip install / numpy problem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "six", "wheel", "numpy"]
+requires = ["setuptools", "six", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
-requires = ["setuptools", "six", "wheel", "oldest-supported-numpy"]
+requires = ["setuptools",
+            "six",
+            "wheel",
+            "numpy; python_version=='2.7'",
+            "oldest-supported-numpy; python_version>='3.0'" ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
So pip is installing the latest numpy to compile when you have an older incompatible version installed already. At least I think that is what happened. So we try to depend on oldest-supported-numpy instead, which does not exist on python2.