### PR TITLE
ImageD11_gui fixes and some scanning notebooks updates

### DIFF
--- a/ImageD11/nbGui/S3DXRD/1_S3DXRD_index_z_slice_minor_phase.ipynb
+++ b/ImageD11/nbGui/S3DXRD/1_S3DXRD_index_z_slice_minor_phase.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Jupyter notebook based on ImageD11 to process scanning 3DXRD data\n",
     "# Written by Haixing Fang, Jon Wright and James Ball\n",
-    "## Date: 19/02/2024"
+    "## Date: 21/02/2024"
    ]
   },
   {
@@ -53,7 +53,7 @@
     "%matplotlib widget\n",
     "from matplotlib import pyplot as plt\n",
     "\n",
-    "import utils\n",
+    "import ImageD11.nbGui.nb_utils as utils\n",
     "\n",
     "import ImageD11.grain\n",
     "import ImageD11.unitcell\n",
@@ -76,21 +76,19 @@
    },
    "outputs": [],
    "source": [
-    "# OLD DATASETS\n",
-    "\n",
     "# NOTE: For old datasets before the new directory layout structure, we don't distinguish between RAW_DATA and PROCESSED_DATA\n",
     "# In this case, use this cell to specify where your experimental folder is, and do not run the cell below\n",
-    "# e.g /data/visitor/4752/id11/20210513\n",
+    "# e.g /data/visitor/ma4752/id11/20210513\n",
     "\n",
     "### USER: specify your experimental directory\n",
     "\n",
-    "rawdata_path = \"/home/esrf/james1997a/Data/ma4752/id11/20210618\"\n",
+    "rawdata_path = \"/home/esrf/james1997a/Data/ihma439/id11/20231211/RAW_DATA\"\n",
     "\n",
     "!ls -lrt {rawdata_path}\n",
     "\n",
     "### USER: specify where you want your processed data to go\n",
     "\n",
-    "processed_data_root_dir = \"/home/esrf/james1997a/Data/ma4752/id11/20240118/James\""
+    "processed_data_root_dir = \"/home/esrf/james1997a/Data/ihma439/id11/20231211/PROCESSED_DATA/James/20240221\""
    ]
   },
   {
@@ -103,8 +101,8 @@
    "source": [
     "# USER: pick a sample and a dataset you want to segment\n",
     "\n",
-    "sample = \"MA4752_S4_2_XRD\"\n",
-    "dataset = \"DTL1z90\""
+    "sample = \"FeAu_0p5_tR_nscope\"\n",
+    "dataset = \"top_100um\""
    ]
   },
   {
@@ -119,8 +117,12 @@
     "\n",
     "dset_path = os.path.join(processed_data_root_dir, sample, f\"{sample}_{dataset}\", f\"{sample}_{dataset}_dataset.h5\")\n",
     "\n",
-    "e2dx_path = \"/data/id11/nanoscope/Eiger/spatial_20210415_JW/e2dx.edf\"\n",
-    "e2dy_path = \"/data/id11/nanoscope/Eiger/spatial_20210415_JW/e2dy.edf\""
+    "# USER: specify the path to the parameter file\n",
+    "\n",
+    "par_path = os.path.join(processed_data_root_dir, 'Fe_refined.par')\n",
+    "\n",
+    "e2dx_path = os.path.join(processed_data_root_dir, '../../CeO2/e2dx_E-08-0173_20231127.edf')\n",
+    "e2dy_path = os.path.join(processed_data_root_dir, '../../CeO2/e2dy_E-08-0173_20231127.edf')"
    ]
   },
   {
@@ -137,17 +139,6 @@
     "\n",
     "print(ds)\n",
     "print(ds.shape)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "par_path = 'nickel.par'"
    ]
   },
   {
@@ -345,61 +336,32 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# now we are indexing!\n",
-    "\n",
+    "# indexing will select all rings with a multiplicity below max_multiplity to search\n",
     "max_multiplicity = 11\n",
+    "# the minimum number of peaks on a ring for a ring to be indexed on\n",
+    "min_counts_on_ring = 0\n",
+    "# the sequence of hkl tolerances the indexer will iterate through\n",
+    "hkl_tols_seq = [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.1]\n",
+    "# the sequence of minpks fractions the indexer will iterate through\n",
+    "fracs = [0.9, 0.8, 0.7, 0.6, 0.5]\n",
+    "# the tolerance in g-vector angle\n",
+    "cosine_tol = np.cos(np.radians(90.25))\n",
+    "# the max number of UBIs we can find per pair of rings\n",
+    "max_grains = 1000\n",
     "\n",
-    "min_counts_on_ring = 30\n",
-    "\n",
-    "n_peaks_expected = 0\n",
-    "rings = []\n",
-    "for i, dstar in enumerate(indexer.unitcell.ringds):\n",
-    "    multiplicity = len(indexer.unitcell.ringhkls[indexer.unitcell.ringds[i]])\n",
-    "    counts_on_this_ring = (indexer.ra == i).sum()\n",
-    "    if counts_on_this_ring > min_counts_on_ring:\n",
-    "        n_peaks_expected += multiplicity\n",
-    "        if multiplicity < max_multiplicity:\n",
-    "            rings.append((counts_on_this_ring, multiplicity, i))\n",
-    "\n",
-    "rings.sort()\n",
-    "\n",
-    "print(f\"{n_peaks_expected} peaks expected\")\n",
-    "print(f\"Trying these rings (counts, multiplicity, ring number): {rings}\")\n",
-    "\n",
-    "# USER: specify the HKL tolerances you want to use for indexing\n",
-    "hkl_tols_seq = [0.01, 0.02, 0.03]\n",
-    "\n",
-    "# USER: specify the fraction of the total expected peaks\n",
-    "fracs = [0.9, 0.8, 0.7]\n",
-    "\n",
-    "# ImageD11.cImageD11.cimaged11_omp_set_num_threads(1)\n",
-    "ImageD11.indexing.loglevel=3\n",
-    "\n",
-    "# indexer.uniqueness = 0.3\n",
-    "indexer.cosine_tol = np.cos(np.radians(90.25))\n",
-    "indexer.max_grains = 1000\n",
-    "\n",
-    "# iterate over HKL tolerances\n",
-    "for frac in fracs:\n",
-    "    for tol in hkl_tols_seq:\n",
-    "        indexer.minpks = n_peaks_expected*frac\n",
-    "        indexer.hkl_tol = tol\n",
-    "        \n",
-    "        # iterate over rings\n",
-    "        for i in range(len(rings)):\n",
-    "            for j in range(i, len(rings)):\n",
-    "                indexer.ring_1 = rings[i][2]\n",
-    "                indexer.ring_2 = rings[j][2]\n",
-    "        \n",
-    "                indexer.find()\n",
-    "                indexer.scorethem()\n",
-    "        \n",
-    "        print(frac, tol, len(indexer.ubis))"
+    "grains, indexer = utils.do_index(cf=cf_strong,\n",
+    "                                dstol=indexer.ds_tol,\n",
+    "                                max_mult=max_multiplicity,\n",
+    "                                min_ring_count=min_counts_on_ring,\n",
+    "                                hkl_tols=hkl_tols_seq,\n",
+    "                                fracs=fracs,\n",
+    "                                cosine_tol=cosine_tol,\n",
+    "                                max_grains=max_grains\n",
+    ")"
    ]
   },
   {
@@ -410,9 +372,6 @@
    },
    "outputs": [],
    "source": [
-    "# create grain objects\n",
-    "grains = [ImageD11.grain.grain(ubi, translation=np.array([0., 0., 0.])) for ubi in indexer.ubis]\n",
-    "\n",
     "# set grain GIDs (useful if we ever delete a grain)\n",
     "for i, g in enumerate(grains):\n",
     "    g.gid = i\n",
@@ -453,127 +412,32 @@
     "\n",
     "tol=0.05\n",
     "\n",
-    "# column to store the grain labels\n",
-    "labels = np.zeros(cf_strong.nrows, 'i')\n",
-    "# get all g-vectors from columnfile\n",
-    "gv = np.transpose((cf_strong.gx,cf_strong.gy,cf_strong.gz)).astype(float)\n",
-    "# column to store drlv2 (error in hkl)\n",
-    "drlv2 =  np.ones(cf_strong.nrows, 'd')\n",
-    "# iterate over all grains\n",
-    "print(f\"Scoring and assigning {len(grains)} grains\")\n",
-    "for g in tqdm(grains):\n",
-    "    n = ImageD11.cImageD11.score_and_assign(g.ubi, gv, tol, drlv2, labels, g.gid)\n",
-    "\n",
-    "# add the labels column to the columnfile\n",
-    "cf_strong.addcolumn(labels, 'grain_id')\n",
+    "utils.assign_peaks_to_grains(grains, cf_strong, tol=tol)\n",
     "\n",
     "print(\"Storing peak data in grains\")\n",
     "# iterate through all the grains\n",
     "for g in tqdm(grains):\n",
     "    # store this grain's peak indices so we know which 4D peaks we used for indexing\n",
+    "    g.mask_4d = cf_strong.grain_id == g.gid\n",
     "    g.peaks_4d = cf_strong.index[cf_strong.grain_id == g.gid]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_index_results(ind, colfile, title):\n",
-    "    # Generate a histogram of |drlv| for a ubi matrix\n",
-    "    indexer.histogram_drlv_fit()\n",
-    "    indexer.fight_over_peaks()\n",
-    "    \n",
-    "    fig, axs = plt.subplots(3, 2, layout=\"constrained\", figsize=(9,12))\n",
-    "    axs_flat = axs.ravel()\n",
-    "    \n",
-    "    # For each grain, plot the error in hkl vs the number of peaks with that error\n",
-    "    \n",
-    "    for grh in ind.histogram:\n",
-    "        axs_flat[0].plot(ind.bins[1:-1], grh[:-1], \"-\")\n",
-    "    \n",
-    "    axs_flat[0].set(ylabel=\"number of peaks\",\n",
-    "                    xlabel=\"error in hkl (e.g. hkl versus integer)\",\n",
-    "                    title=title)\n",
-    "    \n",
-    "    # set a mask of all non-assigned g-vectors\n",
-    "    \n",
-    "    m = ind.ga == -1\n",
-    "    \n",
-    "    # plot the assigned g-vectors omega vs dty (sinograms)\n",
-    "    \n",
-    "    axs_flat[1].scatter(colfile.omega[~m],\n",
-    "                        colfile.dty[~m],\n",
-    "                        c=ind.ga[~m],\n",
-    "                        s=2,\n",
-    "                        cmap='tab20')\n",
-    "    \n",
-    "    axs_flat[1].set(title=f'Sinograms of {ind.ga.max()+1} grains',\n",
-    "                    xlabel='Omega/deg',\n",
-    "                    ylabel='dty/um')\n",
-    "    \n",
-    "    # Define weak peaks as all non-assigned peaks with intensity 1e-4 of max\n",
-    "    cut = colfile.sum_intensity[m].max() * 1e-4\n",
-    "    weak = colfile.sum_intensity[m] < cut\n",
-    "    \n",
-    "    # Plot unassigned peaks in omega vs dty\n",
-    "    \n",
-    "    axs_flat[2].scatter(colfile.omega[m][weak],  colfile.dty[m][weak],  s=2, label='weak')\n",
-    "    axs_flat[2].scatter(colfile.omega[m][~weak], colfile.dty[m][~weak], s=2, label='not weak')\n",
-    "    \n",
-    "    axs_flat[2].set(title='Sinograms of unassigned peaks',\n",
-    "                    xlabel='Omega/deg',\n",
-    "                    ylabel='dty/um')\n",
-    "    axs_flat[2].legend()\n",
-    "    \n",
-    "    # Plot d-star vs intensity for all assigned peaks\n",
-    "    \n",
-    "    axs_flat[3].scatter(colfile.ds[~m], colfile.sum_intensity[~m], s=2)\n",
-    "    axs_flat[3].set(title='Intensity of all assigned peaks',\n",
-    "                    xlabel='d-star',\n",
-    "                    ylabel='Intensity',\n",
-    "                    yscale='log')\n",
-    "    \n",
-    "    # Plot d-star vs intensity for all unassigned peaks\n",
-    "    \n",
-    "    axs_flat[4].scatter(colfile.ds[m][weak],  colfile.sum_intensity[m][weak],  s=2, label='weak')\n",
-    "    axs_flat[4].scatter(colfile.ds[m][~weak], colfile.sum_intensity[m][~weak], s=2, label='not weak')\n",
-    "    \n",
-    "    axs_flat[4].set(title='Intensity of all unassigned peaks',\n",
-    "                    xlabel='d-star',\n",
-    "                    ylabel='Intensity',\n",
-    "                    yscale='log')\n",
-    "    axs_flat[4].legend()\n",
-    "    \n",
-    "    # Get the number of peaks per grain\n",
-    "    \n",
-    "    npks = [(ind.ga == i).sum() for i in range(len(ind.ubis))]\n",
-    "    \n",
-    "    # Plot histogram of number of peaks per grain\n",
-    "    \n",
-    "    axs_flat[5].hist(npks, bins=64)\n",
-    "    axs_flat[5].set(title='Hist of peaks per grain',\n",
-    "                    xlabel='Number of peaks',\n",
-    "                    ylabel='Number of grains')\n",
-    "    \n",
-    "    for ax in axs_flat:\n",
-    "        ax.set_box_aspect(0.7)\n",
-    "    \n",
-    "    plt.show()"
+    "utils.plot_index_results(indexer, cf_strong, 'First attempt')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "plot_index_results(indexer, cf_strong, 'First attempt')"
+    "utils.plot_grain_sinograms(grains, cf_strong, 25)"
    ]
   },
   {

--- a/ImageD11/nbGui/S3DXRD/2_S3DXRD_sinograms_map_minor_phase.ipynb
+++ b/ImageD11/nbGui/S3DXRD/2_S3DXRD_sinograms_map_minor_phase.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Jupyter notebook based on ImageD11 to process scanning 3DXRD data\n",
     "# Written by Haixing Fang, Jon Wright and James Ball\n",
-    "## Date: 19/02/2024"
+    "## Date: 21/02/2024"
    ]
   },
   {
@@ -60,7 +60,7 @@
     "import ipywidgets as ipyw\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "import utils\n",
+    "import ImageD11.nbGui.nb_utils as utils\n",
     "\n",
     "import ImageD11.refinegrains\n",
     "import ImageD11.columnfile\n",
@@ -78,21 +78,19 @@
    },
    "outputs": [],
    "source": [
-    "# OLD DATASETS\n",
-    "\n",
     "# NOTE: For old datasets before the new directory layout structure, we don't distinguish between RAW_DATA and PROCESSED_DATA\n",
     "# In this case, use this cell to specify where your experimental folder is, and do not run the cell below\n",
-    "# e.g /data/visitor/4752/id11/20210513\n",
+    "# e.g /data/visitor/ma4752/id11/20210513\n",
     "\n",
     "### USER: specify your experimental directory\n",
     "\n",
-    "rawdata_path = \"/home/esrf/james1997a/Data/ma4752/id11/20210618\"\n",
+    "rawdata_path = \"/home/esrf/james1997a/Data/ihma439/id11/20231211/RAW_DATA\"\n",
     "\n",
     "!ls -lrt {rawdata_path}\n",
     "\n",
     "### USER: specify where you want your processed data to go\n",
     "\n",
-    "processed_data_root_dir = \"/home/esrf/james1997a/Data/ma4752/id11/20240118/James\""
+    "processed_data_root_dir = \"/home/esrf/james1997a/Data/ihma439/id11/20231211/PROCESSED_DATA/James/20240221\""
    ]
   },
   {
@@ -105,8 +103,8 @@
    "source": [
     "# USER: pick a sample and a dataset you want to segment\n",
     "\n",
-    "sample = \"MA4752_S4_2_XRD\"\n",
-    "dataset = \"DTL1z90\""
+    "sample = \"FeAu_0p5_tR_nscope\"\n",
+    "dataset = \"top_100um\""
    ]
   },
   {
@@ -121,10 +119,10 @@
     "\n",
     "dset_path = os.path.join(processed_data_root_dir, sample, f\"{sample}_{dataset}\", f\"{sample}_{dataset}_dataset.h5\")\n",
     "\n",
-    "par_path = 'nickel.par'\n",
+    "par_path = os.path.join(processed_data_root_dir, 'Fe_refined.par')\n",
     "\n",
-    "e2dx_path = \"/data/id11/nanoscope/Eiger/spatial_20210415_JW/e2dx.edf\"\n",
-    "e2dy_path = \"/data/id11/nanoscope/Eiger/spatial_20210415_JW/e2dy.edf\""
+    "e2dx_path = os.path.join(processed_data_root_dir, '../../CeO2/e2dx_E-08-0173_20231127.edf')\n",
+    "e2dy_path = os.path.join(processed_data_root_dir, '../../CeO2/e2dy_E-08-0173_20231127.edf')"
    ]
   },
   {
@@ -232,7 +230,7 @@
    "outputs": [],
    "source": [
     "# If the sinograms are only half-sinograms (we scanned dty across half the sample rather than the full sample), set the below to true:\n",
-    "is_half_scan = True"
+    "is_half_scan = False"
    ]
   },
   {
@@ -244,40 +242,7 @@
    "outputs": [],
    "source": [
     "if is_half_scan:\n",
-    "    c0 = 0\n",
-    "    # check / fix the centre of rotation\n",
-    "    # get value of bin closest to c0\n",
-    "    central_bin = np.argmin( abs(ds.ybincens - c0))\n",
-    "    # get centre dty value of this vin\n",
-    "    central_value = ds.ybincens[central_bin]\n",
-    "\n",
-    "    lo_side = ds.ybincens[:central_bin+1]\n",
-    "    hi_side = ds.ybincens[central_bin:]\n",
-    "    \n",
-    "    # get the hi/lo side which is widest\n",
-    "    # i.e if you go from -130 to +20, it selects -130\n",
-    "    yrange = max( hi_side[-1] - hi_side[0], lo_side[-1] - lo_side[0] )\n",
-    "\n",
-    "    # round to nearest multiple of ds.ystep\n",
-    "    yrange = np.ceil( yrange / ds.ystep ) * ds.ystep\n",
-    "    \n",
-    "    # make new ymin and ymax that are symmetric around central_value\n",
-    "    ds.ymin = central_value - yrange\n",
-    "    ds.ymax = central_value + yrange\n",
-    "    \n",
-    "    new_yrange = ds.ymax - ds.ymin\n",
-    "    \n",
-    "    # determine new number of y bins\n",
-    "    ny = int(new_yrange//ds.ystep) + 1\n",
-    "    \n",
-    "    ds.ybincens = np.linspace(ds.ymin, ds.ymax, ny)\n",
-    "    ds.ybinedges = np.linspace(ds.ymin - ds.ystep / 2, ds.ymax + ds.ystep / 2, ny + 1)\n",
-    "    \n",
-    "    print(len(ds.ybincens))\n",
-    "    print(ds.ybincens)\n",
-    "    print(ds.ystep)\n",
-    "    print(yrange)\n",
-    "    print(ny)"
+    "    utils.correct_half_scan(ds)"
    ]
   },
   {
@@ -326,19 +291,7 @@
    "source": [
     "tol = 0.25\n",
     "\n",
-    "# column to store the grain labels\n",
-    "labels_4d_strong = np.zeros(cf_strong.nrows, 'i')\n",
-    "# get all g-vectors from columnfile\n",
-    "gvecs_4d_strong = np.transpose((cf_strong.gx,cf_strong.gy,cf_strong.gz)).astype(float)\n",
-    "# column to store drlv2 (error in hkl)\n",
-    "drlv2 = np.ones(cf_strong.nrows, 'd')\n",
-    "# iterate over all grains\n",
-    "print(f\"Scoring and assigning {len(grains)} grains\")\n",
-    "for g in tqdm(grains):\n",
-    "    n = ImageD11.cImageD11.score_and_assign(g.ubi, gvecs_4d_strong, tol, drlv2, labels_4d_strong, g.gid)\n",
-    "\n",
-    "# add the labels column to the columnfile\n",
-    "cf_strong.addcolumn(labels_4d_strong, 'grain_id')\n",
+    "utils.assign_peaks_to_grains(grains, cf_strong, tol=tol)\n",
     "\n",
     "print(\"Storing peak data in grains\")\n",
     "# iterate through all the grains\n",
@@ -391,26 +344,7 @@
    },
    "outputs": [],
    "source": [
-    "n_grains_to_plot=25\n",
-    "\n",
-    "grains_step = len(grains)//n_grains_to_plot + 1\n",
-    "\n",
-    "grid_size = np.ceil(np.sqrt(len(grains[::grains_step]))).astype(int)\n",
-    "nrows = (len(grains[::grains_step])+grid_size-1)//grid_size\n",
-    "\n",
-    "# plt.style.use('light_background')\n",
-    "fig, axs = plt.subplots(grid_size, nrows, figsize=(10,10), layout=\"constrained\", sharex=True, sharey=True)\n",
-    "for i, ax in enumerate(axs.ravel()):\n",
-    "    if i < len(grains[::grains_step]):\n",
-    "    # get corresponding grain for this axis\n",
-    "        g = grains[::grains_step][i]\n",
-    "        m = cf_strong.grain_id == g.gid\n",
-    "        ax.scatter(cf_strong.omega[m], cf_strong.dty[m], c=cf_strong.sum_intensity[m])\n",
-    "        \n",
-    "fig.supxlabel(\"Omega\")\n",
-    "fig.supylabel(\"Y translation (um)\")\n",
-    "    \n",
-    "plt.show()"
+    "utils.plot_grain_sinograms(grains, cf_strong, 25)"
    ]
   },
   {
@@ -934,41 +868,7 @@
    },
    "outputs": [],
    "source": [
-    "grain_labels_array = np.zeros_like(grains[0].recon) - 1\n",
-    "red = np.zeros_like(grains[0].recon)\n",
-    "grn = np.zeros_like(grains[0].recon)\n",
-    "blu = np.zeros_like(grains[0].recon)\n",
-    "\n",
-    "raw_intensity_array = np.zeros_like(grains[0].recon)\n",
-    "\n",
-    "cutoff_level = 0.5\n",
-    "\n",
-    "raw_intensity_array.fill(cutoff_level)\n",
-    "\n",
-    "# ignore the centre when determining r.max()???\n",
-    "\n",
-    "def norm(r):\n",
-    "    m = r > r.max()*0.2\n",
-    "    return (r/r[m].mean()).clip(0,1)\n",
-    "\n",
-    "for g in tqdm(grains):\n",
-    "    i = g.gid\n",
-    "    \n",
-    "    g_raw_intensity = norm(g.recon)\n",
-    "    \n",
-    "    g_raw_intensity_mask = g_raw_intensity > raw_intensity_array\n",
-    "    \n",
-    "    g_raw_intenstiy_map = g_raw_intensity[g_raw_intensity_mask]\n",
-    "    \n",
-    "    raw_intensity_array[g_raw_intensity_mask] = g_raw_intenstiy_map\n",
-    "    \n",
-    "    red[g_raw_intensity_mask] = g_raw_intenstiy_map*g.rgb_z[0]\n",
-    "    grn[g_raw_intensity_mask] = g_raw_intenstiy_map*g.rgb_z[1]\n",
-    "    blu[g_raw_intensity_mask] = g_raw_intenstiy_map*g.rgb_z[2]\n",
-    "    \n",
-    "    grain_labels_array[g_raw_intensity_mask] = i\n",
-    "    \n",
-    "raw_intensity_array[raw_intensity_array == cutoff_level] = 0"
+    "rgb_array, grain_labels_array, raw_intensity_array = utils.build_slice_arrays(grains, cutoff_level=0.5)"
    ]
   },
   {
@@ -981,9 +881,8 @@
    "source": [
     "# plot initial output\n",
     "\n",
-    "image_to_show = np.transpose((red, grn, blu), axes=(1, 2, 0))\n",
     "fig, ax = plt.subplots(constrained_layout=True)\n",
-    "ax.imshow(image_to_show)  # originally 1,2,0\n",
+    "ax.imshow(rgb_array)  # originally 1,2,0\n",
     "plt.show()"
    ]
   },

