### PR TITLE
Moving many functions from nbgui into ImageD11

### DIFF
--- a/ImageD11/blobcorrector.py
+++ b/ImageD11/blobcorrector.py
@@ -318,7 +318,19 @@ class eiger_spatial(object):
         s = self.dx.shape
         i, j = numpy.mgrid[ 0:s[0], 0:s[1] ]
         return self.dy + j, self.dx + i
-    
+
+
+def correct_cf_with_spline(cf, spline_file):
+    """Creates a correctorclass from the spline file
+       Corrects the columnfile with the spline file
+       Returns the corrected columnfile"""
+
+    corrector = correctorclass(spline_file)
+    corrector.correct_px_lut(cf)
+
+    return cf
+
+
 #
 #"""
 #http://homepages.inf.ed.ac.uk/rbf/CVonline/LOCAL_COPIES/OWENS/LECT5/node5.html

--- a/ImageD11/grain.py
+++ b/ImageD11/grain.py
@@ -207,9 +207,10 @@ class grain:
         """Creates a H5Py group for this grain.
            parent_group is the parent H5py Group
            group_name is the name of the H5py Group for this name
-           Very useful for saving lists of grains to an H5 file"""
+           Very useful for saving lists of grains to an H5 file.
+           Uses require_group to modify existing data if present"""
 
-        grain_group = parent_group.create_group(group_name)
+        grain_group = parent_group.require_group(group_name)
 
         # essential attributes:
         save_array(grain_group, 'ubi', self.ubi)
@@ -337,6 +338,8 @@ ARRATTRS = ["translation"]
 
 
 def write_grain_file_h5(filename, list_of_grains):
+    """Write list of grains to H5py file.
+       Will fail if the grain already exists"""
     # TODO: Use Silx Nexus IO instead?
 
     with h5py.File(filename, 'w-') as hout:

--- a/ImageD11/grain.py
+++ b/ImageD11/grain.py
@@ -3,7 +3,7 @@
 
 from __future__ import print_function
 
-
+import h5py
 # ImageD11_v0.4 Software for beamline ID11
 # Copyright (C) 2005  Jon Wright
 #
@@ -25,42 +25,43 @@ import numpy as np, math
 import ImageD11.indexing, ImageD11.unitcell, ImageD11.finite_strain
 import xfab.tools
 
+
 # helpers : put these into xfab.tools at some point?
 def e6_to_symm(e):
     """ Follows the eps convention from xfab 
     eps = [e11, e12, e13, e22, e23, e33]
     """
     e11, e12, e13, e22, e23, e33 = e
-    return np.array(((e11,e12,e13),
-                     (e12,e22,e23),
-                     (e13,e23,e33)))
+    return np.array(((e11, e12, e13),
+                     (e12, e22, e23),
+                     (e13, e23, e33)))
+
 
 def symm_to_e6(m):
     """ Follows the eps convention from xfab 
     eps = [e11, e12, e13, e22, e23, e33]
     """
-    return np.array( ( m[0,0], m[0,1], m[0,2],
-                               m[1,1], m[1,2],
-                                       m[2,2] ) )
-
+    return np.array((m[0, 0], m[0, 1], m[0, 2],
+                     m[1, 1], m[1, 2],
+                     m[2, 2]))
 
 
 class grain:
-    def __init__(self,ubi,translation=None, **kwds):
+    def __init__(self, ubi, translation=None, **kwds):
         if translation is None:
             # If translation has not been read from ubi file make it 
             # be None to avoid confusion with a grain which is known
             # to be at [0,0,0]
             self.translation = None
         else:
-            self.translation = np.array(translation,float)
+            self.translation = np.array(translation, float)
         self.set_ubi(ubi)
 
     def set_ubi(self, ubi):
         """ Update the orientation and clear cached values """
-        self.ubi = np.array(ubi,float)
+        self.ubi = np.array(ubi, float)
         assert np.linalg.det(self.ubi) >= 0, 'Left handed axis system!'
-        self.clear_cache()        
+        self.clear_cache()
 
     def clear_cache(self):
         # We will cache a bunch of things and access them
@@ -77,7 +78,7 @@ class grain:
         self._rmt = None
         self._unitcell = None
 
-    @property 
+    @property
     def UB(self):
         """ The UB matrix from Busing and Levy
         columns are the reciprocal space lattice vectors
@@ -93,7 +94,7 @@ class grain:
     @property
     def B(self):
         if self._B is None:
-            self._B = ImageD11.unitcell.unitcell( self.unitcell ).B.copy()
+            self._B = ImageD11.unitcell.unitcell(self.unitcell).B.copy()
         return self._B.copy()
 
     @property
@@ -101,45 +102,45 @@ class grain:
         """ The orientation matrix (U) from Busing and Levy """
         if self._U is None:
             # ubi = inv(UB) = inv(B)inv(U)
-            self._U = np.dot( self.B, self.ubi ).T
+            self._U = np.dot(self.B, self.ubi).T
         return self._U.copy()
 
     @property
     def u(self):
         return self.U
-    
+
     @property
     def Rod(self):
         """ A Rodriguez vector. 
         Length proportional to angle, direction is axis"""
         if self._rod is None:
-            self._rod = xfab.tools.u_to_rod( self.U )
+            self._rod = xfab.tools.u_to_rod(self.U)
         return self._rod.copy()
 
     @property
     def mt(self):
         """Metric tensor """
         if self._mt is None:
-            self._mt = np.dot( self.ubi, self.ubi.T )
+            self._mt = np.dot(self.ubi, self.ubi.T)
         return self._mt.copy()
 
     @property
     def rmt(self):
         """ Reciprocal metric tensor """
         if self._rmt is None:
