### PR TITLE
Update release continuous integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-*
@@ -59,8 +59,9 @@ jobs:
           # Skip cp312 tests for now: not all dependencies are available.
           CIBW_TEST_SKIP: "*cp312-* *-*linux_i686 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-win_amd64"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -69,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -91,8 +92,9 @@ jobs:
           pip install --pre dist/ImageD11*.tar.gz
           pytest test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   pypi-publish:
@@ -107,9 +109,10 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR:
- Updates `cibuildwheel` action to fix an issue on Windows (see https://github.com/pypa/cibuildwheel/releases/tag/v2.16.5)
- Updates `upload|download-artifacts` actions: This now allows to download the produced wheel/tarball from the action page (see https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)