### PR TITLE
reduce atol/rtol on tests

### DIFF
--- a/test/test_orix.py
+++ b/test/test_orix.py
@@ -19,8 +19,8 @@ class TestOrixPhase(unittest.TestCase):
 
     def test_no_spacegroup(self):
         # set up hexagonal B matrix without a spacegroup
-        hex_ucell_array = np.array([3, 3, 4, 90., 90., 120.])
-        hex_ucell = unitcell(hex_ucell_array, symmetry='P')
+        hex_ucell_array = np.array([3, 3, 4, 90.0, 90.0, 120.0])
+        hex_ucell = unitcell(hex_ucell_array, symmetry="P")
 
         # should fail because we didn't pass a spacegroup for the symmetry
         with self.assertRaises(AttributeError):
@@ -28,7 +28,7 @@ class TestOrixPhase(unittest.TestCase):
 
     def test_with_spacegroup(self):
         # set up hexagonal B matrix with a spacegroup
-        hex_ucell_array = np.array([3, 3, 4, 90., 90., 120.])
+        hex_ucell_array = np.array([3, 3, 4, 90.0, 90.0, 120.0])
         hex_ucell = unitcell(hex_ucell_array, symmetry=194)
 
         # we should have an orix phase object
@@ -41,16 +41,16 @@ class TestGetOrixOrien(unittest.TestCase):
 
     def test_no_spacegroup(self):
         # set up hexagonal B matrix without a spacegroup
-        hex_ucell_array = np.array([3, 3, 4.1, 90., 90., 120.])
+        hex_ucell_array = np.array([3, 3, 4.1, 90.0, 90.0, 120.0])
         hex_ucell = unitcell(hex_ucell_array, symmetry=194)
 
         B = hex_ucell.B
 
         # set up reference unit cell
-        ref_hex_ucell_array = np.array([3, 3, 4.0, 90., 90., 120.])
-        ref_hex_ucell = unitcell(ref_hex_ucell_array, symmetry='P')
+        ref_hex_ucell_array = np.array([3, 3, 4.0, 90.0, 90.0, 120.0])
+        ref_hex_ucell = unitcell(ref_hex_ucell_array, symmetry="P")
 
-        U = np.squeeze(R.from_euler('zyx', [-90, 0, -90], degrees=True).as_matrix())
+        U = np.squeeze(R.from_euler("zyx", [-90, 0, -90], degrees=True).as_matrix())
 
         UB = np.dot(U, B)
 
@@ -60,13 +60,13 @@ class TestGetOrixOrien(unittest.TestCase):
 
     def test_hexagonal(self):
         # set up hexagonal B matrix
-        hex_ucell_array = np.array([3, 3, 4.1, 90., 90., 120.])
+        hex_ucell_array = np.array([3, 3, 4.1, 90.0, 90.0, 120.0])
         hex_ucell = unitcell(hex_ucell_array, symmetry=194)
 
         B = hex_ucell.B
 
         # set up reference unit cell
-        ref_hex_ucell_array = np.array([3, 3, 4.0, 90., 90., 120.])
+        ref_hex_ucell_array = np.array([3, 3, 4.0, 90.0, 90.0, 120.0])
         ref_hex_ucell = unitcell(ref_hex_ucell_array, symmetry=194)
 
         # set up U matrix
@@ -76,7 +76,7 @@ class TestGetOrixOrien(unittest.TestCase):
         # b* to point in +X lab
         # c* to point in +Y lab
 
-        U = np.squeeze(R.from_euler('zyx', [-90, 0, -90], degrees=True).as_matrix())
+        U = np.squeeze(R.from_euler("zyx", [-90, 0, -90], degrees=True).as_matrix())
 
         UB = np.dot(U, B)
 
@@ -86,7 +86,9 @@ class TestGetOrixOrien(unittest.TestCase):
         # a* should be pointing in lab Z
 
         # get direction of (100) normal in cartesian lab frame as Numpy array
