### PR TITLE
Release workflow: Increase verbosity of cibuildwheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install and test sdist
         run: |
-          pip install --pre dist/imaged11*.tar.gz
+          pip install dist/imaged11*.tar.gz
           pytest test
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
+          CIBW_BUILD_VERBOSITY: 1
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
           # Do not build for pypy, muslinux and python3.12 on ppc64le

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install and test sdist
         run: |
-          pip install --pre dist/ImageD11*.tar.gz
+          pip install --pre dist/imaged11*.tar.gz
           pytest test
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Following some recent troubleshooting by @kif with this, this PR proposes to increase the verbosity of the build.

It also removes the `--pre` installation flag which makes the tests of the generated source tarball fail because it run the tests with numpy v2.

BTW, if you want to support numpy v2, the wheels should be generated with numpy v2.