-            self._rmt = np.linalg.inv( self.mt )
+            self._rmt = np.linalg.inv(self.mt)
         return self._rmt.copy()
-        
+
     @property
     def unitcell(self):
         """ a,b,c,alpha,beta,gamma """
         if self._unitcell is None:
             G = self.mt
-            a, b, c = np.sqrt( np.diag( G ) )
-            al = np.degrees( np.arccos( G[1,2]/b/c ) )
-            be = np.degrees( np.arccos( G[0,2]/a/c ) )
-            ga = np.degrees( np.arccos( G[0,1]/a/b ) )
-            self._unitcell = np.array( (a,b,c,al,be,ga) )
+            a, b, c = np.sqrt(np.diag(G))
+            al = np.degrees(np.arccos(G[1, 2] / b / c))
+            be = np.degrees(np.arccos(G[0, 2] / a / c))
+            ga = np.degrees(np.arccos(G[0, 1] / a / b))
+            self._unitcell = np.array((a, b, c, al, be, ga))
         return self._unitcell.copy()
 
     def eps_grain_matrix(self, dzero_cell, m=0.5):
@@ -151,12 +152,12 @@ class grain:
         Returns eps as a symmetric matrix
         ... in the grain reference system of dzero_cell
         """
-        if hasattr( dzero_cell, "UB" ):
+        if hasattr(dzero_cell, "UB"):
             B = dzero_cell.UB
         else:
-            B = ImageD11.unitcell.unitcell( dzero_cell ).B
-        F = ImageD11.finite_strain.DeformationGradientTensor( self.ubi, B )
-        eps = F.finite_strain_ref( m )
+            B = ImageD11.unitcell.unitcell(dzero_cell).B
+        F = ImageD11.finite_strain.DeformationGradientTensor(self.ubi, B)
+        eps = F.finite_strain_ref(m)
         return eps
 
     def eps_grain(self, dzero_cell, m=0.5):
@@ -169,9 +170,8 @@ class grain:
          e11 e12 e13 e22 e23 e33
         ... in the grain reference system of dzero_cell
         """
-        E = self.eps_grain_matrix( dzero_cell, m )
-        return symm_to_e6( E )
-
+        E = self.eps_grain_matrix(dzero_cell, m)
+        return symm_to_e6(E)
 
     def eps_sample_matrix(self, dzero_cell, m=0.5):
         """ dzero_cell can be another grain or cell parameters:
@@ -182,14 +182,13 @@ class grain:
         Returns eps as a symmetric matrix
         ... in the sample system (z up, x along the beam at omega=0)
         """
-        if hasattr( dzero_cell, "UB" ):
+        if hasattr(dzero_cell, "UB"):
             B = dzero_cell.UB
         else:
-            B = ImageD11.unitcell.unitcell( dzero_cell ).B
-        F = ImageD11.finite_strain.DeformationGradientTensor( self.ubi, B )
-        eps = F.finite_strain_lab( m )
+            B = ImageD11.unitcell.unitcell(dzero_cell).B
+        F = ImageD11.finite_strain.DeformationGradientTensor(self.ubi, B)
+        eps = F.finite_strain_lab(m)
         return eps
-
 
     def eps_sample(self, dzero_cell, m=0.5):
         """ dzero_cell can be another grain or cell parameters:
@@ -201,38 +200,103 @@ class grain:
          e11 e12 e13 e22 e23 e33
         ... in the sample system (z up, x along the beam at omega=0)
         """
-        E = self.eps_sample_matrix( dzero_cell, m )
-        return symm_to_e6( E )
+        E = self.eps_sample_matrix(dzero_cell, m)
+        return symm_to_e6(E)
 
-        
+    def to_h5py_group(self, parent_group, group_name):
+        """Creates a H5Py group for this grain.
+           parent_group is the parent H5py Group
+           group_name is the name of the H5py Group for this name
+           Very useful for saving lists of grains to an H5 file"""
+
+        grain_group = parent_group.create_group(group_name)
+
+        # essential attributes:
+        save_array(grain_group, 'ubi', self.ubi)
+
+        # optional attributes:
+        for attr in STRINGATTRS + NUMATTRS:
+            if hasattr(self, attr):
+                if getattr(self, attr) is not None:
+                    grain_group[attr] = getattr(self, attr)
+
+        # write array attributes
+        for attr in ARRATTRS:
+            if hasattr(self, attr):
+                if getattr(self, attr) is not None:
+                    save_array(grain_group, attr, getattr(self, attr))
+
+        return grain_group
+
+    @classmethod
+    def from_h5py_group(cls, grain_group):
+        """Creates a grain object from an h5py group"""
+        # read essential attributes"
+        ubi = grain_group["ubi"][:]
+
+        # make grain object:
+        g = grain(ubi=ubi)
+
+        # read optional attributes:
+        # strings:
+        for attr in STRINGATTRS:
+            if attr in grain_group.keys():
+                setattr(g, attr, grain_group.get(attr)[()].decode())
+
+        # numbers:
+        for attr in NUMATTRS:
+            if attr in grain_group.keys():
+                setattr(g, attr, grain_group.get(attr)[()])
+
+        # arrays:
+        for attr in ARRATTRS:
+            if attr in grain_group.keys():
+                setattr(g, attr, grain_group.get(attr)[:])
+
+        return g
 
 
-    
+# TODO: Use Silx Nexus IO instead?
+# This is a temporary sensible middle ground!
+def save_array(grp, name, ary):
+    # TODO: Move this helper function somewhere else
+    cmp = {'compression': 'gzip',
+           'compression_opts': 2,
+           'shuffle': True}
+
+    hds = grp.require_dataset(name,
+                              shape=ary.shape,
+                              dtype=ary.dtype,
+                              **cmp)
+    hds[:] = ary
+    return hds
+
 def write_grain_file(filename, list_of_grains):
     f = open(filename, "w")
     for g in list_of_grains:
         t = g.translation