-        ra_direc_lab = np.array((~orix_orien * Miller(hkl=(1, 0, 0), phase=orix_phase)).xyz).T
+        ra_direc_lab = np.array(
+            (~orix_orien * Miller(hkl=(1, 0, 0), phase=orix_phase)).xyz
+        ).T
         lab_z = np.array([0, 0, 1])
 
         ra_direc_lab_unit = ra_direc_lab / np.linalg.norm(ra_direc_lab)
@@ -94,19 +96,19 @@ class TestGetOrixOrien(unittest.TestCase):
         self.assertTrue(np.allclose(ra_direc_lab_unit, lab_z))
 
     def test_hexagonal_many(self):
-        print("")
+        # print("")
         # set up hexagonal B matrix
-        hex_ucell_array = np.array([3, 3, 4.0, 90., 90., 120.])
+        hex_ucell_array = np.array([3, 3, 4.0, 90.0, 90.0, 120.0])
         hex_ucell = unitcell(hex_ucell_array, symmetry=194)
 
         B = hex_ucell.B
 
         # set up reference unit cell
-        ref_hex_ucell_array = np.array([3, 3, 4.0, 90., 90., 120.])
+        ref_hex_ucell_array = np.array([3, 3, 4.0, 90.0, 90.0, 120.0])
         ref_hex_ucell = unitcell(ref_hex_ucell_array, symmetry=194)
 
         # many random orientations
-        Us = R.random(100000).as_matrix()
+        Us = R.random(1000).as_matrix()
 
         UBs = np.dot(Us, B)
 
@@ -124,20 +126,53 @@ class TestGetOrixOrien(unittest.TestCase):
         # work out a* directions in lab frame using Orix
         astar_lab_orix = np.array((~orix_orien).outer(astar_miller).xyz).T[0]
 
-        # are they close within 5%?
-        self.assertTrue(np.allclose(astar_lab_id11, astar_lab_orix, rtol=0.05, atol=0))
+        # are they essentially the same:
+        self.assertTrue(np.allclose(astar_lab_id11, astar_lab_orix))
+
+    def test_one_equals_many(self):
+        """
+        Check that the orientation we get back with one orientation is the same
+        as for an array (the code path is different)
+        """
+        Umats = [m.as_matrix() for m in R.random(10)]
+        for uc in (
+            [3, 3, 3, 90, 90, 90],  # cubic
+            [3, 3, 4, 90, 90, 120],  # hexagonal
+            [3, 3, 3, 65, 65, 65],  # trigonal   PROBLEM CASE!!! which number/setting?
+            [3, 3, 4, 90, 90, 90],  # tetragonal
+            [3, 4, 5, 90, 90, 90],  # orthorhombic
+            [3, 4, 5, 95, 90, 90],  # monoclinic a
+            [3, 4, 5, 90, 95, 90],  # monoclinic b
+            [3, 4, 5, 90, 90, 95],  # monoclinic c
+            [3, 4, 5, 91, 92, 93],  # triclinic
+        ):
+            for sgno in (
+                2,  # P-1,
+                10,  # P2/m
+                123,  # P4/mmm
+                162,  # R-3m
+                191,  # P6/mm
+                221,  # Pm3m
+            ):
+                cell = unitcell(uc, sgno)
+                UBs = [m.dot(cell.B) for m in Umats]
+                # convert one at a time:
+                o1 = [cell.get_orix_orien(m).to_matrix() for m in UBs]
+                # convert as an array:
+                o2 = [m.to_matrix() for m in cell.get_orix_orien(UBs)]
+                self.assertTrue(np.allclose(o1, o2))
 
 
 class TestIPFCol(unittest.TestCase):
     def test_cubic(self):
         # set up B matrix
-        cubic_ucell_array = np.array([3., 3., 3., 90., 90., 90.])
+        cubic_ucell_array = np.array([3.0, 3.0, 3.0, 90.0, 90.0, 90.0])
         cubic_ucell = unitcell(cubic_ucell_array, symmetry="F")
 
         B = cubic_ucell.B
 
         # set up reference unit cell
