### PR TITLE
Exclude Python 3.12 in setup.py

### DIFF
--- a/.github/workflows/build_flake_pytest_ubuntu2004.yml
+++ b/.github/workflows/build_flake_pytest_ubuntu2004.yml
@@ -15,9 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.8", "3.11", "3.x"]
-        exclude:
-          - python-version: "3.12"
+        python-version: ["2.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_flake_pytest_ubuntu2004.yml
+++ b/.github/workflows/build_flake_pytest_ubuntu2004.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["2.7", "3.8", "3.11", "3.x"]
         exclude:
-          python-version: "3.12"
+          - python-version: "3.12"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_flake_pytest_ubuntu2004.yml
+++ b/.github/workflows/build_flake_pytest_ubuntu2004.yml
@@ -16,7 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["2.7", "3.8", "3.11", "3.x"]
-
+        exclude:
+          python-version: "3.12"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -202,6 +202,7 @@ setup(name='ImageD11',
       cmdclass={ 'build_ext' : build_ext_subclass },
       description='ImageD11',
       license = "GPL",
+      python_requires='<3.12',  # Numba still not working for 3.12
       ext_package = "ImageD11",   # Puts extensions in the ImageD11 directory
       ext_modules = [extension,],
       setup_requires = minimal,   # to compile


### PR DESCRIPTION
Until Numba updates to Python 3.12
This should fix the CI for Python 3.x