### PR TITLE
Add diffraction origin peak updating to columnfile.py

### DIFF
--- a/ImageD11/columnfile.py
+++ b/ImageD11/columnfile.py
@@ -429,9 +429,16 @@ class columnfile(object):
         peaks_xyz = np.array((xl,yl,zl))
         assert "omega" in self.titles,"No omega column"
         om = self.omega *  float( pars.get("omegasign") )
-        tth, eta = transform.compute_tth_eta_from_xyz(
-            peaks_xyz, om,
-            **pars.parameters)
+        if "dox" in self.titles and "doy" in self.titles and "doz" in self.titles:
+            # respect diffraction origin positions, dox, doy, doz...
+            s1 = peaks_xyz - np.array((self.dox, self.doy, self.doz))
+            eta = np.degrees(np.arctan2(-s1[1, :], s1[2, :]))
+            s1_perp_x = np.sqrt(s1[1, :] * s1[1, :] + s1[2, :] * s1[2, :])
+            tth = np.degrees(np.arctan2(s1_perp_x, s1[0, :]))
+        else:
+            tth, eta = transform.compute_tth_eta_from_xyz(
+                peaks_xyz, om,
+                **pars.parameters)
         gx, gy, gz = transform.compute_g_vectors(
             tth, eta, om,
             wvln  = pars.get("wavelength"),


### PR DESCRIPTION
This is a first suggestion for how the `columnfile.updateGeometry()` could be modified to make it possible for users that are interested in correcting their peak positions based on some belived diffraction origin positions rather than assuming that all peaks come from the origin as is currently assumed in  `columnfile.updateGeometry()`. Such corrections can be crucial for larger samples when recovering strains and lattice variations.

**Example:** *consider a scenario where we have a columnfile, `colf`, and a list of grains, `grains`, each featuring a centroid translation in x-lab coordinates `grains[i].dx` and a translation in  y-lab coordinates `grains[i].dy`. Additionally, each grain has a mask, `grains[i].mask`, indicating which peaks it has indexed in the `colf`. Then we may adopt something like the below to update the columnfile to better respect the fact that each peak is originating form a different part in the sample:*

```python
    colf.addcolumn( np.zeros((colf.nrows, )), 'gtx' )
    colf.addcolumn( np.zeros((colf.nrows, )), 'gty' )
    for g in grains:
        colf.gtx[g.mask] = g.dx
        colf.gty[g.mask] = g.dy
    s = np.sin(np.radians(colf.omega))
    c = np.cos(np.radians(colf.omega))
    colf.addcolumn( c*colf.gtx - s*colf.gty,  'dox' )
    colf.addcolumn( np.zeros((colf.nrows, )), 'doy' )
    colf.addcolumn( np.zeros((colf.nrows, )), 'doz' )
    colf.updateGeometry() # every peak is re-computed using an individual grain centroid...
 ```
*The idea is that once the columns `dox,doy,doz` have been set, specifying the diffraction origin (do) for each peak, the `columnfile.updateGeometry()` will respect this and compute the `tth,eta,gx,gy,gz` in accordance. In general one may set `dox, doy, doz` differently also within each `grains[i].mask` using information from the reconstructed grain shapes etc.*