-        ref_cubic_ucell_array = np.array([3, 3, 3, 90., 90., 90.])
+        ref_cubic_ucell_array = np.array([3, 3, 3, 90.0, 90.0, 90.0])
         ref_cubic_ucell = unitcell(ref_cubic_ucell_array, symmetry=225)
 
         # set up U matrix
@@ -147,35 +182,30 @@ class TestIPFCol(unittest.TestCase):
         # b* to point in +X lab
         # c* to point in +Y lab
 
-        U = np.squeeze(R.from_euler('zyx', [-90, 0, -90], degrees=True).as_matrix())
+        U = np.squeeze(R.from_euler("zyx", [-90, 0, -90], degrees=True).as_matrix())
 
         UB = np.dot(U, B)
 
         # each of the 100, 010, 001, etc directions should have red colours (cubic symmetry)
 
-        axes = np.array([
-            [1., 0, 0],
-            [0, 1, 0],
-            [0, 0, 1],
-            [-1, 0, 0],
-            [0, -1, 0],
-            [0, 0, -1]
-        ])
+        axes = np.array(
+            [[1.0, 0, 0], [0, 1, 0], [0, 0, 1], [-1, 0, 0], [0, -1, 0], [0, 0, -1]]
+        )
 
-        red = np.array([[1., 0., 0.]])
+        red = np.array([[1.0, 0.0, 0.0]])
 
         for axis in axes:
             rgb = ref_cubic_ucell.get_ipf_colour(UBs=UB, axis=axis)
             self.assertTrue(np.allclose(rgb, red))
 
     def test_cubic_110(self):
-        cubic_ucell_array = np.array([3., 3., 3., 90., 90., 90.])
+        cubic_ucell_array = np.array([3.0, 3.0, 3.0, 90.0, 90.0, 90.0])
         cubic_ucell = unitcell(cubic_ucell_array, symmetry="F")
 
         B = cubic_ucell.B
 
         # set up reference unit cell
-        ref_cubic_ucell_array = np.array([3, 3, 3, 90., 90., 90.])
+        ref_cubic_ucell_array = np.array([3, 3, 3, 90.0, 90.0, 90.0])
         ref_cubic_ucell = unitcell(ref_cubic_ucell_array, symmetry=225)
 
         # set up U matrix
@@ -185,7 +215,7 @@ class TestIPFCol(unittest.TestCase):
         # rotate 45 degrees in Z
         # should mean 0.5 e1 + 0.5 e2 + 0.0 e3
 
-        U = np.squeeze(R.from_euler('z', [44], degrees=True).as_matrix())
+        U = np.squeeze(R.from_euler("z", [45.0], degrees=True).as_matrix())
 
         UB = np.dot(U, B)
 
@@ -193,19 +223,18 @@ class TestIPFCol(unittest.TestCase):
         # so in an IPF-X plot, the colour should be green
 
         rgb = ref_cubic_ucell.get_ipf_colour(UBs=UB, axis=np.array([1, 0, 0]))
-        green = np.array([0., 1., 0.])
-
-        self.assertTrue(np.allclose(rgb, green, atol=0.05))
+        green = np.array([0.0, 1.0, 0.0])
+        self.assertTrue(np.allclose(rgb, green, atol=0.01))
 
     def test_cubic_111(self):
         # set up B matrix
-        cubic_ucell_array = np.array([3., 3., 3., 90., 90., 90.])
+        cubic_ucell_array = np.array([3.0, 3.0, 3.0, 90.0, 90.0, 90.0])
         cubic_ucell = unitcell(cubic_ucell_array, symmetry="F")
 
         B = cubic_ucell.B
 
         # set up reference unit cell
-        ref_cubic_ucell_array = np.array([3, 3, 3, 90., 90., 90.])
+        ref_cubic_ucell_array = np.array([3, 3, 3, 90.0, 90.0, 90.0])
         ref_cubic_ucell = unitcell(ref_cubic_ucell_array, symmetry=225)
 
         # set up U matrix
