### PR TITLE
Add build wheels, tarball and deploy to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Build and deploy
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            cibw_archs: "auto64"
+          #- os: ubuntu-20.04
+          #  cibw_archs: "auto32"
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
+          - os: ubuntu-20.04
+            cibw_archs: "ppc64le"
+          - os: windows-2019
+            cibw_archs: "auto64"
+          #- os: windows-2019
+          #  cibw_archs: "auto32"
+          - os: macos-11
+            cibw_archs: "universal2"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.2
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          # Do not build for pypy, muslinux and python3.12 on ppc64le
+          CIBW_SKIP: pp* *-musllinux_* cp312-*linux_ppc64le
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
+          # Use silx wheelhouse: needed for ppc64le
+          CIBW_ENVIRONMENT_LINUX: "PIP_FIND_LINKS=https://www.silx.org/pub/wheelhouse/ PIP_TRUSTED_HOST=www.silx.org"
+
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {project}/test
+          # Skip tests for 32bits and emulated architectures, arm64 macos and on Windows
+          # Skip cp312 tests for now: not all dependencies are available.
+          CIBW_TEST_SKIP: "*cp312-* *-*linux_i686 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-win_amd64"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - name: Check the package
+        run: |
+          python -m twine check dist/*
+
+      - name: Install and test sdist
+        run: |
+          pip install --pre dist/ImageD11*.tar.gz
+          pytest test
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  pypi-publish:
+    needs: [build_wheels, build_sdist]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR adds a github actions "workflow" to automate the generation of wheels thanks to [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) and the upload to pypi thanks to [gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish).
This workflow is triggered when a release is published in github.
I already did the set-up to use [pypi's trusted publishers](https://docs.pypi.org/trusted-publishers/). As it is you have to publish a github release on a tag starting with `v` to trigger the workflow and click on a button approve the upload to pypi. This can be more automated (e.g., upload when a tag is pushed to the repo but it makes it more sensitive to errors).

It build the source distribution and wheels for Python 3.7 to 3.12 for:
- MacOS: `universal2`, i.e., `x86_64` and `arm64`
- Windows: `x86_64`
- Linux: `x86_64`, `aarch64` and `ppc64le`

Tests are run only on "native" architecture (i.e., `x86_64`).
It could also build for 32bits architecture on Windows and Linux but dependencies like `scipy` are not available for this architecture so it has little interest.

Limitations:
- No python3.12 wheel for `ppc64le`: This can be done but not for `manylinux2014` as I didn't managed to build a wheel of `numpy` for python3.12 on `ppc64le` (yet?).
- No tests on Windows, if I recall it was failing on compiling `bslz4_to_sparse`, so the solution could be to generate wheels for this project too.
- No tests for emulated architectures.

I tested the deployment on test.pypi.org
