### PR TITLE
Update release workflow to use macos-13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,8 @@ jobs:
           # Use silx wheelhouse: needed for ppc64le
           CIBW_ENVIRONMENT_LINUX: "PIP_FIND_LINKS=https://www.silx.org/pub/wheelhouse/ PIP_TRUSTED_HOST=www.silx.org"
 
-          CIBW_TEST_REQUIRES: pytest
+          CIBW_BEFORE_TEST: "pip install --only-binary :all: fabio PyQt5"
+          CIBW_TEST_EXTRAS: full
           CIBW_TEST_COMMAND: pytest {project}/test
           # Skip tests for 32bits and emulated architectures, arm64 macos and on Windows
           CIBW_TEST_SKIP: "*-*linux_i686 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-win_amd64"
@@ -87,7 +88,7 @@ jobs:
 
       - name: Install and test sdist
         run: |
-          pip install dist/imaged11*.tar.gz
+          pip install "$(ls dist/imaged11*.tar.gz)[full]"
           pytest test
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             cibw_archs: "auto64"
           #- os: windows-2019
           #  cibw_archs: "auto32"
-          - os: macos-11
+          - os: macos-13
             cibw_archs: "universal2"
 
     steps:


### PR DESCRIPTION
This PR updates the release workflow to:
- use `macos-13` (11 is no longer available and 12 is deprecated)
- fix the installation of dependencies for the tests to pass

Here is a manual run of it: https://github.com/FABLE-3DXRD/ImageD11/actions/runs/11384434752