@@ -213,29 +242,33 @@ class TestIPFCol(unittest.TestCase):
         # we want:
         # some (111) normal to point along X
         # rotate 45 degrees in Z
-        # should mean 0.5 e1 + 0.5 e2 + 0.0 e3
 
-        U = np.squeeze(R.from_euler('zy', [45, 45], degrees=True).as_matrix())
-
+        # You need 111 along an axis, so the angle between 111 and the 110 axis is:
+        cosangle = (
+            np.dot((1, 1, 1), (1, 1, 0))
+            / np.linalg.norm((1, 1, 1))
+            / np.linalg.norm((1, 1, 0))
+        )
+        angle = np.degrees(np.arccos(cosangle))
+        U = R.from_euler("ZYZ", (0, angle, -45), degrees=True).as_matrix()
         UB = np.dot(U, B)
-
-        # 111 should be pointing along X
+        # 111 should be pointing along X : check this
+        g111 = UB.dot((1, 1, 1))
+        self.assertTrue(np.allclose((1, 0, 0), g111 / np.linalg.norm(g111)))
         # so in an IPF-X plot, the colour should be blue-ish
-
         rgb = ref_cubic_ucell.get_ipf_colour(UBs=UB, axis=np.array([1, 0, 0]))
-        blue = np.array([0., 0., 1.])
-
-        self.assertTrue(np.allclose(rgb, blue, atol=0.3))
+        blue = np.array([0.0, 0.0, 1.0])
+        self.assertTrue(np.allclose(rgb, blue, atol=0.01))
 
     def test_hexagonal(self):
         # set up hexagonal B matrix
-        hex_ucell_array = np.array([3, 3, 4, 90., 90., 120.])
+        hex_ucell_array = np.array([3, 3, 4, 90.0, 90.0, 120.0])
         hex_ucell = unitcell(hex_ucell_array, symmetry="P")
 
         B = hex_ucell.B
 
         # set up reference unit cell
-        ref_hex_ucell_array = np.array([3, 3, 4.0, 90., 90., 120.])
+        ref_hex_ucell_array = np.array([3, 3, 4.0, 90.0, 90.0, 120.0])
         ref_hex_ucell = unitcell(ref_hex_ucell_array, symmetry=194)
 
         # set up U matrix
@@ -245,7 +278,7 @@ class TestIPFCol(unittest.TestCase):
         # b* to point in +X lab
         # c* to point in +Y lab
 
-        U = np.squeeze(R.from_euler('zyx', [-90, 0, -90], degrees=True).as_matrix())
+        U = np.squeeze(R.from_euler("zyx", [-90, 0, -90], degrees=True).as_matrix())
 
         UB = np.dot(U, B)
 
@@ -255,14 +288,17 @@ class TestIPFCol(unittest.TestCase):
         # on TSL, (10-10) is blue
 
         rgb = ref_hex_ucell.get_ipf_colour(UBs=UB, axis=np.array([0, 0, 1]))
-        blue = np.array([0., 0., 1.])
-
-        self.assertTrue(np.allclose(rgb, blue, atol=0.3))
+        blue = np.array([0.0, 0.0, 1.0])
+        self.assertTrue(np.allclose(rgb, blue, atol=0.01))
 
         # on an IPF-Y, c* should be parallel to Y
         # c* is (0001) normal
 
         rgb = ref_hex_ucell.get_ipf_colour(UBs=UB, axis=np.array([0, 1, 0]))
-        red = np.array([1., 0., 0.])
+        red = np.array([1.0, 0.0, 0.0])
 
-        self.assertTrue(np.allclose(rgb, red, atol=0.3))
+        self.assertTrue(np.allclose(rgb, red, atol=0.01))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sorry - Black format messed up the diff. Main changes:
- the color tests have a smaller tolerance (orientation was wrong for blue)
- added a check on the code path of 1 UB vs many UBs