### PR TITLE
Change from 32-bit to 64-bit for int and float in HDF colfile

### DIFF
--- a/ImageD11/columnfile.py
+++ b/ImageD11/columnfile.py
@@ -502,9 +502,9 @@ try:
         g.attrs['ImageD11_type'] = 'peaks'
         for t in c.titles:
             if t in INTS:
-                ty = np.int32
+                ty = np.int64
             else:
-                ty = np.float32
+                ty = np.float64
             # print "adding",t,ty
             dat = getattr(c, t).astype( ty )
             if t in list(g.keys()):
@@ -534,9 +534,9 @@ try:
         g.attrs['ImageD11_type'] = 'peaks'
         for t in cf.titles:
             if t in INTS:
-                ty = np.int32
+                ty = np.int64
             else:
-                ty = np.float32
+                ty = np.float64
             g.create_dataset( t, data = getattr(cf, t).astype( ty ) )
         h.close()
 


### PR DESCRIPTION
In a 4D merged peak colfile, we can exceed the int32 max value in the `sum_intensity` column (see image attached).
This leads to a loss of precision when saving to HDF.
This is resolved by changing to 64-bit dtypes for these values.
![image](https://github.com/FABLE-3DXRD/ImageD11/assets/42615415/9ee97ef7-173c-4626-9650-eb42e59dc6d5)
