### PR TITLE
Add scanning 3DXRD example notebooks

### DIFF
--- a/ImageD11/nbGui/S3DXRD/0_S3DXRD_segment_and_label_single_dset.ipynb
+++ b/ImageD11/nbGui/S3DXRD/0_S3DXRD_segment_and_label_single_dset.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8deabe5b",
+   "metadata": {},
+   "source": [
+    "# Jupyter notebook based on ImageD11 to process scanning 3DXRD data\n",
+    "# Written by Haixing Fang, Jon Wright and James Ball\n",
+    "## Date: 16/01/2024"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "851fcab9-7631-439f-885c-438bcefeac84",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# There is a bug with the current version of ImageD11 in the site-wide Jupyter env.\n",
+    "# This has been fixed here: https://github.com/FABLE-3DXRD/ImageD11/commit/4af88b886b1775585e868f2339a0eb975401468f\n",
+    "# Until a new release has been made and added to the env, we need to get the latest version of ImageD11 from GitHub\n",
+    "# Put it in your home directory somewhere\n",
+    "# USER: Change the path below to point to your local copy of ImageD11:\n",
+    "\n",
+    "id11_code_path = \"/home/esrf/james1997a/Code/ImageD11\"\n",
+    "\n",
+    "import sys\n",
+    "\n",
+    "sys.path.insert(0, id11_code_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b5c1db6-5a32-4294-abef-cfc2150d24de",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import functions we need\n",
+    "\n",
+    "import os, glob, pprint\n",
+    "\n",
+    "import ImageD11.sinograms.dataset\n",
+    "import ImageD11.sinograms.lima_segmenter\n",
+    "import ImageD11.sinograms.assemble_label\n",
+    "import ImageD11.sinograms.properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f45e3647-2e1b-4a31-b5de-01adbd4d7573",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Check that we're importing ImageD11 from the home directory rather than from the Jupyter kernel\n",
+    "\n",
+    "?ImageD11.sinograms.dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a307437-2d15-4de5-985f-7c7daf68db0c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: specify your experimental directory\n",
+    "\n",
+    "base_dir = \"/home/esrf/james1997a/Data/ihma439/id11/20231211\"\n",
+    "\n",
+    "rawdata_path = os.path.join(base_dir, 'RAW_DATA')\n",
+    "\n",
+    "!ls -lrt {rawdata_path}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad077c4b-39cc-4b90-9637-33c32f12e364",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: pick a sample and a dataset you want to segment\n",
+    "\n",
+    "sample = \"FeAu_0p5_tR_nscope\"\n",
+    "dataset = \"top_700um\"\n",
+    "\n",
+    "# USER: specify path to detector mask\n",
+    "\n",
+    "mask_path = '/data/id11/nanoscope/Eiger/eiger_mask_E-08-0173_20231127.edf'\n",
+    "\n",
+    "processed_data_root_dir = os.path.join(base_dir, 'PROCESSED_DATA/James')  # USER: modify this to change the destination folder if desired\n",
+    "sparse_pixels_dir = os.path.join(processed_data_root_dir, \"SparsePixels_NewMask\")  # USER: modify this to change the name of the SparsePixels folder inside processed_data_root_dir\n",
+    "\n",
+    "# makes folders if they don't already exist\n",
+    "\n",
+    "if not os.path.exists(processed_data_root_dir):\n",
+    "    os.makedir(processed_data_root_dir)\n",
+    "    \n",
+    "if not os.path.exists(sparse_pixels_dir):\n",
+    "    os.makedirs(sparse_pixels_dir)\n",
+    "\n",
+    "# desination of H5 files\n",
+    "\n",
+    "dset_path = os.path.join(sparse_pixels_dir, f\"ds_{sample}_{dataset}.h5\" )\n",
+    "sparse_path = os.path.join(sparse_pixels_dir, f'{sample}_{dataset}_sparse.h5')\n",
+    "pks_path = os.path.join(sparse_pixels_dir, f'pks_{sample}_{dataset}.h5')\n",
+    "\n",
+    "# create ImageD11 dataset object\n",
+    "\n",
+    "ds = ImageD11.sinograms.dataset.DataSet(dataroot=rawdata_path,\n",
+    "                                        analysisroot=sparse_pixels_dir,\n",
+    "                                        sample=sample,\n",
+    "                                        dset=dataset)\n",
+    "ds.import_all()\n",
+    "ds.save(dset_path)\n",
+    "\n",
+    "# create batch file to send to SLURM cluster\n",
+    "\n",
+    "sbat = ImageD11.sinograms.lima_segmenter.setup(dset_path, maskfile=mask_path)\n",
+    "sbat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b8bb44d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# send batch file to SLURM cluster\n",
+    "\n",
+    "!sbatch {sbat}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a057fef3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# check status of SLURM jobs\n",
+    "\n",
+    "!squeue -u $USER"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b56de064-adb9-4d9c-92e8-301d24598f16",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# you must wait until the SLURM jobs have completed before running the next cell!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5de23264-4c22-43fe-8be6-8cc54039ea2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# label sparse peaks\n",
+    "\n",
+    "ImageD11.sinograms.assemble_label.main(dset_path, sparse_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddb029cd-7f66-4c91-abee-5f1723303360",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# generate peaks table\n",
+    "\n",
+    "ImageD11.sinograms.properties.main(dset_path, sparse_path, pks_path, options={'algorithm': 'lmlabel', 'wtmax': 70000, 'save_overlaps': False})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b6e6575-bb8e-47ac-88e1-0ff5350ab1a5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ImageD11/nbGui/S3DXRD/1_S3DXRD_index_z_slice.ipynb
+++ b/ImageD11/nbGui/S3DXRD/1_S3DXRD_index_z_slice.ipynb
@@ -1,0 +1,715 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Jupyter notebook based on ImageD11 to process scanning 3DXRD data\n",
+    "# Written by Haixing Fang, Jon Wright and James Ball\n",
+    "## Date: 16/01/2024"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# There is a bug with the current version of ImageD11 in the site-wide Jupyter env.\n",
+    "# This has been fixed here: https://github.com/FABLE-3DXRD/ImageD11/commit/4af88b886b1775585e868f2339a0eb975401468f\n",
+    "# Until a new release has been made and added to the env, we need to get the latest version of ImageD11 from GitHub\n",
+    "# Put it in your home directory somewhere\n",
+    "# USER: Change the path below to point to your local copy of ImageD11:\n",
+    "\n",
+    "id11_code_path = \"/home/esrf/james1997a/Code/ImageD11\"\n",
+    "\n",
+    "import sys\n",
+    "\n",
+    "sys.path.insert(0, id11_code_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import functions we need\n",
+    "\n",
+    "import os, glob, pprint\n",
+    "import numpy as np\n",
+    "import matplotlib\n",
+    "import h5py\n",
+    "\n",
+    "%matplotlib widget\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "import ImageD11.grain\n",
+    "import ImageD11.unitcell\n",
+    "import ImageD11.indexing\n",
+    "import ImageD11.columnfile\n",
+    "import ImageD11.refinegrains\n",
+    "import ImageD11.sinograms.dataset\n",
+    "import ImageD11.sinograms.properties\n",
+    "import ImageD11.sinograms.lima_segmenter\n",
+    "import ImageD11.sinograms.assemble_label\n",
+    "\n",
+    "from ImageD11.blobcorrector import eiger_spatial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: specify your experimental directory\n",
+    "\n",
+    "base_dir = \"/home/esrf/james1997a/Data/ihma439/id11/20231211\"\n",
+    "\n",
+    "rawdata_path = os.path.join(base_dir, 'RAW_DATA')\n",
+    "\n",
+    "!ls -lrt {rawdata_path}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: pick a sample and a dataset you want to segment\n",
+    "\n",
+    "sample = \"FeAu_0p5_tR_nscope\"\n",
+    "dataset = \"top_700um\"\n",
+    "\n",
+    "# USER: specify path to detector mask\n",
+    "\n",
+    "processed_data_root_dir = os.path.join(base_dir, 'PROCESSED_DATA/James')  # USER: modify this to change the destination folder if desired\n",
+    "sparse_pixels_dir = os.path.join(processed_data_root_dir, \"SparsePixels_NewMask\")  # USER: modify this to change the name of the SparsePixels folder inside processed_data_root_dir\n",
+    "\n",
+    "# desination of H5 files\n",
+    "\n",
+    "dset_path = os.path.join(sparse_pixels_dir, f\"ds_{sample}_{dataset}.h5\" )\n",
+    "sparse_path = os.path.join(sparse_pixels_dir, f'{sample}_{dataset}_sparse.h5')\n",
+    "pks_path = os.path.join(sparse_pixels_dir, f'pks_{sample}_{dataset}.h5')\n",
+    "cf_path = os.path.join(sparse_pixels_dir, f'cf_{sample}_{dataset}.h5')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load the dataset from file\n",
+    "\n",
+    "ds = ImageD11.sinograms.dataset.load(dset_path)\n",
+    "\n",
+    "print(ds)\n",
+    "print(ds.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# merge your peaks in 2D and 4D\n",
+    "\n",
+    "peaks_table = ImageD11.sinograms.properties.pks_table.load(pks_path)\n",
+    "peaks_4d = peaks_table.pk2dmerge(ds.omega, ds.dty)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Generate a mask that selects only 4D peaks greater than 25 pixels in size\n",
+    "\n",
+    "m = peaks_4d['Number_of_pixels'] > 25\n",
+    "\n",
+    "# then plot omega vs dty for all peaks - should look sinusoidal\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "counts, xedges, yedges, im = ax.hist2d(peaks_4d['omega'][m], peaks_4d['dty'][m], weights=np.sqrt(peaks_4d['sum_intensity'][m]), bins=(ds.obinedges, ds.ybinedges), norm=matplotlib.colors.LogNorm())\n",
+    "ax.set_xlabel(\"Omega angle\")\n",
+    "ax.set_ylabel(\"dty\")\n",
+    "\n",
+    "fig.colorbar(im, ax=ax)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# We will now generate a cf (columnfile) object each for the 2D and 4D peaks.\n",
+    "# These columnfile objects will be corrected for detector spatial distortion\n",
+    "# USER: specify the paths to the dxfile and dyfile\n",
+    "\n",
+    "e2dx_path = os.path.join(processed_data_root_dir, '../CeO2/e2dx_E-08-0173_20231127.edf')\n",
+    "e2dy_path = os.path.join(processed_data_root_dir, '../CeO2/e2dy_E-08-0173_20231127.edf')\n",
+    "\n",
+    "# USER: specify the path to the parameter file\n",
+    "\n",
+    "par_path = 'Fe_refined.par'\n",
+    "\n",
+    "spatial_correction_function = eiger_spatial(dxfile=e2dx_path, dyfile=e2dy_path)\n",
+    "\n",
+    "spatial_correction_dict_4d = spatial_correction_function(peaks_4d)\n",
+    "\n",
+    "cf_4d = ImageD11.columnfile.colfile_from_dict(spatial_correction_dict_4d)\n",
+    "\n",
+    "# Filter the columnfile to select only peaks greater than 5 pixels in size\n",
+    "\n",
+    "print(f\"{cf_4d.nrows} peaks before filtration\")\n",
+    "cf_4d.filter(cf_4d.Number_of_pixels > 5)\n",
+    "print(f\"{cf_4d.nrows} peaks after filtration\")\n",
+    "\n",
+    "# calculates the scattering vector (g-vector) geometries using parameters from the file\n",
+    "\n",
+    "cf_4d.parameters.loadparameters(par_path)\n",
+    "\n",
+    "cf_4d.updateGeometry()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# plot the 4D peaks (fewer of them) as a cake (two-theta vs eta)\n",
+    "# if the parameters in the par file are good, these should look like straight lines\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "ax.scatter(cf_4d.tth, cf_4d.eta, s=1)\n",
+    "\n",
+    "ax.set_xlabel(\"Two-theta\")\n",
+    "ax.set_ylabel(\"eta\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# OPTIONAL: export CF to an flt so we can play with it with ImageD11_gui\n",
+    "# uncomment the below line\n",
+    "\n",
+    "# cf_4d.writefile(f'{sample}_{dataset}_4d_peaks.flt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def strongest_peaks(colf, uself=True, frac=0.995, B=0.2, doplot=None):\n",
+    "    # correct intensities for structure factor (decreases with 2theta)\n",
+    "    cor_intensity = colf.sum_intensity * (np.exp(colf.ds*colf.ds*B))\n",
+    "    if uself:\n",
+    "        lf = ImageD11.refinegrains.lf(colf.tth, colf.eta)\n",
+    "        cor_intensity *= lf\n",
+    "    order = np.argsort( cor_intensity )[::-1] # sort the peaks by intensity\n",
+    "    sortedpks = cor_intensity[order]\n",
+    "    cums =  np.cumsum(sortedpks)\n",
+    "    cums /= cums[-1]\n",
+    "    enough = np.searchsorted(cums, frac)\n",
+    "    # Aim is to select the strongest peaks for indexing.\n",
+    "    cutoff = sortedpks[enough]\n",
+    "    mask = cor_intensity > cutoff\n",
+    "    if doplot is not None:\n",
+    "        fig, axs = plt.subplots(1,2,figsize=(10,5))\n",
+    "        axs[0].plot(cums/cums[-1], ',')\n",
+    "        axs[0].set(xlabel='npks',ylabel='fractional intensity')\n",
+    "        axs[0].plot([mask.sum(),], [frac,], \"o\" )\n",
+    "        axs[1].plot(cums/cums[-1], ',')\n",
+    "        axs[1].set(xlabel='npks logscale',ylabel='fractional intensity', xscale='log', ylim=(doplot,1.), \n",
+    "                 xlim=(np.searchsorted(cums, doplot), len(cums)))\n",
+    "        axs[1].plot( [mask.sum(),], [frac,], \"o\" )\n",
+    "        plt.show()\n",
+    "    return mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# here we are filtering our peaks (cf_4d) to select only the strongest ones for indexing\n",
+    "\n",
+    "# USER: modify the \"frac\" parameter below and re-run the cell until the orange dot sits nicely on the \"elbow\" of the blue line\n",
+    "# this indicates the fractional intensity cutoff we will select\n",
+    "# if the blue line does not look elbow-shaped in the logscale plot, try changing the \"doplot\" parameter (the y scale of the logscale plot) until it does\n",
+    "\n",
+    "ms = strongest_peaks(cf_4d, frac=0.99, doplot=0.8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# strongest_peaks returns a mask for cf_4d, so now we filter the peaks by the mask to keep only the brightest ones\n",
+    "\n",
+    "cf_4d.filter(ms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we can take a look at the intensities of the remaining peaks\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "ax.plot(cf_4d.tth, cf_4d.sum_intensity,',')\n",
+    "ax.semilogy()\n",
+    "\n",
+    "ax.set_xlabel(\"Two-theta\")\n",
+    "ax.set_ylabel(\"Intensity\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we can define a unit cell from our parameters\n",
+    "\n",
+    "Fe = ImageD11.unitcell.unitcell_from_parameters(cf_4d.parameters)\n",
+    "Fe.makerings(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now let's plot our peaks again, with the rings from the unitcell included, to check our lattice parameters are good\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "skip=1\n",
+    "ax.plot( cf_4d.ds[::skip], cf_4d.eta[::skip],',',alpha=0.5)\n",
+    "ax.plot( Fe.ringds, [0,]*len(Fe.ringds), '|', ms=90 )\n",
+    "ax.set_xlabel('1 / d ($\\AA$)')\n",
+    "ax.set_ylabel('$\\\\eta$ (deg)')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Let's copy our 4D peaks to a new object, so we can filter them for indexing\n",
+    "\n",
+    "cf_4d_to_index = cf_4d.copy()\n",
+    "\n",
+    "# remove peaks with two-theta > 25 (edge of detector)\n",
+    "\n",
+    "cf_4d_to_index.filter(cf_4d_to_index.tth < 25)\n",
+    "\n",
+    "# specify our ImageD11 indexer with these peaks\n",
+    "\n",
+    "indexer = ImageD11.indexing.indexer_from_colfile(cf_4d_to_index)\n",
+    "\n",
+    "print(f\"Indexing {cf_4d_to_index.nrows} peaks\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: set a tolerance in d-space (for assigning peaks to powder rings)\n",
+    "\n",
+    "indexer.ds_tol = 0.01\n",
+    "\n",
+    "# change the log level so we can see what the ring assigments look like\n",
+    "\n",
+    "ImageD11.indexing.loglevel = 1\n",
+    "\n",
+    "# assign peaks to powder rings\n",
+    "\n",
+    "indexer.assigntorings()\n",
+    "\n",
+    "# change log level back again\n",
+    "\n",
+    "ImageD11.indexing.loglevel = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# let's plot the assigned peaks\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "# indexer.ra is the ring assignments\n",
+    "\n",
+    "ax.scatter(cf_4d_to_index.ds, cf_4d_to_index.eta, c=indexer.ra, cmap='tab20', s=1)\n",
+    "ax.set_xlabel(\"d-star\")\n",
+    "ax.set_ylabel(\"eta\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# check the maximum expected peaks\n",
+    "allpks = np.sum([len(indexer.unitcell.ringhkls[ds]) for ds in indexer.unitcell.ringds])\n",
+    "allpks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we are indexing!\n",
+    "# USER: specify the rings you want to use for indexing\n",
+    "rings = 2, 4, 6, 1\n",
+    "\n",
+    "# USER: specify the HKL tolerances you want to use for indexing\n",
+    "\n",
+    "# hkl_tols_seq = [0.050, 0.025, 0.010]\n",
+    "hkl_tols_seq = [0.04]\n",
+    "\n",
+    "# USER: specify the fraction of the total expected peaks\n",
+    "\n",
+    "# fracs = (0.75, 0.5)\n",
+    "fracs = [0.75]\n",
+    "\n",
+    "ImageD11.cImageD11.cimaged11_omp_set_num_threads(1)\n",
+    "ImageD11.indexing.loglevel=3\n",
+    "\n",
+    "# iterate over HKL tolerances\n",
+    "for tol in hkl_tols_seq:\n",
+    "    # iterate over minpks fractions\n",
+    "    for frac in fracs:\n",
+    "        for indexer.ring_1 in rings:\n",
+    "            for indexer.ring_2 in rings:\n",
+    "                indexer.minpks = allpks*frac\n",
+    "                indexer.hkl_tol = tol\n",
+    "                indexer.find()\n",
+    "                indexer.scorethem()                \n",
+    "        print(frac, tol, len(indexer.ubis))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def plot_index_results(ind, colfile, title):\n",
+    "    # Generate a histogram of |drlv| for a ubi matrix\n",
+    "    indexer.histogram_drlv_fit()\n",
+    "    indexer.fight_over_peaks()\n",
+    "    \n",
+    "    fig, axs = plt.subplots(3, 2, layout=\"constrained\", figsize=(9,12))\n",
+    "    axs_flat = axs.ravel()\n",
+    "    \n",
+    "    # For each grain, plot the error in hkl vs the number of peaks with that error\n",
+    "    \n",
+    "    for grh in ind.histogram:\n",
+    "        axs_flat[0].plot(ind.bins[1:-1], grh[:-1], \"-\")\n",
+    "    \n",
+    "    axs_flat[0].set(ylabel=\"number of peaks\",\n",
+    "                    xlabel=\"error in hkl (e.g. hkl versus integer)\",\n",
+    "                    title=title)\n",
+    "    \n",
+    "    # set a mask of all non-assigned g-vectors\n",
+    "    \n",
+    "    m = ind.ga == -1\n",
+    "    \n",
+    "    # plot the assigned g-vectors omega vs dty (sinograms)\n",
+    "    \n",
+    "    axs_flat[1].scatter(colfile.omega[~m],\n",
+    "                        colfile.dty[~m],\n",
+    "                        c=ind.ga[~m],\n",
+    "                        s=2,\n",
+    "                        cmap='tab20')\n",
+    "    \n",
+    "    axs_flat[1].set(title=f'Sinograms of {ind.ga.max()+1} grains',\n",
+    "                    xlabel='Omega/deg',\n",
+    "                    ylabel='dty/um')\n",
+    "    \n",
+    "    # Define weak peaks as all non-assigned peaks with intensity 1e-4 of max\n",
+    "    cut = colfile.sum_intensity[m].max() * 1e-4\n",
+    "    weak = colfile.sum_intensity[m] < cut\n",
+    "    \n",
+    "    # Plot unassigned peaks in omega vs dty\n",
+    "    \n",
+    "    axs_flat[2].scatter(colfile.omega[m][weak],  colfile.dty[m][weak],  s=2, label='weak')\n",
+    "    axs_flat[2].scatter(colfile.omega[m][~weak], colfile.dty[m][~weak], s=2, label='not weak')\n",
+    "    \n",
+    "    axs_flat[2].set(title='Sinograms of unassigned peaks',\n",
+    "                    xlabel='Omega/deg',\n",
+    "                    ylabel='dty/um')\n",
+    "    axs_flat[2].legend()\n",
+    "    \n",
+    "    # Plot d-star vs intensity for all assigned peaks\n",
+    "    \n",
+    "    axs_flat[3].scatter(colfile.ds[~m], colfile.sum_intensity[~m], s=2)\n",
+    "    axs_flat[3].set(title='Intensity of all assigned peaks',\n",
+    "                    xlabel='d-star',\n",
+    "                    ylabel='Intensity',\n",
+    "                    yscale='log')\n",
+    "    \n",
+    "    # Plot d-star vs intensity for all unassigned peaks\n",
+    "    \n",
+    "    axs_flat[4].scatter(colfile.ds[m][weak],  colfile.sum_intensity[m][weak],  s=2, label='weak')\n",
+    "    axs_flat[4].scatter(colfile.ds[m][~weak], colfile.sum_intensity[m][~weak], s=2, label='not weak')\n",
+    "    \n",
+    "    axs_flat[4].set(title='Intensity of all unassigned peaks',\n",
+    "                    xlabel='d-star',\n",
+    "                    ylabel='Intensity',\n",
+    "                    yscale='log')\n",
+    "    axs_flat[4].legend()\n",
+    "    \n",
+    "    # Get the number of peaks per grain\n",
+    "    \n",
+    "    npks = [(ind.ga == i).sum() for i in range(len(ind.ubis))]\n",
+    "    \n",
+    "    # Plot histogram of number of peaks per grain\n",
+    "    \n",
+    "    axs_flat[5].hist(npks, bins=64)\n",
+    "    axs_flat[5].set(title='Hist of peaks per grain',\n",
+    "                    xlabel='Number of peaks',\n",
+    "                    ylabel='Number of grains')\n",
+    "    \n",
+    "    for ax in axs_flat:\n",
+    "        ax.set_box_aspect(0.7)\n",
+    "    \n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plot_index_results(indexer, cf_4d_to_index, 'First attempt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: Define HKL tolerance to try to assign all peaks to existing grains\n",
+    "\n",
+    "hkl_tol = 0.04\n",
+    "\n",
+    "# Get an array of g-vectors from the columnfile\n",
+    "gvectors = np.transpose((cf_4d.gx, cf_4d.gy, cf_4d.gz)).copy()\n",
+    "n_gvectors = len(gvectors)\n",
+    "\n",
+    "# Make storage arrays for errors (drlv2) and labels\n",
+    "# both arrays are persistent throughout assigments\n",
+    "# so they get steadily improved over time\n",
+    "drlv2 = np.full(n_gvectors, 2, dtype=float)\n",
+    "labels = np.full(n_gvectors, -1, 'i')\n",
+    "\n",
+    "# Create array of grain objects, one per UBI matrix from indexer.ubis\n",
+    "grains = [ImageD11.grain.grain(ubi.copy()) for ubi in indexer.ubis]\n",
+    "\n",
+    "# print what fraction of the g-vectors are unassigned:\n",
+    "print(f\"Trying to assign {cf_4d.nrows} peaks\")\n",
+    "print(f\"Currently {(indexer.ga != -1).sum()/cf_4d.nrows} of peaks are assigned\")\n",
+    "\n",
+    "# Iterate over each UBI matrix\n",
+    "for i, grain in enumerate(grains):\n",
+    "    # Assign g-vectors to this grain if drlv2 < htl_tol**2\n",
+    "    # Then refine the grain using all the assigned g-vectors\n",
+    "    ImageD11.cImageD11.score_and_refine(grain.ubi, gvectors, hkl_tol)\n",
+    "    ImageD11.cImageD11.score_and_refine(grain.ubi, gvectors, hkl_tol)\n",
+    "    # assign all g-vectors to new refined grain\n",
+    "    # will re-assign g-vectors if this grain gives a lower error than currently assigned\n",
+    "    # updates drlv2 with new errors for new assignments\n",
+    "    # updates labels with new assignments\n",
+    "    ImageD11.cImageD11.score_and_assign(grain.ubi, gvectors, hkl_tol, drlv2, labels, i)\n",
+    "    # pretend all g-vectors are unassigned\n",
+    "    label_all_unassigned = np.full(n_gvectors, -1, 'i')\n",
+    "    # pretend all grains have max error\n",
+    "    drlv2_all_max = np.full(n_gvectors, 2, dtype=float)\n",
+    "    # score and assign again\n",
+    "    # updates drlv2_all_max with new errors for new assignments\n",
+    "    # updates label_all_unassigned with new assignments\n",
+    "    # now work out which g-vectors were assigned to this grain\n",
+    "    # I think allpks is \"greedy\"\n",
+    "    # In that it greedily assigns peaks to this grain assuming all other peaks are unassigned with max error\n",
+    "    ImageD11.cImageD11.score_and_assign(grain.ubi, gvectors, hkl_tol, drlv2_all_max, label_all_unassigned, i)\n",
+    "\n",
+    "    grain.allpks = label_all_unassigned == i\n",
+    "    # work out the sum of the intensities of all assigned g-vectors\n",
+    "    grain.isum = cf_4d.sum_intensity[grain.allpks].sum()\n",
+    "\n",
+    "# # Iterate over each grain again after all assigned\n",
+    "for i, grain in enumerate(grains):\n",
+    "    # Get the assigned peaks for this grain\n",
+    "    grain.pks = labels == i\n",
+    "    # Get the total number of assigned peaks for this grain\n",
+    "    grain.npks = grain.pks.sum()\n",
+    "    \n",
+    "    # Calculate the real hkls for each gvector of this grain\n",
+    "    hklr = np.dot(grain.ubi, gvectors[grain.pks].T)\n",
+    "    # Round them to integers\n",
+    "    hkli = np.round(hklr).astype(int)\n",
+    "    \n",
+    "    # Work out the number of unique peaks per grain\n",
+    "    # By removing duplicates\n",
+    "    uniqpks = np.unique(np.vstack((hkli, np.sign(cf_4d.eta[grain.pks]).astype(int))),axis=1)\n",
+    "    grain.nuniq = uniqpks.shape[1]\n",
+    "\n",
+    "print(f\"Now {(labels!=-1).sum()/len(labels)} of peaks are assigned\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Save the output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Add labels as a new column in the columnfile\n",
+    "\n",
+    "cf_4d.addcolumn(labels, 'grain_id')\n",
+    "\n",
+    "# Delete the columnfile output file if it exists\n",
+    "if os.path.exists(cf_path):\n",
+    "    os.remove(cf_path)\n",
+    "\n",
+    "# Write columnfile as an HDF file\n",
+    "ImageD11.columnfile.colfile_to_hdf(cf_4d, cf_path)\n",
+    "\n",
+    "# add UBIs as a new dataset\n",
+    "# also add greedy peaks\n",
+    "with h5py.File(cf_path,'a') as hout:\n",
+    "    hout.create_dataset('ubis', data=np.array([grain.ubi for grain in grains]))\n",
+    "    hout.create_dataset('ubis_allpks', data=np.array([grain.allpks for grain in grains]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ImageD11/nbGui/S3DXRD/2_S3DXRD_sinograms_map.ipynb
+++ b/ImageD11/nbGui/S3DXRD/2_S3DXRD_sinograms_map.ipynb
@@ -1,0 +1,1010 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Jupyter notebook based on ImageD11 to process scanning 3DXRD data\n",
+    "# Written by Haixing Fang, Jon Wright and James Ball\n",
+    "## Date: 16/01/2024"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# There is a bug with the current version of ImageD11 in the site-wide Jupyter env.\n",
+    "# This has been fixed here: https://github.com/FABLE-3DXRD/ImageD11/commit/4af88b886b1775585e868f2339a0eb975401468f\n",
+    "# Until a new release has been made and added to the env, we need to get the latest version of ImageD11 from GitHub\n",
+    "# Put it in your home directory somewhere\n",
+    "# USER: Change the path below to point to your local copy of ImageD11:\n",
+    "\n",
+    "id11_code_path = \"/home/esrf/james1997a/Code/ImageD11\"\n",
+    "\n",
+    "import sys\n",
+    "\n",
+    "sys.path.insert(0, id11_code_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import functions we need\n",
+    "\n",
+    "import os\n",
+    "import concurrent.futures\n",
+    "import timeit\n",
+    "\n",
+    "import matplotlib\n",
+    "%matplotlib widget\n",
+    "\n",
+    "import h5py\n",
+    "import tqdm\n",
+    "import numba\n",
+    "import pprint\n",
+    "import numpy as np\n",
+    "import skimage.transform\n",
+    "import ipywidgets as ipyw\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import ImageD11.columnfile\n",
+    "import ImageD11.sinograms.properties\n",
+    "import ImageD11.sinograms.roi_iradon\n",
+    "from ImageD11.blobcorrector import eiger_spatial\n",
+    "from ImageD11.grain import grain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: specify your experimental directory\n",
+    "\n",
+    "base_dir = \"/home/esrf/james1997a/Data/ihma439/id11/20231211\"\n",
+    "\n",
+    "rawdata_path = os.path.join(base_dir, 'RAW_DATA')\n",
+    "\n",
+    "!ls -lrt {rawdata_path}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: pick a sample and a dataset you want to segment\n",
+    "\n",
+    "sample = \"FeAu_0p5_tR_nscope\"\n",
+    "dataset = \"top_700um\"\n",
+    "\n",
+    "# USER: specify path to detector mask\n",
+    "\n",
+    "processed_data_root_dir = os.path.join(base_dir, 'PROCESSED_DATA/James')  # USER: modify this to change the destination folder if desired\n",
+    "sparse_pixels_dir = os.path.join(processed_data_root_dir, \"SparsePixels_NewMask\")  # USER: modify this to change the name of the SparsePixels folder inside processed_data_root_dir\n",
+    "\n",
+    "# desination of H5 files\n",
+    "\n",
+    "dset_path = os.path.join(sparse_pixels_dir, f\"ds_{sample}_{dataset}.h5\" )\n",
+    "sparse_path = os.path.join(sparse_pixels_dir, f'{sample}_{dataset}_sparse.h5')\n",
+    "pks_path = os.path.join(sparse_pixels_dir, f'pks_{sample}_{dataset}.h5')\n",
+    "cf_path = os.path.join(sparse_pixels_dir, f'cf_{sample}_{dataset}.h5')\n",
+    "grain_map_path = os.path.join(sparse_pixels_dir, f'map_{sample}_{dataset}.h5')\n",
+    "ubi_path = os.path.join(sparse_pixels_dir, f'{sample}_{dataset}.ubi')\n",
+    "parfile = 'Fe_refined.par'\n",
+    "\n",
+    "e2dx_path = os.path.join(processed_data_root_dir, '../CeO2/e2dx_E-08-0173_20231127.edf')\n",
+    "e2dy_path = os.path.join(processed_data_root_dir, '../CeO2/e2dy_E-08-0173_20231127.edf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# This is the result from some indexing on a merged/cleaned 3d peaks file\n",
+    "\n",
+    "cf = ImageD11.columnfile.columnfile(cf_path) # has the peak <-> grain labelling for 3D spots\n",
+    "\n",
+    "with h5py.File(cf_path, 'r') as hin:         # the matching ubis\n",
+    "    print(list(hin))\n",
+    "    ubis = hin['ubis'][:]\n",
+    "    allpks = hin['ubis_allpks'][:].sum(axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# convert UBIs to grain objects here so we can directly access the unit cell lengths\n",
+    "\n",
+    "# grains should be a list\n",
+    "# grain GIDs should be assigned as attributes\n",
+    "\n",
+    "grains = []\n",
+    "for gid, ubi in enumerate(ubis):\n",
+    "    g = ImageD11.grain.grain(ubi)\n",
+    "    g.gid = gid\n",
+    "    g.a = np.cbrt(np.linalg.det(g.ubi))\n",
+    "    grains.append(g)\n",
+    "    \n",
+    "mean_unit_cell_lengths = [grain.a for grain in grains]\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(mean_unit_cell_lengths)\n",
+    "ax.set_xlabel(\"Grain ID\")\n",
+    "ax.set_ylabel(\"Unit cell length\")\n",
+    "plt.show()\n",
+    "\n",
+    "a0 = np.median(mean_unit_cell_lengths)\n",
+    "    \n",
+    "print(a0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "len(grains) # number of grains"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(allpks,'+')\n",
+    "ax.set_ylabel('Number of 3D merged spots')\n",
+    "ax.set_xlabel('Grain ID')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "grid_size = np.ceil(np.sqrt(len(grains))).astype(int)\n",
+    "\n",
+    "fig, axs = plt.subplots(grid_size, grid_size, figsize=(10,10), layout=\"constrained\", sharex=True, sharey=True)\n",
+    "for i, ax in enumerate(axs.ravel()):\n",
+    "    if i < len(grains):\n",
+    "    # get corresponding grain for this axis\n",
+    "        g = grains[i]\n",
+    "        m = cf.grain_id == g.gid\n",
+    "        ax.plot(cf.omega[m], cf.dty[m], ',')\n",
+    "        \n",
+    "fig.supxlabel(\"Omega\")\n",
+    "fig.supylabel(\"Y translation (um)\")\n",
+    "    \n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def grain_to_rgb(g, ax=(0,0,1)):# symmetry = Symmetry.cubic):\n",
+    "    # FIXME\n",
+    "    r = np.random.random(3)\n",
+    "    return r/r.max()\n",
+    "    # the_rod = ti.ubi_to_rod(ubis[i])\n",
+    "    # the_rod[2] = -the_rod[2]  # correct from vertical flip on the eiger detector : DONE in parfile\n",
+    "    o = Orientation.from_rodrigues(g.Rod)\n",
+    "    # add 30 degrees to match the pymicro/dct convention for hexagonal\n",
+    "    # ... this is pretty strange? Different choice of B matrix?\n",
+    "    # it's because pymicro uses inverted orientations!\n",
+    "    # need to use Orientation(g.U.T)\n",
+    "    o = Orientation.from_euler(o.euler + np.array([0, 0, 30]))\n",
+    "    axis = np.array( ax, float )\n",
+    "    return o.get_ipf_colour(axis=axis, symmetry=symmetry) #saturate=True)\n",
+    "\n",
+    "\n",
+    "def calcy(cos_omega, sin_omega, sol):\n",
+    "    return sol[0] + cos_omega*sol[1] + sin_omega*sol[2]\n",
+    "\n",
+    "def fity(y, cos_omega, sin_omega, wt=1):\n",
+    "    \"\"\"\n",
+    "    Fit a sinogram to get a grain centroid\n",
+    "    # calc = d0 + x*co + y*so\n",
+    "    # dc/dpar : d0 = 1\n",
+    "    #         :  x = co\n",
+    "    #         :  y = so\n",
+    "    # gradients\n",
+    "    # What method is being used here???????????\n",
+    "    \"\"\"\n",
+    "    g = [wt*np.ones(y.shape, float),  wt*cos_omega, wt*sin_omega]\n",
+    "    nv = len(g)\n",
+    "    m = np.zeros((nv,nv),float)\n",
+    "    r = np.zeros( nv, float )\n",
+    "    for i in range(nv):\n",
+    "        r[i] = np.dot( g[i], wt * y )\n",
+    "        for j in range(i,nv):\n",
+    "            m[i,j] = np.dot( g[i], g[j] )\n",
+    "            m[j,i] = m[i,j]\n",
+    "    sol = np.dot(np.linalg.inv(m), r)\n",
+    "    return sol\n",
+    "\n",
+    "\n",
+    "def fity_robust(dty, co, so, nsigma=5, doplot=False):\n",
+    "    # NEEDS COMMENTING\n",
+    "    cen, dx, dy = fity(dty, co, so)\n",
+    "    calc2 = calc1 = calcy(co, so, (cen, dx, dy))\n",
+    "    selected = np.ones(co.shape, bool)\n",
+    "    for i in range(3):\n",
+    "        err = dty - calc2\n",
+    "        estd = max( err[selected].std(), 1.0 ) # 1 micron\n",
+    "        #print(i,estd)\n",
+    "        es = estd*nsigma\n",
+    "        selected = abs(err) < es\n",
+    "        cen, dx, dy = fity( dty, co, so, selected.astype(float) )\n",
+    "        calc2 = calcy(co, so, (cen, dx, dy))\n",
+    "    # bad peaks are > 5 sigma\n",
+    "    if doplot:\n",
+    "        f, a = plt.subplots(1,2)\n",
+    "        theta = np.arctan2( so, co )\n",
+    "        a[0].plot(theta, calc1, ',')\n",
+    "        a[0].plot(theta, calc2, ',')\n",
+    "        a[0].plot(theta[selected], dty[selected], \"o\")\n",
+    "        a[0].plot(theta[~selected], dty[~selected], 'x')\n",
+    "        a[1].plot(theta[selected], (calc2 - dty)[selected], 'o')\n",
+    "        a[1].plot(theta[~selected], (calc2 - dty)[~selected], 'x')\n",
+    "        a[1].set(ylim = (-es, es))\n",
+    "        pl.show()\n",
+    "    return selected, cen, dx, dy\n",
+    "\n",
+    "def graincen(gid, colf, doplot=True):\n",
+    "    # Get peaks beloging to this grain ID\n",
+    "    m = colf.grain_id == gid\n",
+    "    # Get omega values of peaks in radians\n",
+    "    romega = np.radians(colf.omega[m])\n",
+    "    # Calculate cos and sin of omega\n",
+    "    co = np.cos(romega)\n",
+    "    so = np.sin(romega)\n",
+    "    # Get dty values of peaks\n",
+    "    dty = colf.dty[m]\n",
+    "    selected, cen, dx, dy = fity_robust(dty, co, so, doplot=doplot)\n",
+    "    return selected, cen, dx, dy\n",
+    "\n",
+    "\n",
+    "@numba.njit(parallel=True)\n",
+    "def pmax(ary):\n",
+    "    \"\"\" Find the min/max of an array in parallel \"\"\"\n",
+    "    mx = ary.flat[0]\n",
+    "    mn = ary.flat[0]\n",
+    "    for i in numba.prange(1,ary.size):\n",
+    "        mx = max( ary.flat[i], mx )\n",
+    "        mn = min( ary.flat[i], mn )\n",
+    "    return mn, mx\n",
+    "\n",
+    "@numba.njit(parallel=True)\n",
+    "def palloc(shape, dtype):\n",
+    "    \"\"\" Allocate and fill an array with zeros in parallel \"\"\"\n",
+    "    ary = np.empty(shape, dtype=dtype)\n",
+    "    for i in numba.prange( ary.size ):\n",
+    "        ary.flat[i] = 0\n",
+    "    return ary\n",
+    "\n",
+    "# counting sort by grain_id\n",
+    "@numba.njit\n",
+    "def counting_sort(ary, maxval=None, minval=None):\n",
+    "    \"\"\" Radix sort for integer array. Single threaded. O(n)\n",
+    "    Numpy should be doing this...\n",
+    "    \"\"\"\n",
+    "    if maxval is None:\n",
+    "        assert minval is None\n",
+    "        minval, maxval = pmax( ary ) # find with a first pass\n",
+    "    maxval = int(maxval)\n",
+    "    minval = int(minval)\n",
+    "    histogram = palloc( (maxval - minval + 1,), np.int64 )\n",
+    "    indices = palloc( (maxval - minval + 2,), np.int64 )\n",
+    "    result = palloc( ary.shape, np.int64 )\n",
+    "    for gid in ary:\n",
+    "        histogram[gid - minval] += 1\n",
+    "    indices[0] = 0\n",
+    "    for i in range(len(histogram)):\n",
+    "        indices[ i + 1 ] = indices[i] + histogram[i]\n",
+    "    i = 0\n",
+    "    for gid in ary:\n",
+    "        j = gid - minval\n",
+    "        result[indices[j]] = i\n",
+    "        indices[j] += 1\n",
+    "        i += 1\n",
+    "    return result, histogram\n",
+    "\n",
+    "\n",
+    "@numba.njit(parallel=True)\n",
+    "def find_grain_id(spot3d_id, grain_id, spot2d_label, grain_label, order, nthreads=20):\n",
+    "    \"\"\"\n",
+    "    Assignment grain labels into the peaks 2d array\n",
+    "    spot3d_id = the 3d spot labels that are merged and indexed\n",
+    "    grain_id = the grains assigned to the 3D merged peaks\n",
+    "    spot2d_label = the 3d label for each 2d peak\n",
+    "    grain_label => output, which grain is this peak\n",
+    "    order = the order to traverse spot2d_label sorted\n",
+    "    \"\"\"\n",
+    "    assert spot3d_id.shape == grain_id.shape\n",
+    "    assert spot2d_label.shape == grain_label.shape\n",
+    "    assert spot2d_label.shape == order.shape\n",
+    "    T = nthreads\n",
+    "    print(\"Using\",T,\"threads\")\n",
+    "    for tid in numba.prange( T ):\n",
+    "        pcf = 0 # thread local I hope?\n",
+    "        for i in order[tid::T]:\n",
+    "            grain_label[i] = -1\n",
+    "            pkid = spot2d_label[i]\n",
+    "            while spot3d_id[pcf] < pkid:\n",
+    "                pcf += 1\n",
+    "            if spot3d_id[pcf] == pkid:\n",
+    "                grain_label[i] = grain_id[pcf]\n",
+    "                \n",
+    "\n",
+    "def tocolf(pkd, parfile, dxfile=e2dx_path, dyfile=e2dy_path):\n",
+    "    \"\"\" Converts a dictionary of peaks into and ImageD11 columnfile\n",
+    "    adds on the geometric computations (tth, eta, gvector, etc) \"\"\"\n",
+    "    spat = eiger_spatial(dxfile=dxfile, dyfile=dyfile)\n",
+    "    cf = ImageD11.columnfile.colfile_from_dict(spat(pkd))\n",
+    "    cf.parameters.loadparameters(parfile)\n",
+    "    cf.updateGeometry()\n",
+    "    return cf\n",
+    "\n",
+    "def map_grain_from_peaks(g, flt, ds):\n",
+    "    \"\"\"\n",
+    "    Computes sinogram\n",
+    "    flt is already the peaks for this grain\n",
+    "    Runs iradon\n",
+    "    Returns angles, sino, recon\n",
+    "    \"\"\"   \n",
+    "    NY = len(ds.ybincens)\n",
+    "    iy = np.round((flt.dty - ds.ybincens[0]) / (ds.ybincens[1]-ds.ybincens[0])).astype(int)\n",
+    "\n",
+    "    # The problem is to assign each spot to a place in the sinogram\n",
+    "    hklmin = g.hkl.min(axis=1)\n",
+    "    dh = g.hkl - hklmin[:,np.newaxis]\n",
+    "    de = (g.etasigns.astype(int) + 1)//2\n",
+    "    #   4D array of h,k,l,+/-\n",
+    "    pkmsk = np.zeros(list(dh.max(axis=1) + 1 )+[2,], int)\n",
+    "    pkmsk[ dh[0], dh[1], dh[2], de ] = 1\n",
+    "    #   sinogram row to hit\n",
+    "    pkrow = np.cumsum(pkmsk.ravel()).reshape(pkmsk.shape) - 1\n",
+    "    pkhkle = np.arange(np.prod( pkmsk.shape), dtype=int)[pkmsk.flat == 1]\n",
+    "    # keep the indices in the grain\n",
+    "    #pkindices = np.argwhere( pkmsk==1 ) + np.concatenate( (hklmin, [0]) )\n",
+    "    pkindices = np.transpose(np.unravel_index(pkhkle, pkmsk.shape)) + np.concatenate((hklmin, [0]))\n",
+    "    \n",
+    "    npks = pkmsk.sum()\n",
+    "    destRow = pkrow[ dh[0], dh[1], dh[2], de ] \n",
+    "    sino = np.zeros((npks, NY), 'f')\n",
+    "    hits = np.zeros((npks, NY), 'f')\n",
+    "    angs = np.zeros((npks, NY), 'f')\n",
+    "    adr = destRow * NY + iy \n",
+    "    # Just accumulate \n",
+    "    sig = flt.sum_intensity\n",
+    "    ImageD11.cImageD11.put_incr64( sino, adr, sig )\n",
+    "    ImageD11.cImageD11.put_incr64( hits, adr, np.ones(len(de),dtype='f'))\n",
+    "    ImageD11.cImageD11.put_incr64( angs, adr, flt.omega)\n",
+    "    \n",
+    "    sinoangles = angs.sum(axis=1) / hits.sum(axis = 1)\n",
+    "    # Normalise:\n",
+    "    # sino = sino.T/sino.max( axis=1 )).T\n",
+    "    # Sort (cosmetic):\n",
+    "    order = np.lexsort( (np.arange(npks), sinoangles) )\n",
+    "    sinoangles = sinoangles[order]\n",
+    "    ssino = sino[order].T\n",
+    "    return sinoangles, ssino, hits[order].T, pkindices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for grain in grains:\n",
+    "    grain.pks3d, grain.cen, grain.dx, grain.dy = graincen(grain.gid, cf, doplot=False)\n",
+    "    grain.rgb_z = grain_to_rgb(grain, ax=(0,0,1),)# symmetry = Symmetry.cubic)\n",
+    "    grain.rgb_y = grain_to_rgb(grain, ax=(0,1,0),)# symmetry = Symmetry.cubic)\n",
+    "    grain.rgb_x = grain_to_rgb(grain, ax=(1,0,0),)# symmetry = Symmetry.cubic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # focus on a particular grain and try to clean up the assigned peaks\n",
+    "\n",
+    "# def omega_to_dty(g, omega):\n",
+    "#     romega = np.radians(omega)\n",
+    "#     co = np.cos(romega)\n",
+    "#     so = np.sin(romega)\n",
+    "#     dty = g.cen + g.dx * co + g.dy * so\n",
+    "#     return dty\n",
+    "\n",
+    "# fig, axs = plt.subplots(3, 1, layout=\"constrained\", sharex=True)\n",
+    "# g = grains[9]\n",
+    "# m = cf.grain_id == g.gid\n",
+    "# axs[0].scatter(cf.omega[m], cf.dty[m], label=\"Raw data\")\n",
+    "# axs[0].scatter(cf.omega[m], omega_to_dty(g, cf.omega[m]), label=\"Fitted dty from omega\")\n",
+    "\n",
+    "# residuals = cf.dty[m] - omega_to_dty(g, cf.omega[m])\n",
+    "\n",
+    "# axs[1].scatter(cf.omega[m], residuals, label=\"residuals\")\n",
+    "\n",
+    "# # generate mask of peaks to unassign based on strength of residuals\n",
+    "\n",
+    "# residual_mask = np.abs(residuals) > 10  # um\n",
+    "\n",
+    "# # expand the mask to the shape of the grain\n",
+    "\n",
+    "# this_gid_mask = m.copy()\n",
+    "# this_gid_mask[np.where(this_gid_mask)] = residual_mask.reshape(this_gid_mask[np.where(this_gid_mask)].shape)\n",
+    "\n",
+    "# # unassign peaks that meet the mask\n",
+    "\n",
+    "# cf.grain_id[this_gid_mask] = -1\n",
+    "\n",
+    "# # reselect assigned peaks (replot to ensure we unassigned the outliers)\n",
+    "\n",
+    "# m = cf.grain_id == g.gid\n",
+    "    \n",
+    "# # only plot grains that survive\n",
+    "\n",
+    "# axs[2].scatter(cf.omega[m], cf.dty[m], label=\"masked peaks\")\n",
+    "\n",
+    "# axs[0].legend()\n",
+    "# axs[1].legend()\n",
+    "# axs[2].legend()\n",
+    "\n",
+    "# fig.supxlabel(\"Omega\")\n",
+    "# fig.supylabel(\"Y translation (um)\")\n",
+    "\n",
+    "# plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # do for all grains\n",
+    "\n",
+    "# for g in grains[1:]:\n",
+    "#     m = cf.grain_id == g.gid\n",
+    "#     residuals = cf.dty[m] - omega_to_dty(g, cf.omega[m])\n",
+    "#     residual_mask = np.abs(residuals) > 10  # um\n",
+    "\n",
+    "#     # expand the mask to the shape of the grain\n",
+    "\n",
+    "#     this_gid_mask = m.copy()\n",
+    "#     this_gid_mask[np.where(this_gid_mask)] = residual_mask.reshape(this_gid_mask[np.where(this_gid_mask)].shape)\n",
+    "\n",
+    "#     # unassign peaks that meet the mask\n",
+    "\n",
+    "#     cf.grain_id[this_gid_mask] = -1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# grid_size = np.ceil(np.sqrt(len(grains))).astype(int)\n",
+    "\n",
+    "# fig, axs = plt.subplots(grid_size, grid_size, figsize=(10,10), layout=\"constrained\", sharex=True, sharey=True)\n",
+    "# for i, ax in enumerate(axs.ravel()):\n",
+    "#     if i < len(grains):\n",
+    "#     # get corresponding grain for this axis\n",
+    "#         g = grains[i]\n",
+    "#         m = cf.grain_id == g.gid\n",
+    "#         ax.plot(cf.omega[m], cf.dty[m], ',')\n",
+    "        \n",
+    "# fig.supxlabel(\"Omega\")\n",
+    "# fig.supylabel(\"Y translation (um)\")\n",
+    "    \n",
+    "# plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# make sure we get cen right (centre of rotation should be the middle of dty)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot([g.cen for g in grains])\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "c0 = np.median([g.cen for g in grains])\n",
+    "\n",
+    "print('Center of rotation in dty', c0)\n",
+    "\n",
+    "# c0 is being correctly determined\n",
+    "# we know this because of the earlier single-grain dty vs omega plot\n",
+    "# if g.cen was off, the fit would be shifted\n",
+    "# this means we have another parameter we need to introduce\n",
+    "# to account for uneven spacing either side of the center of rotation?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.style.use('dark_background')\n",
+    "fig, ax = plt.subplots(2,2, figsize=(12,12))\n",
+    "a = ax.ravel()\n",
+    "x = [g.dx for g in grains]\n",
+    "y = [g.dy for g in grains]\n",
+    "s = [g.pks3d.sum()/20 for g in grains]\n",
+    "a[0].scatter(x, y, s=s, c=[g.rgb_z for g in grains])\n",
+    "a[0].set(title='IPF color Z',  aspect='equal')\n",
+    "a[1].scatter(x, y, s=s, c=[g.rgb_y for g in grains])\n",
+    "a[1].set(title='IPF color Y', aspect='equal')\n",
+    "a[2].scatter(x, y, s=s, c=[g.rgb_x for g in grains])\n",
+    "a[2].set(title='IPF color X',  aspect='equal')\n",
+    "a[3].scatter(x, y, c=s)\n",
+    "a[3].set(title='Number of 3d peaks', aspect='equal')\n",
+    "\n",
+    "fig.supxlabel(\"Lab x\")\n",
+    "fig.supylabel(\"Lab y\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Big scary block\n",
+    "# Must understand what this does!\n",
+    "\n",
+    "# Ensure cf is sorted by spot3d_id\n",
+    "# NOTE: spot3d_id should be spot4d_id, because we have merged into 4D?\n",
+    "assert (np.argsort(cf.spot3d_id) == np.arange(cf.nrows)).all()\n",
+    "\n",
+    "# load the 2d peak labelling output\n",
+    "pks = ImageD11.sinograms.properties.pks_table.load(pks_path)\n",
+    "\n",
+    "# Load the dataset (for motor positions, not sure why these are not in peaks)\n",
+    "ds = ImageD11.sinograms.dataset.load(dset_path)\n",
+    "\n",
+    "# Grab the 2d peak centroids\n",
+    "p2d = pks.pk2d(ds.omega, ds.dty)\n",
+    "\n",
+    "numba_order, numba_histo = counting_sort(p2d['spot3d_id'])\n",
+    "\n",
+    "grain_2d_id = palloc(p2d['spot3d_id'].shape, np.dtype(int))\n",
+    "\n",
+    "cleanid = cf.grain_id.copy()\n",
+    "\n",
+    "find_grain_id(cf.spot3d_id, cleanid, p2d['spot3d_id'], grain_2d_id, numba_order)\n",
+    "\n",
+    "gord, counts = counting_sort(grain_2d_id)\n",
+    "\n",
+    "inds = np.concatenate(((0,), np.cumsum(counts)))\n",
+    "\n",
+    "# I think what we end up with is:\n",
+    "# inds\n",
+    "# this is an array which tells you which 2D spots each grain owns\n",
+    "# the 2D spots are sorted by spot ID\n",
+    "# inds tells you for each grain were you can find its associated 2D spots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def do_sinos(g, hkltol=0.050):\n",
+    "    i = g.gid\n",
+    "    # the inds[0] refers to not indexed peaks\n",
+    "    g.pks = gord[ inds[i+1] : inds[i+2] ]  \n",
+    "    assert grain_2d_id[g.pks[0]] == i\n",
+    "    flt = tocolf( {p:p2d[p][g.pks] for p in p2d} , parfile)\n",
+    "    hkl_real = np.dot( g.ubi, (flt.gx, flt.gy, flt.gz) )\n",
+    "    hkl_int = np.round(hkl_real).astype(int)\n",
+    "    dh = ((hkl_real - hkl_int)**2).sum(axis = 0)\n",
+    "    assert len(dh)  == flt.nrows\n",
+    "    g.dherrall = dh.mean()\n",
+    "    g.npksall = flt.nrows\n",
+    "    flt.filter( dh < hkltol*hkltol )\n",
+    "    hkl_real = np.dot(g.ubi, (flt.gx, flt.gy, flt.gz))\n",
+    "    hkl_int = np.round(hkl_real).astype(int)\n",
+    "    dh = ((hkl_real - hkl_int)**2).sum(axis = 0)\n",
+    "    g.dherr = dh.mean()\n",
+    "    g.npks = flt.nrows\n",
+    "    g.etasigns = np.sign( flt.eta )\n",
+    "    g.hkl = hkl_int\n",
+    "    g.sinoangles, g.ssino, g.hits, g.shkle = map_grain_from_peaks(g, flt, ds)\n",
+    "    return i,g"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Determine sinograms of all grains\n",
+    "\n",
+    "nthreads = len(os.sched_getaffinity(os.getpid()))\n",
+    "\n",
+    "with concurrent.futures.ThreadPoolExecutor(max_workers= max(1,nthreads-1)) as pool:\n",
+    "    for i in tqdm.tqdm(pool.map(do_sinos, grains), total=len(grains)):\n",
+    "        pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.plot([grain.npksall for grain in grains],\n",
+    "        [grain.dherrall for grain in grains], '.')\n",
+    "ax.plot([grain.npks for grain in grains],\n",
+    "        [grain.dherr for grain in grains], '.')\n",
+    "ax.set_xlabel(\"Number of peaks\")\n",
+    "ax.set_ylabel(\"Mean dH^2\")\n",
+    "ax.loglog()\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Show sinogram of single grain\n",
+    "\n",
+    "i = 21\n",
+    "plt.figure(figsize=(15,10))\n",
+    "plt.imshow((grains[i].ssino/grains[i].ssino.mean(axis=0)), norm=matplotlib.colors.LogNorm(), interpolation='nearest', origin=\"lower\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gcalc = np.dot(grains[i].UB, grains[i].shkle[:,:3].T)\n",
+    "print(gcalc.shape)\n",
+    "gz_gxy = abs(gcalc[2]) / np.sqrt((gcalc[0]**2 + gcalc[1]**2))\n",
+    "# ~sin(eta)\n",
+    "dscalc = np.linalg.norm(gcalc, axis=0)\n",
+    "plt.figure()\n",
+    "plt.plot(gz_gxy, grains[i].ssino.sum(axis=0), '.')\n",
+    "plt.semilogy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def run_iradon(i, pad=20, y0=c0/2):\n",
+    "    g = grains[i]\n",
+    "    outsize = g.ssino.shape[0] + pad\n",
+    "    \n",
+    "    # Perform iradon transform of grain sinogram, store result (reconstructed grain shape) in g.recon\n",
+    "    g.recon = ImageD11.sinograms.roi_iradon.iradon(g.ssino/g.ssino.mean(axis=0), \n",
+    "                                                   theta=g.sinoangles, \n",
+    "                                                   output_size=outsize,\n",
+    "                                                   projection_shifts=np.full(g.ssino.shape, -y0),\n",
+    "                                                   filter_name='hamming',\n",
+    "                                                  )\n",
+    "    return i, g"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Run iradon on a single grain\n",
+    "\n",
+    "i, g = run_iradon(21, pad=20, y0=c0/2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1,2,figsize=(15,10))\n",
+    "axs[0].imshow(g.ssino, origin=\"lower\")\n",
+    "axs[0].set_title(\"ID11 Sinogram\")\n",
+    "axs[1].imshow(g.recon, origin=\"lower\")\n",
+    "axs[1].set_title(\"ID11 iradon\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with concurrent.futures.ThreadPoolExecutor( max_workers= max(1,nthreads-1) ) as pool:\n",
+    "    for i in tqdm.tqdm(pool.map( run_iradon, range(len(grains))), total=len(grains)):\n",
+    "        pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def crystal_direction_cubic( ubi, axis ):\n",
+    "    hkl = np.dot( ubi, axis )\n",
+    "    # cubic symmetry implies:\n",
+    "    #      24 permutations of h,k,l\n",
+    "    #      one has abs(h) <= abs(k) <= abs(l)\n",
+    "    hkl= abs(hkl)\n",
+    "    hkl.sort()\n",
+    "    return hkl\n",
+    "\n",
+    "def hkl_to_color_cubic( hkl ):\n",
+    "    \"\"\"\n",
+    "    https://mathematica.stackexchange.com/questions/47492/how-to-create-an-inverse-pole-figure-color-map\n",
+    "        [x,y,z]=u⋅[0,0,1]+v⋅[0,1,1]+w⋅[1,1,1].\n",
+    "            These are:\n",
+    "                u=z−y, v=y−x, w=x\n",
+    "                This triple is used to assign each direction inside the standard triangle\n",
+    "                \n",
+    "    makeColor[{x_, y_, z_}] := \n",
+    "         RGBColor @@ ({z - y, y - x, x}/Max@{z - y, y - x, x})                \n",
+    "    \"\"\"\n",
+    "    x,y,z = hkl\n",
+    "    assert x<=y<=z\n",
+    "    assert z>=0\n",
+    "    u,v,w = z-y, y-x, x\n",
+    "    m = max( u, v, w )\n",
+    "    r,g,b = u/m, v/m, w/m\n",
+    "    return (r,g,b)\n",
+    "\n",
+    "def hkl_to_pf_cubic( hkl ):\n",
+    "    x,y,z = hkl\n",
+    "    assert x<=y<=z\n",
+    "    assert z>=0\n",
+    "    m = np.sqrt((hkl**2).sum())\n",
+    "    return x/(z+m), y/(z+m)\n",
+    "\n",
+    "def triangle(  ):\n",
+    "    \"\"\" compute a series of point on the edge of the triangle \"\"\"\n",
+    "    xy = [ np.array(v) for v in ( (0,1,1), (0,0,1), (1,1,1)) ]\n",
+    "    xy += [ xy[2]*(1-t) + xy[0]*t for t in np.linspace(0.1,1,5)]\n",
+    "    return np.array( [hkl_to_pf_cubic( np.array(p) ) for p in xy] )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f,a = plt.subplots( 1,3, figsize=(15,5) )\n",
+    "ty, tx = triangle().T\n",
+    "for i,title in enumerate( 'xyz' ):\n",
+    "    ax = np.zeros(3)\n",
+    "    ax[i] = 1.\n",
+    "    hkl = [crystal_direction_cubic( g.ubi, ax ) for g in grains]\n",
+    "    xy = np.array([hkl_to_pf_cubic(h) for h in hkl ])\n",
+    "    rgb = np.array([hkl_to_color_cubic(h) for h in hkl ])\n",
+    "    for j in range(len(grains)):\n",
+    "        grains[j].rgb = rgb[j]\n",
+    "    a[i].scatter( xy[:,1], xy[:,0], c = rgb )   # Note the \"x\" axis of the plot is the 'k' direction and 'y' is h (smaller)\n",
+    "    a[i].set(title=title, aspect='equal', facecolor='silver', xticks=[], yticks=[])\n",
+    "    a[i].plot( tx, ty, 'k-', lw = 1 )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "l = np.zeros_like( grains[0].recon ) - 1\n",
+    "red = np.zeros_like( grains[0].recon )\n",
+    "grn = np.zeros_like( grains[0].recon )\n",
+    "blu = np.zeros_like( grains[0].recon )\n",
+    "s = np.zeros_like( grains[0].recon )\n",
+    "for g in grains:\n",
+    "    # print(i, scale)\n",
+    "    r = g.recon / g.recon.max()\n",
+    "    m = r > s\n",
+    "    px = r[m]\n",
+    "    s[m] = px\n",
+    "    red[m] = px*g.rgb[0]\n",
+    "    grn[m] = px*g.rgb[1]\n",
+    "    blu[m] = px*g.rgb[2]\n",
+    "    l[m] = g.gid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "r.shape, g.ssino.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "image_to_show = np.transpose((red, grn, blu), axes=(2, 1, 0))\n",
+    "# uncomment below to clean up streaks in image a bit (while lying!)\n",
+    "# image_to_show[image_to_show.sum(axis=2) < 0.3] = [0,0,0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "grain_map_image_name = os.path.splitext(os.path.split(grain_map_path)[1])[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15,15))\n",
+    "plt.imshow(image_to_show)  # originally 1,2,0\n",
+    "plt.savefig(grain_map_image_name + '.png')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for g in grains:\n",
+    "    g.translation = (0,0,0)\n",
+    "ImageD11.grain.write_grain_file(ubi_path, grains)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds some example notebooks for simple scanning 3DXRD data analysis.
The general plan is as follows:

1. These notebooks become the authoritative starting point for S3DXRD processing going forward
2. Update the Confluence documentation to point to the notebooks on GitHub
3. Make suggested changes/improvements by @jonwright
4. Move any scary maths out of the notebooks and into ImageD11 itself
5. Continue documentation of a few functions/figures that are still undocumented/uncommented
6. Do the same thing for box scanning