--- a/ImageD11/nbGui/S3DXRD/4_S3DXRD_plot_both_phases.ipynb
+++ b/ImageD11/nbGui/S3DXRD/4_S3DXRD_plot_both_phases.ipynb
@@ -72,21 +72,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# OLD DATASETS\n",
-    "\n",
     "# NOTE: For old datasets before the new directory layout structure, we don't distinguish between RAW_DATA and PROCESSED_DATA\n",
     "# In this case, use this cell to specify where your experimental folder is, and do not run the cell below\n",
-    "# e.g /data/visitor/4752/id11/20210513\n",
+    "# e.g /data/visitor/ma4752/id11/20210513\n",
     "\n",
     "### USER: specify your experimental directory\n",
     "\n",
-    "rawdata_path = \"/home/esrf/james1997a/Data/ma4752/id11/20210618\"\n",
+    "rawdata_path = \"/home/esrf/james1997a/Data/ihma439/id11/20231211/RAW_DATA\"\n",
     "\n",
     "!ls -lrt {rawdata_path}\n",
     "\n",
     "### USER: specify where you want your processed data to go\n",
     "\n",
-    "processed_data_root_dir = \"/home/esrf/james1997a/Data/ma4752/id11/20240118/James\""
+    "processed_data_root_dir = \"/home/esrf/james1997a/Data/ihma439/id11/20231211/PROCESSED_DATA/James/20240221\""
    ]
   },
   {
@@ -98,8 +96,8 @@
    "source": [
     "# USER: pick a sample and a dataset you want to segment\n",
     "\n",
-    "sample = \"MA4752_S4_2_XRD\"\n",
-    "dataset = \"DTL1z90\""
+    "sample = \"FeAu_0p5_tR_nscope\"\n",
+    "dataset = \"top_100um\""
    ]
   },
   {
@@ -113,10 +111,10 @@
     "\n",
     "dset_path = os.path.join(processed_data_root_dir, sample, f\"{sample}_{dataset}\", f\"{sample}_{dataset}_dataset.h5\")\n",
     "\n",
-    "par_path = 'nickel.par'\n",
+    "par_path = os.path.join(processed_data_root_dir, 'Fe_refined.par')\n",
     "\n",
-    "e2dx_path = \"/data/id11/nanoscope/Eiger/spatial_20210415_JW/e2dx.edf\"\n",
-    "e2dy_path = \"/data/id11/nanoscope/Eiger/spatial_20210415_JW/e2dy.edf\""
+    "e2dx_path = os.path.join(processed_data_root_dir, '../../CeO2/e2dx_E-08-0173_20231127.edf')\n",
+    "e2dy_path = os.path.join(processed_data_root_dir, '../../CeO2/e2dy_E-08-0173_20231127.edf')"
    ]
   },
   {

--- a/ImageD11/tkGui/twodplot.py
+++ b/ImageD11/tkGui/twodplot.py
@@ -237,7 +237,7 @@ class twodplot(Tk.Frame):
 
     def logy(self):
 # FIXME - clip negative values before making logscaled?
-        if self.a.yaxis.is_log():
+        if self.a.get_yscale() == "log":
             self.a.set_yscale('linear')
         else:
             self.a.set_yscale('log')
@@ -245,7 +245,7 @@ class twodplot(Tk.Frame):
 
     def logx(self):
 # FIXME - clip negative values before making logscaled?
-        if self.a.xaxis.is_log():
+        if self.a.get_xscale() == "log":
             self.a.set_xscale('linear')
         else:
             self.a.set_xscale('log')

--- a/ImageD11/transform.py
+++ b/ImageD11/transform.py
@@ -395,7 +395,7 @@ def compute_tth_histo(tth, no_bins=100, weight = False, weights = None,
     # Tried to use numpy's digitize but failed. Edges are treated differently between np.histogram and np.digitize (both are inclusive in np.histogram)
     # Tried many combinations and gave up
     binsize = (maxtth - mintth) / (no_bins-1)
-    bins = np.floor((tth - mintth) / binsize).astype(np.int)
+    bins = np.floor((tth - mintth) / binsize).astype(np.int32)
     hpk = np.take(histogram, bins)
     return tthbin, histogram, hpk
 


### PR DESCRIPTION
- Fix problems with log scale buttons in ImageD11_gui caused by twodplot.py 
- Replace outdated `np.int` in ImageD11/transform.py that was causing errors in ImageD11_gui
- Minor phase scanning notebooks now use nb_utils