### PR TITLE
Unitcell: Try to cast symmetry to int during init

### DIFF
--- a/ImageD11/unitcell.py
+++ b/ImageD11/unitcell.py
@@ -173,6 +173,10 @@ class unitcell:
             raise Exception("You must supply 6 lattice parameters\n" + \
                             "      a,b,c,alpha,beta,gamma")
 
+        if isinstance(symmetry, str):
+            if symmetry.isdigit():
+                symmetry = int(symmetry)
+
         if isinstance(symmetry, int):
             # this is an integer spacegroup
             self.symmetry = symmetry


### PR DESCRIPTION
Importing a .gve file into the indexer with `indexer.readgvfile` calls `unitcell.cellfromstring` to build a unitcell from the parameters at the top of the .gve file.
This means that, for .gve files with spacegroup-style symmetries, a `str` type symmetry is passed to the `unitcell.__init__` method.
For numeric (i.e spacegroup) symmetries, this means we don't properly detect that a spacegroup is being supplied.
This patch fixes the bug - if the symmetry is a string, it checks if the string is a digit, and converts to int if possible before continuing the init.