-        f.write("#translation: %g %g %g\n"%(t[0],t[1],t[2]))
-        if hasattr(g,"name"):
-            f.write("#name %s\n"%(g.name.rstrip()))
-        if hasattr(g,"intensity_info"):
-            f.write("#intensity_info %s\n"%(g.intensity_info.rstrip()))
-        if hasattr(g,"npks"):
-            f.write("#npks %d\n"%(int(g.npks)))
-        if hasattr(g,"nuniq"):
-            f.write("#nuniq %d\n"%(int(g.nuniq)))
-        if hasattr(g,"Rod"):
+        f.write("#translation: %g %g %g\n" % (t[0], t[1], t[2]))
+        if hasattr(g, "name"):
+            f.write("#name %s\n" % (g.name.rstrip()))
+        if hasattr(g, "intensity_info"):
+            f.write("#intensity_info %s\n" % (g.intensity_info.rstrip()))
+        if hasattr(g, "npks"):
+            f.write("#npks %d\n" % (int(g.npks)))
+        if hasattr(g, "nuniq"):
+            f.write("#nuniq %d\n" % (int(g.nuniq)))
+        if hasattr(g, "Rod"):
             try:
-                f.write("#Rod %f %f %f\n"%tuple([float(r) for r in g.Rod]))
+                f.write("#Rod %f %f %f\n" % tuple([float(r) for r in g.Rod]))
             except:
-                f.write("#Rod %s"%(g.Rod))
+                f.write("#Rod %s" % (g.Rod))
         f.write("#UBI:\n")
         u = g.ubi
         # More than float32 precision
-        f.write("%.9g %.9g %.9g\n"  %(u[0,0],u[0,1],u[0,2]))
-        f.write("%.9g %.9g %.9g\n"  %(u[1,0],u[1,1],u[1,2]))
-        f.write("%.9g %.9g %.9g\n\n"%(u[2,0],u[2,1],u[2,2]))
+        f.write("%.9g %.9g %.9g\n" % (u[0, 0], u[0, 1], u[0, 2]))
+        f.write("%.9g %.9g %.9g\n" % (u[1, 0], u[1, 1], u[1, 2]))
+        f.write("%.9g %.9g %.9g\n\n" % (u[2, 0], u[2, 1], u[2, 2]))
     f.close()
+
 
 def read_grain_file(filename):
     """read ubifile and return a list of ubi arrays """
@@ -242,26 +306,62 @@ def read_grain_file(filename):
     t = None
     p = {}
     for line in f:
-        if line.find("#translation:")==0:
-            t = [ float(x) for x in line.split()[1:]]
+        if line.find("#translation:") == 0:
+            t = [float(x) for x in line.split()[1:]]
             continue
-        if line[0] == "#" and line.find("UBI")<0:
-            k,v=line[1:].split(" ",1)
-            p[k]=v
+        if line[0] == "#" and line.find("UBI") < 0:
+            k, v = line[1:].split(" ", 1)
+            p[k] = v
             continue
-        if line[0] == "#" and line.find("intensity_info")>-1:
+        if line[0] == "#" and line.find("intensity_info") > -1:
             p["intensity_info"] = line.split("intensity_info")[1].rstrip()
-        if line.find("#")==0: continue
-        vals = [ float(x) for x in line.split() ]
+        if line.find("#") == 0: continue
+        vals = [float(x) for x in line.split()]
         if len(vals) == 3:
             u = u + [vals]
-        if len(u)==3:
-            grainsread.append( grain(u, t) )
-            for k in ["name","npks","nuniq","intensity_info"]: # Rod - is recomputed when needed
+        if len(u) == 3:
+            grainsread.append(grain(u, t))
+            for k in ["name", "npks", "nuniq", "intensity_info"]:  # Rod - is recomputed when needed
                 if k in p:
                     setattr(grainsread[-1], k, p[k])
-            p={}
+            p = {}
             u = []
             t = None
     f.close()
     return grainsread
+
+
+STRINGATTRS = ["intensity_info", "name"]
+NUMATTRS = ["npks", "nuniq"]
+ARRATTRS = ["translation"]
+
+
+def write_grain_file_h5(filename, list_of_grains):
+    # TODO: Use Silx Nexus IO instead?
+
+    with h5py.File(filename, 'w-') as hout:
+        grains_group = hout.create_group('grains')
+
+        # the H5 grain file should be order-preserving
+        # i.e it should always be possible to read the grains in the same order as they are written
+        # so we will use the list positions as the names for the H5 groups
+
+        for ginc, g in enumerate(list_of_grains):
+            group_name = str(ginc)
+            g.to_h5py_group(parent_group=grains_group, group_name=group_name)
+
+
+def read_grain_file_h5(filename):
+    with h5py.File(filename, 'r') as hin:
+        grains_group = hin['grains']
+        grains = []
+
+        # take all the keys in the grains group, sort them by integer value, iterate
+        for gid_string in sorted(grains_group.keys(), key=lambda x: int(x)):
+            grain_group = grains_group[gid_string]
+
+            g = grain.from_h5py_group(grain_group)
+
+            grains.append(g)
+
+    return grains

--- a/ImageD11/nbGui/S3DXRD/run_mlem_recon.py
+++ b/ImageD11/nbGui/S3DXRD/run_mlem_recon.py
@@ -1,40 +1,3 @@
-def run_iradon_mlem(ssino, sinoangles, mask=None, pad=20, y0=0, workers=1, niter=20, apply_halfmask=False, mask_central_zingers=False):
-    outsize = ssino.shape[0] + pad
-    if apply_halfmask:
-        halfmask = np.zeros_like(ssino)
-
-        halfmask[:len(halfmask)//2-1, :] = 1
-        halfmask[len(halfmask)//2-1, :] = 0.5
-        
-        ssino_to_recon = ssino * halfmask
-    else:
-        ssino_to_recon = ssino
-    
-    # Perform iradon transform of grain sinogram, store result (reconstructed grain shape) in g.recon
-    recon =  ImageD11.sinograms.roi_iradon.mlem(ssino_to_recon, 
-                       theta=sinoangles, 
-                       mask=mask,
-                       workers=workers,
-                       output_size=outsize,
-                       projection_shifts=np.full(ssino_to_recon.shape, -y0),
-                       niter=niter)
-    
-    if mask_central_zingers:
-        grs = recon.shape[0]
-        xpr, ypr = -grs//2 + np.mgrid[:grs, :grs]
-        inner_mask_radius = 25
-        outer_mask_radius = inner_mask_radius + 2
-
-        inner_circle_mask = (xpr ** 2 + ypr ** 2) < inner_mask_radius ** 2
-        outer_circle_mask = (xpr ** 2 + ypr ** 2) < outer_mask_radius ** 2
-
-        mask_ring = inner_circle_mask & outer_circle_mask
-        # we now have a mask to apply
-        fill_value = np.median(recon[mask_ring])
-        recon[inner_circle_mask] = fill_value
-    
-    return recon
-
 def read_hdf5(h5name, ginc):
     with h5py.File(h5name, 'r') as hin:
         grains_group = 'grains'
@@ -55,7 +18,9 @@ def main(h5name, ginc, dest, pad, niter, dohm, maskcen):
     # feed ssino, sinoangles, mask to run_iradon_mlem
     nthreads = len(os.sched_getaffinity(os.getpid()))
     # print(f"Running on {nthreads} threads")
-    recon = run_iradon_mlem(ssino, sinoangles, mask=circle_mask, pad=pad, y0=y0, workers=nthreads, niter=niter, apply_halfmask=dohm, mask_central_zingers=maskcen)
+
+    recon = ImageD11.sinograms.roi_iradon.run_mlem(ssino, sinoangles, mask=circle_mask, pad=pad, y0=y0, workers=nthreads, niter=niter, apply_halfmask=dohm, mask_central_zingers=maskcen)
+
     # write result to disk as Numpy array
     # save as TIFF instead?
     np.savetxt(dest, recon)

--- a/ImageD11/nbGui/nb_utils.py
+++ b/ImageD11/nbGui/nb_utils.py
@@ -768,8 +768,8 @@ def assign_peaks_to_grains(grains, cf, tol):
     drlv2 = np.ones(cf.nrows, 'd')
     # iterate over all grains
     print("Scoring and assigning {} grains".format(len(grains)))
-    for g in tqdm(grains):
-        n = ImageD11.cImageD11.score_and_assign(g.ubi, gv, tol, drlv2, labels, g.gid)
+    for inc, g in enumerate(tqdm(grains)):
+        n = ImageD11.cImageD11.score_and_assign(g.ubi, gv, tol, drlv2, labels, inc)
 
     # add the labels column to the columnfile
     cf.addcolumn(labels, 'grain_id')
@@ -1126,7 +1126,7 @@ def do_index(cf,
 
             print(frac, tol, len(indexer.ubis))
 
-    grains = [ImageD11.grain.grain(ubi, translation=np.array([0., 0., 0.])) for ubi in indexer.ubis]
+    grains = [ImageD11.grain.grain(ubi) for ubi in indexer.ubis]
     print("Found {} grains".format(len(grains)))
 
     return grains, indexer

--- a/ImageD11/nbGui/nb_utils.py
+++ b/ImageD11/nbGui/nb_utils.py
@@ -7,7 +7,6 @@ import numba
 import numpy as np
 from matplotlib import pyplot as plt
 from tqdm.auto import tqdm
-from tqdm.contrib.concurrent import process_map
 from scipy.optimize import curve_fit
 from skimage.feature import blob_log
 
@@ -19,8 +18,6 @@ import ImageD11.refinegrains
 import ImageD11.unitcell
 import ImageD11.sinograms.roi_iradon
 import ImageD11.sinograms.properties
-
-from ImageD11.blobcorrector import eiger_spatial
 
 
 ### General utilities (for all notebooks)
@@ -669,12 +666,10 @@ def fit_grain_position_from_recon(grain, ds, y0):
         grain.bad_recon = True
 
 
-# should be fixed by monitor in assemble_label
+# GOTO should be fixed by monitor in assemble_label
 # should just be a sinogram numpy array and a monitor spectrum
-def correct_sinogram_rows_with_ring_current(grain, ds):
-    grain.ssino = grain.ssino / ds.ring_currents_per_scan_scaled[:, None]
-
-
+# def correct_sinogram_rows_with_ring_current(grain, ds):
+#     grain.ssino = grain.ssino / ds.ring_currents_per_scan_scaled[:, None]
 
 
 ### Peak manipulation

--- a/ImageD11/nbGui/nb_utils.py
+++ b/ImageD11/nbGui/nb_utils.py
@@ -674,18 +674,6 @@ def correct_sinogram_rows_with_ring_current(grain, ds):
     grain.ssino = grain.ssino / ds.ring_currents_per_scan_scaled[:, None]
 
 
-def get_ring_current_per_scan(ds):
-    """Gets the ring current for each scan (i.e rotation/y-step)
-       Stores it inside ds.ring_currents_per_scan and a scaled version inside ds.ring_currents_per_scan_scaled"""
-    if not hasattr(ds, "ring_currents_per_scan"):
-        ring_currents = []
-        with h5py.File(ds.masterfile, "r") as h5in:
-            for scan in ds.scans:
-                ring_current = float(h5in[scan]["instrument/machine/current"][()])
-                ring_currents.append(ring_current)
-
-        ds.ring_currents_per_scan = np.array(ring_currents)
-        ds.ring_currents_per_scan_scaled = np.array(ring_currents / np.max(ring_currents))
 
 
 ### Peak manipulation

--- a/ImageD11/nbGui/nb_utils.py
+++ b/ImageD11/nbGui/nb_utils.py
@@ -556,49 +556,6 @@ def save_ubi_map(ds, ubi_map, eps_map, misorientation_map, ipf_x_col_map, ipf_y_
         ipfzdset.attrs['CLASS'] = 'IMAGE'
 
 
-# Other
-
-# GOTO Move to DataSet
-def correct_half_scan(ds):
-    """Pads the dataset to become bigger and symmetric"""
-    # NOTE: We need to keep track of which bins are "real" and measured and which aren't
-    # Sinomask
-    c0 = 0
-    # check / fix the centre of rotation
-    # get value of bin closest to c0
-    central_bin = np.argmin(abs(ds.ybincens - c0))
-    # get centre dty value of this vin
-    central_value = ds.ybincens[central_bin]
-
-    lo_side = ds.ybincens[:central_bin + 1]
-    hi_side = ds.ybincens[central_bin:]
-
-    # get the hi/lo side which is widest
-    # i.e if you go from -130 to +20, it selects -130
-    yrange = max(hi_side[-1] - hi_side[0], lo_side[-1] - lo_side[0])
-
-    # round to nearest multiple of ds.ystep
-    yrange = np.ceil(yrange / ds.ystep) * ds.ystep
-
-    # make new ymin and ymax that are symmetric around central_value
-    ds.ymin = central_value - yrange
-    ds.ymax = central_value + yrange
-
-    new_yrange = ds.ymax - ds.ymin
-
-    # determine new number of y bins
-    ny = int(new_yrange // ds.ystep) + 1
-
-    ds.ybincens = np.linspace(ds.ymin, ds.ymax, ny)
-    ds.ybinedges = np.linspace(ds.ymin - ds.ystep / 2, ds.ymax + ds.ystep / 2, ny + 1)
-
-    print(len(ds.ybincens))
-    print(ds.ybincens)
-    print(ds.ystep)
-    print(yrange)
-    print(ny)
-
-
 ### IPF Colour stuff
 # GOTO New file, Orix interface, taking a grain instance (or a U) as an argument
 # Check sym_u inside ImageD11

--- a/ImageD11/nbGui/nb_utils.py
+++ b/ImageD11/nbGui/nb_utils.py
@@ -609,47 +609,6 @@ def get_rgbs_for_grains(grains):
         grain.rgb_x = grain_to_rgb(grain, ax=(1, 0, 0), )  # symmetry = Symmetry.cubic)
 
 
-### Segmentation
-
-# GOTO Inside blobcorrector
-
-def correct_pixel(pixel, spline_file):
-    sr, fr = pixel
-    sc, fc = ImageD11.blobcorrector.correctorclass(spline_file).correct(sr, fr)
-    return sc, fc
-
-
-def apply_spatial(cf, spline_file, workers):
-    # sc = np.zeros(cf.nrows)
-    # fc = np.zeros(cf.nrows)
-
-    print("Spatial correction...")
-
-    raw_pixels = np.vstack((cf['s_raw'], cf['f_raw'])).T
-
-    corrected_pixels = process_map(correct_pixel, raw_pixels, [spline_file] * len(raw_pixels), max_workers=workers,
-                                   chunksize=len(raw_pixels) // workers)
-
-    sc, fc = [list(t) for t in zip(*corrected_pixels)]
-
-    cf.addcolumn(sc, "sc")
-    cf.addcolumn(fc, "fc")
-
-    return cf
-
-
-def apply_spatial_lut(cf, spline_file):
-    # sc = np.zeros(cf.nrows)
-    # fc = np.zeros(cf.nrows)
-
-    print("Spatial correction...")
-
-    corrector = ImageD11.blobcorrector.correctorclass(spline_file)
-    corrector.correct_px_lut(cf)
-
-    return cf
-
-
 ### Sinogram stuff
 
 # GOTO sinograms/geometry

--- a/ImageD11/nbGui/nb_utils.py
+++ b/ImageD11/nbGui/nb_utils.py
@@ -677,7 +677,7 @@ def correct_sinogram_rows_with_ring_current(grain, ds):
 
 
 ### Peak manipulation
-# GOTO
+# GOTO some sort of Numba zone or C code?
 
 @numba.njit(parallel=True)
 def pmax(ary):
@@ -811,24 +811,11 @@ def get_2d_peaks_from_4d_peaks(ds, cf):
     return gord, inds, p2d
 
 
-# GOTO dataset method
-# add optional peaks mask
-# read only the bits of pkd that we need?
-def tocolf(pkd, ds):
-    """ Converts a dictionary of peaks into an ImageD11 columnfile
-    adds on the geometric computations (tth, eta, gvector, etc) """
-    spat = eiger_spatial(dxfile=ds.e2dxfile, dyfile=ds.e2dyfile)
-    cf = ImageD11.columnfile.colfile_from_dict(spat(pkd))
-    cf.parameters.loadparameters(ds.parfile)
-    cf.updateGeometry()
-    return cf
-
-
 # hkl assignment needs grains2peaks class
 # GOTO: part of a little collection of functions that put stuff on the Grain object
 def do_sinos(g, p2d, ds, hkltol=0.25):
     # g.peaks_2d are 2d peaks that were merged into the 4d peaks that were assigned to this grain (obviously!)
-    flt = tocolf({p: p2d[p][g.peaks_2d] for p in p2d}, ds)  # convert it to a columnfile and spatially correct
+    flt = ds.get_colfile_from_peaks_table({p: p2d[p][g.peaks_2d] for p in p2d}, ds)  # convert it to a columnfile and spatially correct
 
     hkl_real = np.dot(g.ubi, (flt.gx, flt.gy, flt.gz))  # calculate hkl of all assigned peaks
     hkl_int = np.round(hkl_real).astype(int)  # round to nearest integer

--- a/ImageD11/sinograms/dataset.py
+++ b/ImageD11/sinograms/dataset.py
@@ -360,6 +360,19 @@ class DataSet:
         self.ybincens = np.linspace(self.ymin, self.ymax, ny)
         self.ybinedges = np.linspace(self.ymin - self.ystep / 2, self.ymax + self.ystep / 2, ny + 1)
 
+    def get_ring_current_per_scan(self):
+        """Gets the ring current for each scan (i.e rotation/y-step)
+           Stores it inside self.ring_currents_per_scan and a scaled version inside self.ring_currents_per_scan_scaled"""
+        if not hasattr(self, "ring_currents_per_scan"):
+            ring_currents = []
+            with h5py.File(self.masterfile, "r") as h5in:
+                for scan in self.scans:
+                    ring_current = float(h5in[scan]["instrument/machine/current"][()])
+                    ring_currents.append(ring_current)
+
+            self.ring_currents_per_scan = np.array(ring_currents)
+            self.ring_currents_per_scan_scaled = np.array(ring_currents / np.max(ring_currents))
+
     def guess_detector(self):
         '''Guess which detector we are using from the masterfile'''
 

--- a/ImageD11/sinograms/dataset.py
+++ b/ImageD11/sinograms/dataset.py
@@ -328,6 +328,38 @@ class DataSet:
         self.obinedges = np.linspace(self.omin - self.ostep / 2, self.omax + self.ostep / 2, nomega + 1)
         self.ybinedges = np.linspace(self.ymin - self.ystep / 2, self.ymax + self.ystep / 2, ny + 1)
 
+    def correct_bins_for_half_scan(self):
+        """Pads the dataset to become bigger and symmetric"""
+        # TODO: We need to keep track of which bins are "real" and measured and which aren't
+        c0 = 0
+        # check / fix the centre of rotation
+        # get value of bin closest to c0
+        central_bin = np.argmin(abs(self.ybincens - c0))
+        # get centre dty value of this vin
+        central_value = self.ybincens[central_bin]
+
+        lo_side = self.ybincens[:central_bin + 1]
+        hi_side = self.ybincens[central_bin:]
+
+        # get the hi/lo side which is widest
+        # i.e if you go from -130 to +20, it selects -130
+        yrange = max(hi_side[-1] - hi_side[0], lo_side[-1] - lo_side[0])
+
+        # round to nearest multiple of ds.ystep
+        yrange = np.ceil(yrange / self.ystep) * self.ystep
+
+        # make new ymin and ymax that are symmetric around central_value
+        self.ymin = central_value - yrange
+        self.ymax = central_value + yrange
+
+        new_yrange = self.ymax - self.ymin
+
+        # determine new number of y bins
+        ny = int(new_yrange // self.ystep) + 1
+
+        self.ybincens = np.linspace(self.ymin, self.ymax, ny)
+        self.ybinedges = np.linspace(self.ymin - self.ystep / 2, self.ymax + self.ystep / 2, ny + 1)
+
     def guess_detector(self):
         '''Guess which detector we are using from the masterfile'''
 

--- a/ImageD11/sinograms/dataset.py
+++ b/ImageD11/sinograms/dataset.py
@@ -93,6 +93,8 @@ class DataSet:
         self.omega = None
         self.dty = None
 
+        self._peaks_table = None
+
     def update_paths(self):
         # paths for processed data
         # root of analysis for this dataset for this sample:
@@ -455,6 +457,12 @@ class DataSet:
             raise ValueError("I already have a peaks table loaded!")
         self.peaks_table = ImageD11.sinograms.properties.pks_table.load(self.pksfile)
 
+    @property
+    def peaks_table(self):
+        if self._peaks_table is None:
+            self._peaks_table = ImageD11.sinograms.properties.pks_table.load(self.pksfile)
+        return self._peaks_table
+
     def get_colfile_from_peaks_table(self):
         """Converts a dictionary of peaks into an ImageD11 columnfile
         adds on the geometric computations (tth, eta, gvector, etc)"""
@@ -464,11 +472,10 @@ class DataSet:
         # Define spatial correction
         spat = eiger_spatial(dxfile=self.e2dxfile, dyfile=self.e2dyfile)
 
-        # Load the peaks table if not already loaded:
-        if not hasattr(self, "peaks_table"):
-            self.import_peaks_table()
-
+        # Generate columnfile from peaks table
         cf = colfile_from_dict(spat(self.peaks_table))
+
+        # Update parameters for the columnfile
         cf.parameters.loadparameters(self.parfile)
         cf.updateGeometry()
         return cf

--- a/ImageD11/sinograms/dataset.py
+++ b/ImageD11/sinograms/dataset.py
@@ -463,17 +463,20 @@ class DataSet:
             self._peaks_table = ImageD11.sinograms.properties.pks_table.load(self.pksfile)
         return self._peaks_table
 
-    def get_colfile_from_peaks_table(self):
-        """Converts a dictionary of peaks into an ImageD11 columnfile
-        adds on the geometric computations (tth, eta, gvector, etc)"""
+    def get_colfile_from_peaks_table(self, peaks_table=None):
+        """Converts a dictionary of peaks (peaks_table) into an ImageD11 columnfile
+        adds on the geometric computations (tth, eta, gvector, etc)
+        Uses self.peaks_table if no peaks_table provided"""
         # TODO add optional peaks mask
-        # TODO read only the bits of pkd that we need?
 
         # Define spatial correction
         spat = eiger_spatial(dxfile=self.e2dxfile, dyfile=self.e2dyfile)
 
+        if peaks_table is None:
+            peaks_table = self.peaks_table
+
         # Generate columnfile from peaks table
-        cf = colfile_from_dict(spat(self.peaks_table))
+        cf = colfile_from_dict(spat(peaks_table))
 
         # Update parameters for the columnfile
         cf.parameters.loadparameters(self.parfile)

--- a/ImageD11/sinograms/lima_segmenter.py
+++ b/ImageD11/sinograms/lima_segmenter.py
@@ -457,8 +457,14 @@ def setup(
             cut = 1
         else:
             cut = 25  # 5 sigma
+    # Use mask from dataset if no mask provided and dataset has one
+    if len(maskfile) == 0 and hasattr(dso, "maskfile"):
+        maskfile = dso.maskfile
     if len(maskfile) == 0 and ("eiger" in dso.limapath):
         warnings.warn("Eiger detector needs a maskfile that is missing")
+    # Use background file from dataset if no bgfile provided and dataset has one
+    if len(bgfile) == 0 and hasattr(dso, "bgfile"):
+        bgfile = dso.bgfile
     options = SegmenterOptions(
         cut=cut,
         howmany=howmany,

--- a/ImageD11/sinograms/roi_iradon.py
+++ b/ImageD11/sinograms/roi_iradon.py
@@ -513,7 +513,7 @@ def correct_recon_central_zingers(recon, radius=25):
     return recon_corrected
 
 def run_iradon(sino, angles, pad=20, y0=0,
-               workers=1, sample_mask=None,
+               workers=1, mask=None,
                apply_halfmask=False, mask_central_zingers=False, central_mask_radius=25):
     """Applies an iradon to a sinogram, with an optional pad
        Calculates scaled-up output size from pad value
@@ -531,13 +531,10 @@ def run_iradon(sino, angles, pad=20, y0=0,
     else:
         sino_to_recon = sino
 
-    # # pad the sample mask
-    # sample_mask_padded = np.pad(sample_mask, pad//2)
-
     # Perform iradon transform of grain sinogram, store result (reconstructed grain shape) in g.recon
     recon = iradon(sino_to_recon,
                    theta=angles,
-                   mask=sample_mask,
+                   mask=mask,
                    output_size=outsize,
                    projection_shifts=np.full(sino.shape, -y0),
                    filter_name='hamming',
@@ -550,7 +547,7 @@ def run_iradon(sino, angles, pad=20, y0=0,
     return recon
 
 
-def run_mlem(sino, sinoangles, mask=None, pad=20, y0=0, workers=1, niter=20, apply_halfmask=False,
+def run_mlem(sino, angles, mask=None, pad=20, y0=0, workers=1, niter=20, apply_halfmask=False,
              mask_central_zingers=False, central_mask_radius=25):
     """Applies an MLEM reconstruction to a sinogram, with an optional pad
        Calculates scaled-up output size from pad value
@@ -568,7 +565,7 @@ def run_mlem(sino, sinoangles, mask=None, pad=20, y0=0, workers=1, niter=20, app
 
     # Perform iradon transform of grain sinogram, store result (reconstructed grain shape) in g.recon
     recon = mlem(sino_to_recon,
-                 theta=sinoangles,
+                 theta=angles,
                  mask=mask,
                  workers=workers,
                  output_size=outsize,

--- a/ImageD11/sinograms/roi_iradon.py
+++ b/ImageD11/sinograms/roi_iradon.py
@@ -483,6 +483,35 @@ def mlem(sino,
     return mlem_rec
 
 
+def apply_halfmask_to_sino(sino):
+    """Applies halfmask correction to sinogram"""
+    halfmask = np.zeros_like(sino)
+
+    halfmask[:len(halfmask) // 2 - 1, :] = 1
+    halfmask[len(halfmask) // 2 - 1, :] = 0.5
+
+    sino_halfmasked = sino.copy() * halfmask
+
+    return sino_halfmasked
+
+
+def correct_recon_central_zingers(recon, radius=25):
+    recon_corrected = recon.copy()
+    grs = recon.shape[0]
+    xpr, ypr = -grs // 2 + np.mgrid[:grs, :grs]
+    inner_mask_radius = radius
+    outer_mask_radius = inner_mask_radius + 2
+
+    inner_circle_mask = (xpr ** 2 + ypr ** 2) < inner_mask_radius ** 2
+    outer_circle_mask = (xpr ** 2 + ypr ** 2) < outer_mask_radius ** 2
+
+    mask_ring = inner_circle_mask & outer_circle_mask
+    # we now have a mask to apply
+    fill_value = np.median(recon_corrected[mask_ring])
+    recon_corrected[inner_circle_mask] = fill_value
+
+    return recon_corrected
+
 def run_iradon(sino, angles, pad=20, y0=0,
                workers=1, sample_mask=None,
                apply_halfmask=False, mask_central_zingers=False, central_mask_radius=25):
@@ -498,12 +527,7 @@ def run_iradon(sino, angles, pad=20, y0=0,
     outsize = sino.shape[0] + pad
 
     if apply_halfmask:
-        halfmask = np.zeros_like(sino)
-
-        halfmask[:len(halfmask) // 2 - 1, :] = 1
-        halfmask[len(halfmask) // 2 - 1, :] = 0.5
-
-        sino_to_recon = sino * halfmask
+        sino_to_recon = apply_halfmask_to_sino(sino)
     else:
         sino_to_recon = sino
 
@@ -521,17 +545,37 @@ def run_iradon(sino, angles, pad=20, y0=0,
                    workers=workers)
 
     if mask_central_zingers:
-        grs = recon.shape[0]
-        xpr, ypr = -grs // 2 + np.mgrid[:grs, :grs]
-        inner_mask_radius = central_mask_radius
-        outer_mask_radius = inner_mask_radius + 2
+        recon = correct_recon_central_zingers(recon, radius=central_mask_radius)
 
-        inner_circle_mask = (xpr ** 2 + ypr ** 2) < inner_mask_radius ** 2
-        outer_circle_mask = (xpr ** 2 + ypr ** 2) < outer_mask_radius ** 2
+    return recon
 
-        mask_ring = inner_circle_mask & outer_circle_mask
-        # we now have a mask to apply
-        fill_value = np.median(recon[mask_ring])
-        recon[inner_circle_mask] = fill_value
+
+def run_mlem(sino, sinoangles, mask=None, pad=20, y0=0, workers=1, niter=20, apply_halfmask=False,
+             mask_central_zingers=False, central_mask_radius=25):
+    """Applies an MLEM reconstruction to a sinogram, with an optional pad
+       Calculates scaled-up output size from pad value
+       Applies projection shifts of -y0
+       Optionally mask the returned reconstruction with sample_mask
+       Optionally apply halfmask to correct artifacts with half-scans (from -ny to 0 rather than -ny/2 to +ny/2
+       Optionally apply a circular median filter mask to the center of the reconstruction given a radius in central_mask_radius"""
+
+    outsize = sino.shape[0] + pad
+
+    if apply_halfmask:
+        sino_to_recon = apply_halfmask_to_sino(sino)
+    else:
+        sino_to_recon = sino
+
+    # Perform iradon transform of grain sinogram, store result (reconstructed grain shape) in g.recon
+    recon = mlem(sino_to_recon,
+                 theta=sinoangles,
+                 mask=mask,
+                 workers=workers,
+                 output_size=outsize,
+                 projection_shifts=np.full(sino_to_recon.shape, -y0),
+                 niter=niter)
+
+    if mask_central_zingers:
+        recon = correct_recon_central_zingers(recon, radius=central_mask_radius)
 
     return recon

--- a/ImageD11/sinograms/roi_iradon.py
+++ b/ImageD11/sinograms/roi_iradon.py
@@ -481,3 +481,57 @@ def mlem(sino,
         mlem_rec[~mask] = 0.
 
     return mlem_rec
+
+
+def run_iradon(sino, angles, pad=20, y0=0,
+               workers=1, sample_mask=None,
+               apply_halfmask=False, mask_central_zingers=False, central_mask_radius=25):
+    """Applies an iradon to a sinogram, with an optional pad
+       Calculates scaled-up output size from pad value
+       Applies projection shifts of -y0
+       Optionally mask the returned reconstruction with sample_mask
+       Optionally apply halfmask to correct artifacts with half-scans (from -ny to 0 rather than -ny/2 to +ny/2
+       Optionally apply a circular median filter mask to the center of the reconstruction given a radius in central_mask_radius"""
+
+    # TODO Move apply_halfmask method to sinogram class
+
+    outsize = sino.shape[0] + pad
+
+    if apply_halfmask:
+        halfmask = np.zeros_like(sino)
+
+        halfmask[:len(halfmask) // 2 - 1, :] = 1
+        halfmask[len(halfmask) // 2 - 1, :] = 0.5
+
+        sino_to_recon = sino * halfmask
+    else:
+        sino_to_recon = sino
+
+    # # pad the sample mask
+    # sample_mask_padded = np.pad(sample_mask, pad//2)
+
+    # Perform iradon transform of grain sinogram, store result (reconstructed grain shape) in g.recon
+    recon = iradon(sino_to_recon,
+                   theta=angles,
+                   mask=sample_mask,
+                   output_size=outsize,
+                   projection_shifts=np.full(sino.shape, -y0),
+                   filter_name='hamming',
+                   interpolation='linear',
+                   workers=workers)
+
+    if mask_central_zingers:
+        grs = recon.shape[0]
+        xpr, ypr = -grs // 2 + np.mgrid[:grs, :grs]
+        inner_mask_radius = central_mask_radius
+        outer_mask_radius = inner_mask_radius + 2
+
+        inner_circle_mask = (xpr ** 2 + ypr ** 2) < inner_mask_radius ** 2
+        outer_circle_mask = (xpr ** 2 + ypr ** 2) < outer_mask_radius ** 2
+
+        mask_ring = inner_circle_mask & outer_circle_mask
+        # we now have a mask to apply
+        fill_value = np.median(recon[mask_ring])
+        recon[inner_circle_mask] = fill_value
+
+    return recon

--- a/ImageD11/sinograms/roi_iradon.py
+++ b/ImageD11/sinograms/roi_iradon.py
@@ -512,6 +512,7 @@ def correct_recon_central_zingers(recon, radius=25):
 
     return recon_corrected
 
+
 def run_iradon(sino, angles, pad=20, y0=0,
                workers=1, mask=None,
                apply_halfmask=False, mask_central_zingers=False, central_mask_radius=25):


### PR DESCRIPTION
Apologies for the monster commit! Key highlights below:

- New GrainSinogram class to handle building sinograms from a `Grain` and `DataSet` object.
- HDF5 load/save methods for `Grain` class
- Many useful helper functions in `DataSet` class (e.g getting peaks tables for you)
- Some utility functions inside `iradon`
- Lima segmenter now uses mask and background files from the dataset object if none are manually provided
- Utility function for `blobcorrector.py` to correct a columnfile with a spline

All the diffs should be readable aside from `grain.py` which I accidentally linted (sorry!) - look at the bottom of the file for new stuff added.