### PR TITLE
add forward_model for facilitating (s)3DXRD analysis

### DIFF
--- a/ImageD11/forward_model/__init__.py
+++ b/ImageD11/forward_model/__init__.py
@@ -1,0 +1,28 @@
+"""
+forward model for 3DXRD and s3DXRD
+The aim is to exploit forward model for the following purposes:
+1) facilitate analysis for (s)3DXRD by filtering and cleaning peaks for indexed grains, calculating completeness
+2) bridging the combined analysis between DCT and (s)3DXRD for the same sample but measured in different geometries/instruments
+3) forward model based reconstruction for both near-field and far-field geometries
+4) parameters conversion among ImageD11 par, DCT parameters, poni, which all can be converted to a dictionary and compatible with fwd-DCT parameters
+5) other auxillary tools for multi-modality analysis, including interacting with PCT, sample environment, orientation conversion, deformation analysis (schmidt factor calc) etc.
+Copyright (C) 2023-present  Haixing Fang
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+"""
+ 
+__version__ = "1.0.0"
+__author__ = 'Haixing Fang',
+__author_email__ = 'haixing.fang@esrf.fr'

--- a/ImageD11/forward_model/forward_model.py
+++ b/ImageD11/forward_model/forward_model.py
@@ -318,7 +318,7 @@ def get_ds_max(pars):
     p = pars_conversion.convert_ImageD11pars2p(pars)
     ttheta_max = np.arctan(  ((p['detysize']*p['pixelysize']/2)**2 + (p['detzsize']*p['pixelzsize']/2)**2)**(1/2) / p['Lsam2det']  )   # two-teta maximum [radian]
     theta_max = ttheta_max/2.0   # theta [radian]
-    wavelength = econst / Energy
+    wavelength = econst / p['Energy']
     ds_max = 1.0/(p['wavelength']/(2*np.sin(theta_max)))  # 1/d [Angstron^-1]    
     print('Maximum two-theta angle = {}, ds_max = {} Angstrom^-1'.format(np.rad2deg(ttheta_max), ds_max))
     

--- a/ImageD11/forward_model/forward_model.py
+++ b/ImageD11/forward_model/forward_model.py
@@ -1,0 +1,525 @@
+# forward_model.py
+# 1) Given omega, Gw, pos, UBI etc + parameters, output the expected intersection position on the detector
+# Computation done in lab frame: x along X-ray beam, y points outward the synchrotron horizontally, z is vertical up
+# 2) filter, compare, plot etc for column file (cf)
+# 3) forward_match_peaks to find matched peaks and compute completeness
+# Haixing Fang, haixing.fang@esrf.fr
+# Oct 4th, 2024
+
+import numpy as np
+import ImageD11.columnfile
+import ImageD11.unitcell
+import ImageD11.transformer
+from ImageD11.forward_model import pars_conversion
+from matplotlib import pyplot as plt
+
+econst = 12.3984
+
+
+def forward_match_peaks(cf_strong, grains, ds, ucell, pars, ds_max = 2.0, tol_angle=1, tol_pixel=10, thres_int = None):
+    """
+    Perform forward calculation to find the matched fwd peaks and exp peaks
+
+    Arguments:
+    cf_strong -- ImageD11 colume file, e.g. cf_4d = ds.get_cf_4d_from_disk() and then filter
+    grains    -- list of grain object, e.g. grains = ds.get_grains_from_disk(phase_str)
+    ds        -- dataset object,   e.g. ds = ImageD11.sinograms.dataset.load(dset_file)
+    ucell     -- ImageD11.unitcell object, e.g. ucell = ds.phases.unitcells[phase_str]
+    pars      -- ImageD1.parameters object, e.g. pars = ImageD11.parameters.read_par_file(ds.parfile)
+    Optional arguments:
+    ds_max    -- maximum 1/d
+    tol_angle -- tolerance of angles for matching peaks
+    tol_piexl -- tolerance of pixels for matching peaks
+    thres_int -- intensity threshold, None as default to not remove peaks
+
+    Returns:
+    cf_matched_all -- list of matched peaks for each of the grain, list of ImageD11.columnfile
+    Comp_all -- Completeness values [N*2] list, original completeness and updated completeness after removing the low-intensity matched peaks
+    """
+    cf_matched_all = []
+    Comp_all = []
+
+    rot_min = ds.omega.min()-0.1
+    rot_max = ds.omega.max()+0.1
+    rot_step = ds.omega[0][1]-ds.omega[0][0]
+    for i in range(len(grains)):
+        print('******************************************** Perform forward computation for grain no. {} *********************************************'.format(i))
+        if grains[i].translation is None:
+            pos = np.array([0.0, 0.0, 0.0])
+        else:
+            pos = grains[i].translation/1000.0
+
+        U = grains[i].U
+        B = grains[i].B
+
+        fwd, Nr_simu = forward_comp(pos, U, B, ucell, pars, ds_max = ds_max, rot_start = rot_min, rot_end = rot_max, rot_step = rot_step)
+        cf_matched, fwd_matched, ij, Completeness = find_matching_peaks(cf_strong, fwd, dsmax = ds_max, tol_angle=tol_angle, tol_pixel=tol_pixel)
+        if thres_int is not None:
+             cf_matched = cf_remove_weak_peaks(cf_matched, thres_int = thres_int)
+        Comp_all.append([Completeness, cf_matched.nrows/Nr_simu])
+        cf_matched_all.append(cf_matched)
+    return cf_matched_all, Comp_all
+    
+        
+    
+def forward_comp(pos, U, B, ucell, pars, ds_max = 1.2, rot_start = -91, rot_end = 91, rot_step = 0.05):
+    """
+    Given pos, U, B, ucell, pars, forward calculate the expected intersection position on the detector.
+
+    Arguments:
+    pos -- position vector
+    U -- rotation matrix
+    B -- B matrix represented by lattice parameters
+    ucell -- ImageD11.unitcell object
+    pars -- ImageD1.parameters object, e.g. ImageD11.parameters.read_par_file('pars.json')
+    ds_max -- maximum ds
+    rot_start -- starting omega angle [deg]
+    rot_step -- step size of the omega rotation [deg]
+    rot_end -- end omega angle [deg]
+
+    Returns:
+    fwd -- list of expected peak positions: [rot in degrees, hkl, 2-theta in degrees, Gt, dety, detz, dety_mm, detz_mm, HitDetFlag]
+    Nr_simu -- number of theoretical spots expected on the detector
+    """    
+    Nr_simu = 0
+    fwd = []
+    
+    p = pars_conversion.convert_ImageD11pars2p(pars)
+    
+    wavelength = econst/p['Energy'] # [Angstrom]
+    
+    Ki = np.array([p['Energy']/econst, 0, 0]) # note that there is no 2*pi here
+    Klen = np.linalg.norm(Ki) # [A^-1]
+
+    ds_all, hkls = get_hkls(ucell, dsmax = ds_max)
+    
+    Gw = np.dot(p['S'], np.dot(U, np.dot(B, hkls.T)))
+    # Glen = np.sqrt(Gw[0, :]**2 + Gw[1, :]**2 + Gw[2, :]**2)
+    Glen = np.linalg.norm(Gw, axis=0)
+    theta = np.arcsin(Glen / (2*Klen))
+    
+    a = Gw[0,:]/Glen
+    b = -Gw[1,:]/Glen
+    c = (np.cos(2*theta)-1)/np.sqrt(2*(1-np.cos(2*theta)))
+    d = a**2 + b**2
+    sqD = d - c**2
+    omega_all = np.zeros((Gw.shape[1],2))
+    for i in range(omega_all.shape[0]):
+        omega_all[i,:] = find_omega(a[i], b[i], c[i], d[i], sqD[i])
+    if rot_start < 0:
+        omega_all[omega_all > (2*np.pi + np.deg2rad(rot_start))] -= 2*np.pi # bring the omega solution from [0, 2*pi] to [rot_start, 2*pi+rot_start]
+        
+    print('Investigating {} possible omega angle solutions ...'.format(omega_all.shape))
+    print('Omega angle range: [{}, {}]'.format(np.rad2deg(np.nanmin(omega_all)), np.rad2deg(np.nanmax(omega_all))))
+
+    # print(np.rad2deg(omega_all))
+    # computation in lab system
+    i = 0
+    for ii in range(omega_all.shape[0]):
+        for jj in range(2):
+            i += 1
+            omega = omega_all[ii,jj]
+            rot = np.rad2deg(omega)
+            if rot >= rot_start and rot < rot_end - rot_step / 2:
+                dety, detz, dety_mm, detz_mm, Gt, HitDetFlag = forward_det_pos(pos, omega, Gw[:, ii], theta[ii], p)
+                if HitDetFlag == True:
+                    Nr_simu += 1
+                fwd.append([rot, hkls[ii,:], np.rad2deg(theta[ii])*2, Gt, dety, detz, dety_mm, detz_mm, HitDetFlag])
+                
+    print('Done! {} peaks expected on the detector by investigating {}*2 hkl reflections for rotation angle range between {} and {} degrees'.format(Nr_simu, hkls.shape[0], rot_start, rot_end))
+    print('fwd list contains: [rot in degrees, hkl, 2-theta in degrees, Gt, dety, detz, dety_mm, detz_mm, HitDetFlag]')
+    return fwd, Nr_simu
+
+
+def forward_det_pos(pos, omega, Gw, theta, p):
+    """
+    Given omega, Gw, pos, U, and other parameters, outputs the expected intersection position on the detector.
+
+    Arguments:
+    pos -- position vector
+    S -- rotation matrix or similar
+    omega -- rotation angle in radians
+    Gw -- G vector
+    p  -- parameter containing the following:
+    Lsam2det -- distance from the sample to the detector
+    theta -- diffraction angle
+    RotDet -- rotation matrix for the detector
+    dety0, detz0 -- detector center positions in pixels
+    dety00, detz00 -- detector offset position
+    pixelysize, pixelzsize -- pixel sizes in mm
+    detysize, detzsize -- detector sizes in pixels
+    BeamStopY, BeamStopZ -- beamstop positions
+    flip_lr_flag, flip_ud_flag -- flags for flipping left-right or up-down
+
+    Returns:
+    dety, detz -- detector positions in pixels
+    dety_mm, detz_mm -- detector positions in mm
+    Gt.T -- diffraction vector in lab frame, 1*3 numpy array
+    HitDetFlag -- flag if the position hits the effective area of the detector
+    """
+    
+    omega_matrix = get_omega_matrix(omega)
+    Gt = np.dot(omega_matrix, Gw)
+    SamposW = np.dot(omega_matrix, np.dot(p['S'], pos.T))
+
+    # Sample center projected to the position of the detector
+    center = np.array([p['Lsam2det'] - SamposW[0], SamposW[1], SamposW[2]]).T
+
+    # Difference vector in mm
+    diffvec = (p['Lsam2det'] - SamposW[0]) * np.tan(2 * theta)
+    konst = np.sqrt(Gt[1]**2 + Gt[2]**2)
+
+    dety22 = center[1] + (diffvec * Gt[1] / konst)  # dety in mm
+    detz22 = center[2] + (diffvec * Gt[2] / konst)  # detz in mm
+        
+    K_out_unit = (np.array([p['Lsam2det'], dety22, detz22]) - SamposW) / np.sqrt((p['Lsam2det'] - SamposW[0])**2 + (dety22 - SamposW[1])**2 + (detz22 - SamposW[2])**2)
+
+    t = (p['RotDet'][0, 0] * (p['Lsam2det'] - SamposW[0]) + p['RotDet'][1, 0] * (p['dety00'] - SamposW[1]) + p['RotDet'][2, 0] * (p['detz00'] - SamposW[2])) / \
+        (p['RotDet'][0, 0] * K_out_unit[0] + p['RotDet'][1, 0] * K_out_unit[1] + p['RotDet'][2, 0] * K_out_unit[2])
+
+    dety_mm = np.dot(p['RotDet'][:, 1], t * K_out_unit + np.array([SamposW[0] - p['Lsam2det'], SamposW[1] - p['dety00'], SamposW[2] - p['detz00']]).T)  # dety in mm
+    detz_mm = np.dot(p['RotDet'][:, 2], t * K_out_unit + np.array([SamposW[0] - p['Lsam2det'], SamposW[1] - p['dety00'], SamposW[2] - p['detz00']]).T)  # detz in mm
+
+    dety = -dety_mm / p['pixelysize'] + p['dety0']  # dety in pixels
+    detz = -detz_mm / p['pixelzsize'] + p['detz0']  # detz in pixels
+
+    if p['flip_lr_flag'] == True:
+        dety = p['detysize'] - dety + 2 * (p['dety0'] - p['detysize'] / 2)
+        dety_mm = p['detysize'] * p['pixelysize'] - dety_mm
+
+    if p['flip_ud_flag'] == True:
+        detz = p['detzsize'] - detz + 2 * (p['detz0'] - p['detzsize'] / 2)
+        detz_mm = p['detzsize'] * p['pixelzsize'] - detz_mm
+
+    if (1 <= dety <= p['detysize']) and (1 <= detz <= p['detzsize']) and not \
+       (p['BeamStopY'][0] <= dety <= p['BeamStopY'][1] and p['BeamStopZ'][0] <= detz <= p['BeamStopZ'][1]):
+        HitDetFlag = True
+    else:
+        HitDetFlag = False
+
+    return dety, detz, dety_mm, detz_mm, Gt.T, HitDetFlag
+
+
+def get_omega_matrix(omega):
+    """
+    Calculate the rotation matrix (Omega) for a rotation angle around Z vertical axis in right-hand coordinate system
+    Returns:
+    Omega matrix 3*3 array
+    """
+    omega_matrix = np.array([[np.cos(omega), -np.sin(omega), 0],
+                   [np.sin(omega), np.cos(omega), 0],
+                   [0, 0, 1.0]])
+    return omega_matrix
+    
+
+def find_omega(a, b, c, d, sqD):
+    """
+    Finds the omega (rotation angle) that generates the diffraction.
+
+    Arguments:
+    a, b, c, d, sqD -- parameters as per the problem's equation
+
+    Returns:
+    Omega -- list containing the solutions for omega (in the range [0, 2*pi])
+    """
+    Omega = []
+    if sqD > 0:
+        sqD = np.sqrt(sqD)
+        
+        # First Omega solution
+        comega = (a*c + b*sqD) / d
+        somega = (b*c - a*sqD) / d
+        Omega.append(np.arccos(comega))
+        if somega < 0:
+            Omega[0] = -Omega[0]
+
+        # Second Omega solution
+        comega = comega - 2.0 * b * sqD / d
+        somega = somega + 2.0 * a * sqD / d
+        Omega.append(np.arccos(comega))
+        if somega < 0:
+            Omega[1] = -Omega[1]
+
+        # Bring solutions to the range [0, 2*pi]
+        for i in range(2):
+            if Omega[i] < 0:
+                Omega[i] = 2 * np.pi + Omega[i]
+    else:
+        Omega = [np.nan]
+
+    return Omega
+
+
+def get_hkls(ucell, dsmax = 1.2):
+    """
+    get hkl list from the ucell provided by ImageD11
+
+    Arguments:
+    ucell, dsmax
+
+    Returns:
+    ds_all -- 1/d of all the unique hkl families within dsmax
+    hkls   -- list of hkl indices for the lattice planes
+    """
+    Ahkls = ucell.gethkls(dsmax)
+    unique_dict = {}
+
+    # Populate the dictionary with the unique first-column values as keys and corresponding second-column values as lists
+    for val in Ahkls:
+        first_col, second_col = val
+        if first_col not in unique_dict:
+            unique_dict[first_col] = []
+        unique_dict[first_col].append(second_col)
+
+    # Convert the lists of second-column values to numpy arrays
+    unique_arrays = {k: np.array(v) for k, v in unique_dict.items()}
+
+    # Display the unique values and corresponding numpy arrays
+    #for k, v in unique_arrays.items():
+        
+    ds_all = []
+    hkls = []
+    for key in unique_arrays:
+        ds_all.append(key)
+        hkls.append(unique_arrays[key])
+    ds_all = np.vstack(ds_all)
+    hkls = np.vstack(hkls)
+    print('Got {} hkl lattice planes in total out of {} hkl families'.format(hkls.shape[0], ds_all.shape[0]))
+    print('ds range for {} hkl families: [{}, {}]'.format(ds_all.shape[0], np.min(ds_all), np.max(ds_all)))
+
+    return ds_all, hkls
+                            
+
+def get_tth_from_ds(ds, wavelength):
+    """
+    Calculate two-theta angle from ds and wavelength according to Bragg's law
+
+    Arguments:
+    ds -- inverse of d-spacing for a given hkl family
+    wavelength -- [Angstrom]
+
+    Returns:
+    two-theta in degrees
+    """
+    return 2*np.rad2deg(np.arcsin(wavelength*ds/2.0))                  
+
+
+def get_ds_max(pars):
+    """
+    Calculate two-theta angle from ds and wavelength according to Bragg's law
+
+    Arguments:
+    ds -- inverse of d-spacing for a given hkl family
+    wavelength -- [Angstrom]
+
+    Returns:
+    two-theta in degrees
+    """
+    Lsam2det, RotDet, dety0, detz0, dety00, detz00, pixelysize, pixelzsize, detysize, detzsize, \
+        BeamStopY, BeamStopZ, S, flip_lr_flag, flip_ud_flag, Energy = convert_pars2parameters(pars)
+    ttheta_max = np.arctan(  ((detysize*pixelysize/2)**2 + (detzsize*pixelzsize/2)**2)**(1/2) / Lsam2det  )   # two-teta maximum [radian]
+    theta_max = ttheta_max/2.0   # theta [radian]
+    wavelength = econst / Energy
+    ds_max = 1.0/(wavelength/(2*np.sin(theta_max)))  # 1/d [Angstron^-1]
+    print('Maximum two-theta angle = {}, ds_max = {} Angstrom^-1'.format(np.rad2deg(ttheta_max), ds_max))
+    return ds_max
+
+
+def find_matching_peaks(cf, fwd, dsmax=1.5, tol_angle=0.1, tol_pixel=0.55):
+    """
+    Matching the peaks from cf to the forward calculated peaks by checking differences in omega, tth, fc(dety), sc(detz)
+
+    Arguments:
+    cf -- ImageD11 column file [object]
+    fwd -- forward calculated peaks info obtained from forward_comp [list]
+    dsmax -- maximum ds [Angstrom^-1]
+    tol_angle -- tolerance for matching angles, omega and two-theta [deg]
+    tol_pixel -- tolerance for matching pixel coordinate, dety (fc) and detz (sc), [pixel]
+
+    Returns:
+    cf_matched -- colume file that only matches with forward calculated peaks
+    fwd_matched -- matched peaks among all the forward calculated peaks
+    ij -- indices corresponding to cf_matched and fwd_matched, respectively
+    Completeness -- the fraction of matched forward peaks
+    """
+    
+    cf_omega = np.array(cf.omega)
+    cf_tth = np.array(cf.tth)
+    cf_fc = np.array(cf.fc)
+    cf_sc = np.array(cf.sc)
+    
+    # Extract forward peaks into arrays for vectorized matching
+    fwd_omega = np.array([row[0] for row in fwd])
+    fwd_tth = np.array([row[2] for row in fwd])
+    fwd_fc = np.array([row[4] for row in fwd])
+    fwd_sc = np.array([row[5] for row in fwd])
+    
+    # Vectorized differences
+    diff_omega = np.abs(cf_omega[:, np.newaxis] - fwd_omega)
+    diff_tth = np.abs(cf_tth[:, np.newaxis] - fwd_tth)
+    diff_fc = np.abs(cf_fc[:, np.newaxis] - fwd_fc)
+    diff_sc = np.abs(cf_sc[:, np.newaxis] - fwd_sc)
+    
+    # Apply tolerances
+    matches = (diff_omega < tol_angle) & (diff_tth < tol_angle) & (diff_fc < tol_pixel) & (diff_sc < tol_pixel)
+    
+    
+    # Create a boolean mask for the cf object
+    matched_cf_indices, matched_fwd_indices = np.where(matches)
+    
+    matched_mask = np.zeros(cf.nrows, dtype=bool)
+    matched_mask[matched_cf_indices] = True
+    
+    # Filter cf_matched using the boolean mask
+    cf_matched = cf.copy()
+    cf_matched.filter(matched_mask)
+    
+    # Get the corresponding forward matched rows
+    fwd_matched = [fwd[j] for j in np.unique(matched_fwd_indices)]
+    
+    # ij will contain the indices of matched peaks
+    ij = list(zip(matched_cf_indices, matched_fwd_indices))
+    
+    # Calculate the completeness
+    Completeness = len(fwd_matched) / len(fwd)
+    print('Found {}/{} matched peaks, completeness = {}'.format(len(fwd_matched), len(fwd), Completeness))
+    
+    return cf_matched, fwd_matched, ij, Completeness
+
+
+
+def cf_remove_weak_peaks(cf, percent_int = 20, thres_int = None):
+    """
+    remove weak peaks either by specifying the minimum peak intensity or by removing the lowest percent_int percent of the all peaks
+    Matching the peaks from cf to the forward calculated peaks by checking differences in omega, tth, fc(dety), sc(detz)
+
+    Arguments:
+    cf -- ImageD11 column file [object]
+    percent_int -- percentage of the weak intensities
+    thres_int -- threshold intenisty
+
+    Returns:
+    filterd peaks as cf object
+    """
+    if thres_int is None:
+        thres_int = np.percentile(cf.sum_intensity, percent_int)
+    print('Intensity threshold: {}'.format(thres_int))
+    m = cf.sum_intensity > thres_int
+    cf_out = cf.copy()
+    cf_out.filter(m)
+    
+    print('Original {} peaks reduced to {} peaks'.format(cf.nrows, cf_out.nrows))
+    return cf_out
+
+
+def cf_set_difference(cf1, cf2, tol = 0.001):
+    """
+    Matching the peaks from cf to the forward calculated peaks by checking differences in omega, tth, fc(dety), sc(detz)
+
+    Arguments:
+    cf1 -- ImageD11 column file [object]
+    cf2 -- ImageD11 column file [object]
+    tol -- tolerance for matching the peaks, dty, omega, sc and fc
+
+    Returns:
+    cf1_diff -- rest of the peaks from cf1 which is not contained in cf2
+    cf2_diff -- rest of the peaks from cf2 which is not contained in cf1
+    """
+    
+    cf1_omega = np.array(cf1.omega)
+    cf1_dty = np.array(cf1.dty)
+    cf1_fc = np.array(cf1.fc)
+    cf1_sc = np.array(cf1.sc)
+    
+    cf2_omega = np.array(cf2.omega)
+    cf2_dty = np.array(cf2.dty)
+    cf2_fc = np.array(cf2.fc)
+    cf2_sc = np.array(cf2.sc)
+    
+    # Vectorized differences
+    diff_dty = np.abs(cf1_dty[:, np.newaxis] - cf2_dty)
+    diff_omega = np.abs(cf1_omega[:, np.newaxis] - cf2_omega)
+    diff_fc = np.abs(cf1_fc[:, np.newaxis] - cf2_fc)
+    diff_sc = np.abs(cf1_sc[:, np.newaxis] - cf2_sc)
+    
+    # Apply tolerances
+    matches = (diff_dty < tol) & (diff_omega < tol) & (diff_fc < tol) & (diff_sc < tol)
+    
+    # Create a boolean mask for the cf object
+    matched_cf1_indices, matched_cf2_indices = np.where(matches)
+    
+    diff_mask1 = np.ones(cf1.nrows, dtype=bool)
+    diff_mask1[matched_cf1_indices] = False
+    
+    diff_mask2 = np.ones(cf2.nrows, dtype=bool)
+    diff_mask2[matched_cf2_indices] = False
+    
+    # Filter cf using the boolean mask
+    cf1_diff = cf1.copy()
+    cf1_diff.filter(diff_mask1)
+    
+    cf2_diff = cf2.copy()
+    cf2_diff.filter(diff_mask2)
+    
+    print('Found {}/{} different peaks for cf1'.format(cf1_diff.nrows, cf1.nrows))
+    print('Found {}/{} different peaks for cf2'.format(cf2_diff.nrows, cf2.nrows))
+
+    return cf1_diff, cf2_diff
+
+
+def cf_plot_sino(cfs):
+    """
+    plot sinogram for each cf wrapped in a list
+    """
+    if isinstance(cfs, list):
+        ncf = len(cfs)  # assume the input is a list containing multiple cf
+    else:
+        cfs = [cfs]     # wrap the single cf in a list
+        ncf = 1         # assume the input is a single cf
+    print('Got {} colume file object(s)'.format(ncf))
+        
+    f, a = plt.subplots(1, ncf, figsize=(6*ncf, 6))
+    
+    # If there is only one subplot (ncf == 1), treat `a` as a list for consistency
+    if ncf == 1:
+        a = [a]
+    
+    for i, cf in enumerate(cfs):
+        scatter = a[i].scatter(cf.omega, cf.dty, 
+                       c=np.log10(cf.sum_intensity), s=8, cmap='viridis')
+        cbar = plt.colorbar(scatter, ax=a[i])
+        cbar.set_label('Sum Intensity')  # Label for the colorbar
+        a[i].set_xlabel('Omega ($^{o}$)')
+        a[i].set_ylabel('dty ($\mu$m)')
+    
+    plt.tight_layout()
+    plt.show()
+    
+    
+def cf_remove_unmatched_peaks(cf_strong, cf_matched_all):
+    """
+    Remove unmatched peaks from the cf_strong so that grain sinograms are expected to be cleaner after re-assigning the cleaned cf_strong
+
+    Arguments:
+    cf_strong -- ImageD11 colume file, e.g. cf_4d = ds.get_cf_4d_from_disk() and then filter
+    cf_matched_all -- list of matched peaks for each of the grain, list of ImageD11.columnfile
+
+    Returns:
+    cf_clean -- cleaned cf_strong
+    """
+    cf_diff = cf_strong.copy()
+    for cf_matched in cf_matched_all:
+        print('cf_diff has {} peaks'.format(cf_diff.nrows))
+        cf_diff, _ = cf_set_difference(cf_diff, cf_matched, tol = 0.001)
+    
+    cf_clean, _ = cf_set_difference(cf_strong, cf_diff, tol = 0.001)
+    
+    return cf_clean
+    
+
+def cf_filter_for_grain(cf, grain_id = 0):
+    m = cf.grain_id == grain_id
+    cf_out = cf.copy()
+    cf_out.filter(m)   
+    print('Original {} peaks filtered to {} peaks'.format(cf.nrows, cf_out.nrows))
+    return cf_out

--- a/ImageD11/forward_model/forward_model.py
+++ b/ImageD11/forward_model/forward_model.py
@@ -309,19 +309,19 @@ def get_ds_max(pars):
     Calculate two-theta angle from ds and wavelength according to Bragg's law
 
     Arguments:
-    ds -- inverse of d-spacing for a given hkl family
-    wavelength -- [Angstrom]
+    pars    -- ImageD11 pars object
 
     Returns:
-    two-theta in degrees
-    """
-    Lsam2det, RotDet, dety0, detz0, dety00, detz00, pixelysize, pixelzsize, detysize, detzsize, \
-        BeamStopY, BeamStopZ, S, flip_lr_flag, flip_ud_flag, Energy = convert_pars2parameters(pars)
-    ttheta_max = np.arctan(  ((detysize*pixelysize/2)**2 + (detzsize*pixelzsize/2)**2)**(1/2) / Lsam2det  )   # two-teta maximum [radian]
+    ds_max  -- maximum ds spacing detectable on the detector [Anstrom^-1]
+    """    
+    
+    p = pars_conversion.convert_ImageD11pars2p(pars)
+    ttheta_max = np.arctan(  ((p['detysize']*p['pixelysize']/2)**2 + (p['detzsize']*p['pixelzsize']/2)**2)**(1/2) / p['Lsam2det']  )   # two-teta maximum [radian]
     theta_max = ttheta_max/2.0   # theta [radian]
     wavelength = econst / Energy
-    ds_max = 1.0/(wavelength/(2*np.sin(theta_max)))  # 1/d [Angstron^-1]
+    ds_max = 1.0/(p['wavelength']/(2*np.sin(theta_max)))  # 1/d [Angstron^-1]    
     print('Maximum two-theta angle = {}, ds_max = {} Angstrom^-1'.format(np.rad2deg(ttheta_max), ds_max))
+    
     return ds_max
 
 

--- a/ImageD11/forward_model/io.py
+++ b/ImageD11/forward_model/io.py
@@ -352,29 +352,30 @@ def write_xdmf(h5name, xdmf_filename = None, ctrl = 'recon_mlem', attributes = [
     
     # Write XDMF file
     with open(xdmf_filename, 'wt') as fileID:
-        fileID.write('<?xml version="1.0"?>\n')
-        fileID.write('<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd"[]>\n')
-        fileID.write('<Xdmf xmlns:xi="http://www.w3.org/2003/XInclude" Version="2.2">\n')
-        fileID.write(' <Domain>\n')
-        fileID.write('  <!-- *************** START OF GM3D *************** -->\n')
-        fileID.write('  <Grid Name="GM3D" GridType="Uniform">\n')
-        fileID.write(f'   <Topology TopologyType="3DCoRectMesh" Dimensions="{MeshDimensions[0]} {MeshDimensions[1]} {MeshDimensions[2]}"></Topology>\n')
-        fileID.write('    <Geometry Type="ORIGIN_DXDYDZ">\n')
-        fileID.write('     <!-- Origin  Z, Y, X -->\n')
-        fileID.write('     <DataItem Format="XML" Dimensions="3">0 0 0</DataItem>\n')
-        fileID.write('     <!-- DxDyDz (Spacing/Resolution) Z, Y, X -->\n')
-        fileID.write(f'     <DataItem Format="XML" Dimensions="3">{voxelsize[0]:.6f} {voxelsize[1]:.6f} {voxelsize[2]:.6f}</DataItem>\n')
-        fileID.write('    </Geometry>\n')
-        
-        for attr in attributes:
-            fileID.write(f'    <Attribute Name="{attr}" AttributeType="Scalar" Center="Cell">\n')
-            fileID.write(f'      <DataItem Format="HDF" Dimensions="{ScalarDimensions[0]} {ScalarDimensions[1]} {ScalarDimensions[2]} {ScalarDimensions[3]}" NumberType="Float" Precision="6" >{h5name}:/{attr}</DataItem>\n')
-            fileID.write('    </Attribute>\n')
-        
-        fileID.write('  </Grid>\n')
-        fileID.write('  <!-- *************** END OF GM3D *************** -->\n')
-        fileID.write(' </Domain>\n')
-        fileID.write('</Xdmf>\n')
+    fileID.write('<?xml version="1.0"?>\n')
+    fileID.write('<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd"[]>\n')
+    fileID.write('<Xdmf xmlns:xi="http://www.w3.org/2003/XInclude" Version="2.2">\n')
+    fileID.write(' <Domain>\n')
+    fileID.write('  <!-- *************** START OF GM3D *************** -->\n')
+    fileID.write('  <Grid Name="GM3D" GridType="Uniform">\n')
+    fileID.write('   <Topology TopologyType="3DCoRectMesh" Dimensions="{0} {1} {2}"></Topology>\n'.format(MeshDimensions[0], MeshDimensions[1], MeshDimensions[2]))
+    fileID.write('    <Geometry Type="ORIGIN_DXDYDZ">\n')
+    fileID.write('     <!-- Origin  Z, Y, X -->\n')
+    fileID.write('     <DataItem Format="XML" Dimensions="3">0 0 0</DataItem>\n')
+    fileID.write('     <!-- DxDyDz (Spacing/Resolution) Z, Y, X -->\n')
+    fileID.write('     <DataItem Format="XML" Dimensions="3">{0:.6f} {1:.6f} {2:.6f}</DataItem>\n'.format(voxelsize[0], voxelsize[1], voxelsize[2]))
+    fileID.write('    </Geometry>\n')
+    
+    for attr in attributes:
+        fileID.write('    <Attribute Name="{0}" AttributeType="Scalar" Center="Cell">\n'.format(attr))
+        fileID.write('      <DataItem Format="HDF" Dimensions="{0} {1} {2} {3}" NumberType="Float" Precision="6" >{4}:/{5}</DataItem>\n'.format(ScalarDimensions[0], ScalarDimensions[1], ScalarDimensions[2], ScalarDimensions[3], h5name, attr))
+        fileID.write('    </Attribute>\n')
+    
+    fileID.write('  </Grid>\n')
+    fileID.write('  <!-- *************** END OF GM3D *************** -->\n')
+    fileID.write(' </Domain>\n')
+    fileID.write('</Xdmf>\n')
+
     print('Done writing the xdmf file')
 
     

--- a/ImageD11/forward_model/io.py
+++ b/ImageD11/forward_model/io.py
@@ -1,0 +1,411 @@
+# io.py, a batch of function to read and write files in the following format
+# h5 files
+# edf images
+# tif images
+# xml (to be added)
+# write to dream3d and xdmf files
+# read motor positions
+# Haixing Fang, haixing.fang@esrf.fr
+# March 20, 2024
+
+import os
+import glob
+
+import numpy as np
+import fabio
+import matplotlib.pyplot as plt
+import h5py
+import matplotlib
+import ImageD11.columnfile
+import ImageD11.unitcell
+import ImageD11.transformer
+import xml.etree.ElementTree as ET
+import scipy.io
+from scipy import ndimage
+import tifffile as tiff
+from PIL import Image
+
+
+def read_images_from_h5(h5name, scan = '1.1', detector = None, StartIndex = None, EndIndex = None):
+    # read images from h5 file
+    # StartIndex starts from 0
+    # number of images = EndIndex - StartIndex
+    if detector is None:
+        detector = guess_camera_name(h5name, scan)
+    with h5py.File(h5name, 'r') as hin:
+        dataset = hin[scan]['measurement/'][detector]
+        print('data dimensions: {}'.format(dataset.shape))
+        if StartIndex is not None and EndIndex is not None:
+            if StartIndex < 0:
+                StartIndex = 0
+            if EndIndex > dataset.shape[0]:
+                EndIndex = dataset.shape[0]
+            imgs = dataset[StartIndex:EndIndex, :, :]
+        else:
+             imgs = dataset[()]
+    return imgs
+    
+    
+def read_tomo_from_hdf5(hdf5name, ctrl_name = '/entry0000/reconstruction/results/data', StartIndex = None, EndIndex = None, scale = (1.0,), diffrz_offset = None):
+    # read tomography volume from nabu reconstructed hdf5 file
+    # usually the file 
+    with h5py.File(hdf5name, 'r') as hin:
+        dataset = hin[ctrl_name]
+        print('data dimensions: {}'.format(dataset.shape))
+        if StartIndex is not None and EndIndex is not None:
+            if StartIndex < 0:
+                StartIndex = 0
+            if EndIndex > dataset.shape[0]:
+                EndIndex = dataset.shape[0]
+            pct_vol = dataset[StartIndex:EndIndex, :, :]
+        else:
+            pct_vol = dataset[()]
+    if scale[0] != 1.0:
+        print("I am going to make a scaling on pct_vol because scaling = {}.".format(scale))
+        pct_vol = im_scaling(pct_vol, scale)
+    
+    from scipy import ndimage
+
+    if diffrz_offset is not None:
+        print("I am going to make a rotation about Z axis for pct_vol because diffrz_offset = {:.4f} degrees.".format(diffrz_offset))
+        for i in range(pct_vol.shape[0]):
+            pct_vol[i, :, :] = ndimage.rotate(pct_vol[i, :, :], diffrz_offset, reshape=False, mode='nearest', cval=0)
+        
+    return pct_vol
+
+
+def im_fabio(data):
+    assert isinstance(data, np.ndarray), "Dataset is not a NumPy array."
+    if data.ndim < 3:
+        obj = fabio.edfimage.EdfImage(data)
+        return obj
+
+
+def write_edf(data, edfname):
+    obj = im_fabio(data)
+    if not edfname.endswith('.edf'):
+        edfname = edfname + '.edf'
+    obj.write(edfname)
+
+
+def im_scaling(im_in, scale = (0.55/1.47,)):
+    # example input for scaling: 0.61/1.63 (20x/7.5x) before 14/11/2023 and 0.55/1.47 (20x/7.5x) since 14/11/2023
+    if len(scale) != len(im_in.shape):
+        scale = [scale[0]] * len(im_in.shape)
+        scale = tuple(scale)
+        print('Scaling the image data with a factor of {}'.format(scale))
+    im_out = ndimage.zoom(im_in, scale, order=0)
+    return im_out
+   
+
+def read_motor_posisitions_from_h5(h5name, scan = '1.1'):
+    # read all the motor positions from h5 file
+    with h5py.File(h5name, 'r') as hin:
+        MotorPos = {}
+        for motor in hin[scan]['instrument/positioners'].keys():
+            MotorPos[motor] = hin[scan]['instrument/positioners'][motor][()]
+    return MotorPos
+
+
+def convert_h52_tif(h5name, save_path, prefix_name = 'proj', save_stack = False, ctrl_name = '1.1/measurement/marana3', data_format = 'uint16'):
+    with h5py.File(h5name, 'r') as hin:
+        dataset = hin[ctrl_name][:]
+        print("Dataset shape:", dataset.shape)
+        if data_format == 'uint16':
+            print('Converting to uint16 format ...')
+            normalized_data = (65535 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint16)
+        elif data_format == 'uint8':
+            print('Converting to uint8 format ...')
+            normalized_data = (255 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint8)
+        else:
+            print('Converting to uint16 format ...')
+            normalized_data = (65535 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint16)
+    
+    if not os.path.exists(save_path):
+        os.mkdir(save_path)
+    
+    print("Writing tif images to {}".format(save_path))
+    if save_stack:
+        # save the entire 3D dataset as a single multi-page TIFF image
+        images = [Image.fromarray(normalized_data[i]) for i in range(normalized_data.shape[0])]
+        filename = os.path.join(save_path, prefix_name + "_stack.tif")
+        images[0].save(filename, save_all=True, append_images=images[1:])
+    else:
+        # Save each slice of the 3D dataset as an individual TIFF image
+        for i in range(normalized_data.shape[0]):
+            image = Image.fromarray(normalized_data[i])
+            filename = os.path.join(save_path, prefix_name + f"{i:04d}" + ".tif")
+            image.save(filename)
+    print('Done')
+    
+    
+    print("Writing TIFF images to {}".format(save_path))
+    if save_stack:
+        # Save the entire 3D dataset as a single multi-page TIFF image
+        filename = os.path.join(save_path, prefix_name + "_stack.tif")
+        tiff.imwrite(filename, normalized_data, photometric='minisblack')
+    else:
+        # Save each slice of the 3D dataset as an individual TIFF image
+        for i in range(normalized_data.shape[0]):
+            filename = os.path.join(save_path, f"{prefix_name}_{i:04d}.tif")
+            tiff.imwrite(filename, normalized_data[i], photometric='minisblack')
+
+
+
+def convert_to_list(input_data):
+    if isinstance(input_data, str):
+        return [input_data]
+    return input_data
+    
+
+def get_scan_h5(experiment, scan_type = ['dct',]):
+    # get all the samples with a particular scan type
+    # scan_type = 'dct', 'pct', 'ff', 'topotomo'
+    scan_type = convert_to_list(scan_type)
+    subfolders = glob.glob(os.path.join('/data/visitor/',experiment,'id11','*'))
+    for subfolder in subfolders:
+        sub_folders = glob.glob(os.path.join(subfolder,'*'))
+        for sub_folder in sub_folders:
+            if 'RAW_DATA' not in os.path.basename(sub_folder):
+                continue
+            else:
+                raw_path = sub_folder
+    
+    print('...................................... Experiment {} ............................'.format(experiment))
+    print('Raw data path: ', raw_path)
+    
+    # find relevant h5 files
+    samples = {}
+    skips = 'align', 'sample','beam', 'set_up', 'setup', 'test', 'optics', 'slits', 'CeO2', 'ceO2', 'gpfs', 'check_distance', 'calib', 'temp', 'change_energy', 'energy', 'clean'
+    for item in sorted( os.listdir( raw_path ) ):
+        folder = os.path.join( raw_path, item )
+        if not os.path.isdir( folder ) or folder in skips:
+            continue
+        datasets = os.listdir( folder )
+        for dset in datasets:
+            for skip in skips:
+                if dset.find(skip)>=0:
+                    # print("# Skipping", dset, 'because', skip)
+                    break
+            else:
+                scanfolder = os.path.join( folder, dset )
+                # print('scanfolder: ', scanfolder)
+                if os.path.isdir(scanfolder):
+                    if len(scan_type)==1:
+                        scans = glob.glob(scanfolder + '/*' + scan_type[0] + '*.h5')
+                    elif len(scan_type)>1:
+                        scans = []
+                        for scan_type_sub in scan_type:
+                            scan = glob.glob(scanfolder + '/*' + scan_type_sub + '*.h5')
+                            scans.append(scan)
+                    if any(sublist for sublist in scans if sublist):
+                        for scan_type_sub in scan_type:
+                            if dset.find(scan_type_sub)>=0:
+                                 # print('# TODO', item, dset, len(scans))
+                                if item in samples:
+                                    samples[item].append( dset )
+                                else:
+                                    samples[item] = [dset,]
+
+    # pprint.pprint(samples)
+    print('Found {} samples with scan type of {}'.format(len(samples), scan_type))
+    print('Samples of {} are as follows:'.format(scan_type))
+    for sample in samples:
+        print(sample)
+    return samples, raw_path
+
+   
+def read_matlab_file(file_path):
+    # Load the .mat file
+    if is_mat_v7p3(file_path):
+        mat_data = read_h5_struct(file_path)
+    else:
+        mat_data = scipy.io.loadmat(file_path)
+    return mat_data
+    
+    
+def is_mat_v7p3(file_path):
+    with open(file_path, 'rb') as f:
+        header = f.read(19)
+        print(header)
+        # Check if the file starts with HDF5 magic bytes
+        if header == b'MATLAB 7.3 MAT-file':
+            return True
+        else:
+            return False
+
+        
+def read_h5_file(file_path):
+    data_dict = {}
+
+    def visit_group(name, obj):
+        keys = name.split('/')  # Split by group level
+        current = data_dict
+
+        # Traverse to the correct location in the dictionary for nested groups
+        for key in keys[:-1]:
+            current = current.setdefault(key, {})
+
+        # Add dataset or group
+        if isinstance(obj, h5py.Dataset):
+            current[keys[-1]] = obj[()]
+        elif isinstance(obj, h5py.Group):
+            current[keys[-1]] = {}
+
+    with h5py.File(file_path, 'r') as file:
+        file.visititems(visit_group)
+    
+    return data_dict
+
+
+def read_h5_struct(file_path):
+    '''
+    suitable for reading matlab file saved as a struct, e.g. parameters.mat
+    '''
+    data_dict = {}
+
+    def load_h5_group(obj, data_dict):
+        for key, item in obj.items():
+            if isinstance(item, h5py.Group):
+                # Initialize a dictionary for this group
+                data_dict[key] = {}
+                load_h5_group(item, data_dict[key])  # Recursively load sub-groups
+
+            elif isinstance(item, h5py.Dataset):
+                # Initialize an entry in the dictionary for datasets
+                if item.dtype.kind == 'S':  # ASCII string
+                    data_dict[key] = item.asstr()[()]
+                elif item.dtype.kind == 'O':  # UTF-8 string or other objects
+                    if not item.name == '/parameters/cryst/symm':   # not able to read multiple p.cryst.symm yet
+                        data_dict[key] = []
+                        #print(item.shape[0], item.name)
+                        for i in range(item.shape[0]):
+                            entry = item[i][0]
+                            referenced_item = obj[entry][()]
+                            # print(referenced_item.dtype)
+                            if isinstance(entry, h5py.Group):
+                                ref_dict = {}
+                                load_h5_group(entry, ref_dict)
+                                data_dict[key].append(ref_dict)
+                            else:
+                                if referenced_item.dtype == 'u2':  # Unsigned integer                                   
+                                    # data_content = h5py.File(file_path, 'r')[entry][()]
+                                    data_content = obj[entry][()]
+                                    ascii_codes = data_content.flatten().astype(int)
+                                    char_list = [chr(code) for code in ascii_codes]
+                                    merged_string = ''.join(char_list)
+                                    data_dict[key].append(merged_string)
+                                else:
+                                    # data_content = h5py.File(file_path, 'r')[entry][()]
+                                    data_content = obj[entry][()]
+                                    data_dict[key].append(data_content)
+                    else:
+                        print('NOTE: not able to read multiple parameters.cryst.symm yet!')
+                elif item.dtype.kind == 'u':  # Unsigned integer (ASCII codes)
+                    data_content = item[:]  # Read all data
+                    ascii_codes = data_content.flatten().astype(int)
+                    char_list = [chr(code) for code in ascii_codes]
+                    merged_string = ''.join(char_list)
+                    data_dict[key] = merged_string
+                else:
+                    data_dict[key] = item[()]
+
+    with h5py.File(file_path, 'r') as file:
+        load_h5_group(file, data_dict)
+    
+    return data_dict
+
+
+def write_pct_vol(h5name, data, ctrl_name = '/entry0000/reconstruction/results/data'):
+    if not ctrl_name.startswith('/'):
+        ctrl_name = '/' + ctrl_name
+    if not h5name.endswith(('.h5', '.hdf5')):
+        h5name = h5name + '.h5'
+    with h5py.File(h5name, 'w') as f:
+        f.create_dataset(ctrl_name, data = data)
+        print('Finished writing data with a dimension of: {}'.format(data.shape))
+
+
+def write_xdmf(h5name, xdmf_filename = None, ctrl = 'recon_mlem', attributes = ['recon_mlem',], voxelsize = [0.0002, 0.0002, 0.0002]):
+    # write .xdmf file for visualing 3D/4D data with ParaView
+    if xdmf_filename == None:
+        xdmf_filename = h5name.replace('.h5','.xdmf')
+    print('Writing {}'.format(xdmf_filename))
+    with h5py.File(h5name, 'r') as hin:
+        recon_3d = hin[ctrl][()]
+    dim = recon_3d.shape
+    dim4 = list(dim[:3])
+    dim4.append(1)
+    
+    # MeshDimensions
+    MeshDimensions = (dim[0] + 1, dim[1] + 1, dim[2] + 1)
+    MeshDimensionsStr = 'Dimensions="%d %d %d"' % (MeshDimensions[0], MeshDimensions[1], MeshDimensions[2])
+
+    # ScalarDimensions
+    ScalarDimensions = dim4
+    ScalarDimensionsStr = 'Dimensions="%d %d %d %d"' % (ScalarDimensions[0], ScalarDimensions[1], ScalarDimensions[2], ScalarDimensions[3])
+
+    # VectorDimensions
+    VectorDimensions = list(dim[:3])
+    VectorDimensions.append(3)
+    VectorDimensionsStr = 'Dimensions="%d %d %d %d"' % (VectorDimensions[0], VectorDimensions[1], VectorDimensions[2], VectorDimensions[3])
+    
+    # Write XDMF file
+    with open(xdmf_filename, 'wt') as fileID:
+        fileID.write('<?xml version="1.0"?>\n')
+        fileID.write('<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd"[]>\n')
+        fileID.write('<Xdmf xmlns:xi="http://www.w3.org/2003/XInclude" Version="2.2">\n')
+        fileID.write(' <Domain>\n')
+        fileID.write('  <!-- *************** START OF GM3D *************** -->\n')
+        fileID.write('  <Grid Name="GM3D" GridType="Uniform">\n')
+        fileID.write(f'   <Topology TopologyType="3DCoRectMesh" Dimensions="{MeshDimensions[0]} {MeshDimensions[1]} {MeshDimensions[2]}"></Topology>\n')
+        fileID.write('    <Geometry Type="ORIGIN_DXDYDZ">\n')
+        fileID.write('     <!-- Origin  Z, Y, X -->\n')
+        fileID.write('     <DataItem Format="XML" Dimensions="3">0 0 0</DataItem>\n')
+        fileID.write('     <!-- DxDyDz (Spacing/Resolution) Z, Y, X -->\n')
+        fileID.write(f'     <DataItem Format="XML" Dimensions="3">{voxelsize[0]:.6f} {voxelsize[1]:.6f} {voxelsize[2]:.6f}</DataItem>\n')
+        fileID.write('    </Geometry>\n')
+        
+        for attr in attributes:
+            fileID.write(f'    <Attribute Name="{attr}" AttributeType="Scalar" Center="Cell">\n')
+            fileID.write(f'      <DataItem Format="HDF" Dimensions="{ScalarDimensions[0]} {ScalarDimensions[1]} {ScalarDimensions[2]} {ScalarDimensions[3]}" NumberType="Float" Precision="6" >{h5name}:/{attr}</DataItem>\n')
+            fileID.write('    </Attribute>\n')
+        
+        fileID.write('  </Grid>\n')
+        fileID.write('  <!-- *************** END OF GM3D *************** -->\n')
+        fileID.write(' </Domain>\n')
+        fileID.write('</Xdmf>\n')
+    print('Done writing the xdmf file')
+
+    
+def camera_names_ID11():
+    return ['marana3', 'marana1', 'marana2', 'marana', 'frelon3', 'frelon6', 'eiger', 'basler_eh32']
+
+
+def guess_camera_name(h5name, scan = '1.1'):
+    scan = convert_to_list(scan)
+    camera_list = camera_names_ID11()
+    camera_name = None
+    with h5py.File(h5name, 'r') as hin:
+        for key in hin[scan[0]]['measurement'].keys():
+            if key in camera_list:
+                print('I got this camera name: {}'.format(key))
+                camera_name = key
+    return camera_name
+
+
+def delete_file_if_exists(filepath):
+    if os.path.exists(filepath):
+        os.remove(filepath)
+        print('{} has been deleted.'.format(filepath))
+    else:
+        print('{} does not exist.'.format(filepath))
+
+
+def delete_group_from_h5(h5name, group_name):
+    with h5py.File(h5name, 'a') as h5f:  # Use 'a' mode to open for read/write access
+        if group_name in h5f:
+            del h5f[group_name]  # Delete the existing group
+            return True
+        else:
+            return False

--- a/ImageD11/forward_model/io.py
+++ b/ImageD11/forward_model/io.py
@@ -352,29 +352,29 @@ def write_xdmf(h5name, xdmf_filename = None, ctrl = 'recon_mlem', attributes = [
     
     # Write XDMF file
     with open(xdmf_filename, 'wt') as fileID:
-    fileID.write('<?xml version="1.0"?>\n')
-    fileID.write('<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd"[]>\n')
-    fileID.write('<Xdmf xmlns:xi="http://www.w3.org/2003/XInclude" Version="2.2">\n')
-    fileID.write(' <Domain>\n')
-    fileID.write('  <!-- *************** START OF GM3D *************** -->\n')
-    fileID.write('  <Grid Name="GM3D" GridType="Uniform">\n')
-    fileID.write('   <Topology TopologyType="3DCoRectMesh" Dimensions="{0} {1} {2}"></Topology>\n'.format(MeshDimensions[0], MeshDimensions[1], MeshDimensions[2]))
-    fileID.write('    <Geometry Type="ORIGIN_DXDYDZ">\n')
-    fileID.write('     <!-- Origin  Z, Y, X -->\n')
-    fileID.write('     <DataItem Format="XML" Dimensions="3">0 0 0</DataItem>\n')
-    fileID.write('     <!-- DxDyDz (Spacing/Resolution) Z, Y, X -->\n')
-    fileID.write('     <DataItem Format="XML" Dimensions="3">{0:.6f} {1:.6f} {2:.6f}</DataItem>\n'.format(voxelsize[0], voxelsize[1], voxelsize[2]))
-    fileID.write('    </Geometry>\n')
-    
-    for attr in attributes:
-        fileID.write('    <Attribute Name="{0}" AttributeType="Scalar" Center="Cell">\n'.format(attr))
-        fileID.write('      <DataItem Format="HDF" Dimensions="{0} {1} {2} {3}" NumberType="Float" Precision="6" >{4}:/{5}</DataItem>\n'.format(ScalarDimensions[0], ScalarDimensions[1], ScalarDimensions[2], ScalarDimensions[3], h5name, attr))
-        fileID.write('    </Attribute>\n')
-    
-    fileID.write('  </Grid>\n')
-    fileID.write('  <!-- *************** END OF GM3D *************** -->\n')
-    fileID.write(' </Domain>\n')
-    fileID.write('</Xdmf>\n')
+        fileID.write('<?xml version="1.0"?>\n')
+        fileID.write('<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd"[]>\n')
+        fileID.write('<Xdmf xmlns:xi="http://www.w3.org/2003/XInclude" Version="2.2">\n')
+        fileID.write(' <Domain>\n')
+        fileID.write('  <!-- *************** START OF GM3D *************** -->\n')
+        fileID.write('  <Grid Name="GM3D" GridType="Uniform">\n')
+        fileID.write('   <Topology TopologyType="3DCoRectMesh" Dimensions="{0} {1} {2}"></Topology>\n'.format(MeshDimensions[0], MeshDimensions[1], MeshDimensions[2]))
+        fileID.write('    <Geometry Type="ORIGIN_DXDYDZ">\n')
+        fileID.write('     <!-- Origin  Z, Y, X -->\n')
+        fileID.write('     <DataItem Format="XML" Dimensions="3">0 0 0</DataItem>\n')
+        fileID.write('     <!-- DxDyDz (Spacing/Resolution) Z, Y, X -->\n')
+        fileID.write('     <DataItem Format="XML" Dimensions="3">{0:.6f} {1:.6f} {2:.6f}</DataItem>\n'.format(voxelsize[0], voxelsize[1], voxelsize[2]))
+        fileID.write('    </Geometry>\n')
+
+        for attr in attributes:
+            fileID.write('    <Attribute Name="{0}" AttributeType="Scalar" Center="Cell">\n'.format(attr))
+            fileID.write('      <DataItem Format="HDF" Dimensions="{0} {1} {2} {3}" NumberType="Float" Precision="6" >{4}:/{5}</DataItem>\n'.format(ScalarDimensions[0], ScalarDimensions[1], ScalarDimensions[2], ScalarDimensions[3], h5name, attr))
+            fileID.write('    </Attribute>\n')
+
+        fileID.write('  </Grid>\n')
+        fileID.write('  <!-- *************** END OF GM3D *************** -->\n')
+        fileID.write(' </Domain>\n')
+        fileID.write('</Xdmf>\n')
 
     print('Done writing the xdmf file')
 

--- a/ImageD11/forward_model/io.py
+++ b/ImageD11/forward_model/io.py
@@ -134,7 +134,7 @@ def convert_h52_tif(h5name, save_path, prefix_name = 'proj', save_stack = False,
         # Save each slice of the 3D dataset as an individual TIFF image
         for i in range(normalized_data.shape[0]):
             image = Image.fromarray(normalized_data[i])
-            filename = os.path.join(save_path, prefix_name + f"{i:04d}" + ".tif")
+            filename = os.path.join(save_path, "{}{:04d}.tif".format(prefix_name, i))
             image.save(filename)
     print('Done')
     
@@ -147,7 +147,7 @@ def convert_h52_tif(h5name, save_path, prefix_name = 'proj', save_stack = False,
     else:
         # Save each slice of the 3D dataset as an individual TIFF image
         for i in range(normalized_data.shape[0]):
-            filename = os.path.join(save_path, f"{prefix_name}_{i:04d}.tif")
+            filename = os.path.join(save_path, "{}{:04d}.tif".format(prefix_name, i))
             tiff.imwrite(filename, normalized_data[i], photometric='minisblack')
 
 

--- a/ImageD11/forward_model/ori_converter.py
+++ b/ImageD11/forward_model/ori_converter.py
@@ -1,0 +1,402 @@
+# it is adapted from hyperspherical-coverings/quat_utils.py and github transforms3d/euler.py and quaternions.py
+# cross verified with GrainRecon_v2 matlab functions
+# Haixing Fang, haixing.fang@esrf.fr
+# Oct 23, 2023
+import numpy as np
+import math
+
+# axis sequences for Euler angles
+_NEXT_AXIS = [1, 2, 0, 1]
+
+# map axes strings to/from tuples of inner axis, parity, repetition, frame
+_AXES2TUPLE = {
+    'sxyz': (0, 0, 0, 0), 'sxyx': (0, 0, 1, 0), 'sxzy': (0, 1, 0, 0),
+    'sxzx': (0, 1, 1, 0), 'syzx': (1, 0, 0, 0), 'syzy': (1, 0, 1, 0),
+    'syxz': (1, 1, 0, 0), 'syxy': (1, 1, 1, 0), 'szxy': (2, 0, 0, 0),
+    'szxz': (2, 0, 1, 0), 'szyx': (2, 1, 0, 0), 'szyz': (2, 1, 1, 0),
+    'rzyx': (0, 0, 0, 1), 'rxyx': (0, 0, 1, 1), 'ryzx': (0, 1, 0, 1),
+    'rxzx': (0, 1, 1, 1), 'rxzy': (1, 0, 0, 1), 'ryzy': (1, 0, 1, 1),
+    'rzxy': (1, 1, 0, 1), 'ryxy': (1, 1, 1, 1), 'ryxz': (2, 0, 0, 1),
+    'rzxz': (2, 0, 1, 1), 'rxyz': (2, 1, 0, 1), 'rzyz': (2, 1, 1, 1)}
+
+_TUPLE2AXES = dict((v, k) for k, v in _AXES2TUPLE.items())
+
+# For testing whether a number is close to zero
+_EPS4 = np.finfo(float).eps * 4.0
+
+_FLOAT_EPS = np.finfo(np.float64).eps
+
+
+def flip_up(q):
+    if q[0] < 0:
+        q = -q
+    return q
+
+
+def multiply(r, a):
+
+    b0 = r[0] * a[0] - r[1] * a[1] - r[2] * a[2] - r[3] * a[3]
+    b1 = r[0] * a[1] + r[1] * a[0] + r[2] * a[3] - r[3] * a[2]
+    b2 = r[0] * a[2] - r[1] * a[3] + r[2] * a[0] + r[3] * a[1]
+    b3 = r[0] * a[3] + r[1] * a[2] - r[2] * a[1] + r[3] * a[0]
+    return flip_up(np.array([b0, b1, b2, b3]))
+
+
+def random_quaternions(n):
+
+    x0 = np.random.uniform(0, 1, n)
+    x1 = np.random.uniform(0, 2 * np.pi, n)
+    x2 = np.random.uniform(0, 2 * np.pi, n)
+
+    r1, r2 = np.sqrt(1 - x0), np.sqrt(x0)
+    s1, c1 = np.sin(x1), np.cos(x1)
+    s2, c2 = np.sin(x2), np.cos(x2)
+
+    return np.array([s1 * r1, c1 * r1, s2 * r2, c2 * r2]).T
+
+
+def multiply_first_component(r, a):
+    return r[0] * a[0] - r[1] * a[1] - r[2] * a[2] - r[3] * a[3]
+
+
+def rotate_into_fundamental_zone(q, generators):
+
+    index = np.argmax([abs(multiply_first_component(q, g)) for g in generators])
+    return multiply(q, generators[index])
+
+
+def map_points_out(basis_points, basis_weights, superset, subset, map_indices):
+
+    assert( len(map_indices) * len(subset) == len(superset) )
+
+    superset = np.array(superset)
+    subset = np.array(subset)
+
+    mapped_points = []
+    mapped_weights = []
+    for g in superset[map_indices]:
+        for b, w in zip(basis_points, basis_weights):
+            r = multiply(b, g)
+            r = rotate_into_fundamental_zone(r, subset)
+            mapped_points += [r]
+            mapped_weights += [w]
+
+    return np.array(mapped_points), np.array(mapped_weights)
+
+
+def quat2u(q):
+
+    a, b, c, d = q
+
+    u0 = a*a + b*b - c*c - d*d
+    u1 = 2*b*c - 2*a*d
+    u2 = 2*b*d + 2*a*c
+
+    u3 = 2*b*c + 2*a*d
+    u4 = a*a - b*b + c*c - d*d
+    u5 = 2*c*d - 2*a*b
+
+    u6 = 2*b*d - 2*a*c
+    u7 = 2*c*d + 2*a*b
+    u8 = a*a - b*b - c*c + d*d
+
+    return np.array([[u0, u1, u2], [u3, u4, u5], [u6, u7, u8]])
+
+
+def rod2quat(r):
+
+	s = 1 / np.sqrt(1 + np.linalg.norm(r)**2)
+	return np.array([s, s * r[0], s * r[1], s * r[2]])
+
+def quat2rod(q):
+    
+    q = np.asarray(q)
+    quatmod = np.sqrt( np.sum(q*q) )
+    
+    qinn = q/quatmod # normalized quaternion
+    thalf = np.arccos(qinn[0])
+    R = np.zeros(3,)
+    if thalf != 0:
+        R = qinn[1:4] / np.cos(thalf)
+    
+    return R
+
+
+def u2quat(u):
+    
+    r11, r12, r13 = u[0]
+    r21, r22, r23 = u[1]
+    r31, r32, r33 = u[2]
+
+    q0 = (1.0 + r11 + r22 + r33) / 4.0
+    q1 = (1.0 + r11 - r22 - r33) / 4.0
+    q2 = (1.0 - r11 + r22 - r33) / 4.0
+    q3 = (1.0 - r11 - r22 + r33) / 4.0
+    q = np.array([q0, q1, q2, q3])
+    q = np.sqrt(np.maximum(0, q))
+
+    i = np.argmax(q)
+    if i == 0:
+        q[1] *= np.sign(r32 - r23)
+        q[2] *= np.sign(r13 - r31)
+        q[3] *= np.sign(r21 - r12)
+
+    elif i == 1:
+        q[0] *= np.sign(r32 - r23)
+        q[2] *= np.sign(r21 + r12)
+        q[3] *= np.sign(r13 + r31)
+
+    elif i == 2:
+        q[0] *= np.sign(r13 - r31)
+        q[1] *= np.sign(r21 + r12)
+        q[3] *= np.sign(r32 + r23)
+
+    elif i == 3:
+        q[0] *= np.sign(r21 - r12)
+        q[1] *= np.sign(r31 + r13)
+        q[2] *= np.sign(r32 + r23)
+
+    return q / np.linalg.norm(q)
+
+
+def quat2euler(q):
+    q = np.asarray(q)
+    u = quat2u(q)
+    return u2euler(u,'rzxz')
+#     the following tested to be not correct
+#     euler angle conventions are taken from EMSoft
+#     qq = q**2
+#     q03 = qq[0] + qq[3]
+#     q12 = qq[1] + qq[2]
+#     chi = np.sqrt(q03 * q12)
+#     if chi == 0:
+#         if q12 == 0:
+#             phi = 0
+#             phi2 = 0
+#             phi1 = np.arctan2(-2 * q[0] * q[3], qq[0] - qq[3])
+#         else:
+#             phi = np.pi
+#             phi2 = 0
+#             phi1 = np.arctan2(2 * q[1] * q[2], qq[1] - qq[2])
+#     else:
+#         phi = np.arctan2(2 * chi, q03 - q12)
+#         phi1 = np.arctan2((-q[0] * q[2] + q[1] * q[3]) / chi, (-q[0] * q[1] - q[2] * q[3]) / chi)
+#         phi2 = np.arctan2((+q[0] * q[2] + q[1] * q[3]) / chi, (-q[0] * q[1] + q[2] * q[3]) / chi)
+
+#     res = np.array([phi1, phi, phi2]) % (2 * np.pi)
+#     res[1] %= np.pi
+#     return res
+
+
+#euler angle conventions are taken from EMSoft
+def euler2quat(e):
+
+    ee = np.array(e) / 2
+    cphi = np.cos(ee[1])
+    sphi = np.sin(ee[1])
+    cm = np.cos(ee[0] - ee[2])
+    sm = np.sin(ee[0] - ee[2])
+    cp = np.cos(ee[0] + ee[2])
+    sp = np.sin(ee[0] + ee[2])
+
+    res = np.array([cphi * cp, -sphi * cm, -sphi * sm, -cphi * sp])
+    return flip_up(res)
+
+def quat2axangle(quat, identity_thresh=None):
+    ''' Convert quaternion to rotation of angle around axis
+
+    Parameters
+    ----------
+    quat : 4 element sequence
+       w, x, y, z forming quaternion.
+    identity_thresh : None or scalar, optional
+       Threshold below which the norm of the vector part of the quaternion (x,
+       y, z) is deemed to be 0, leading to the identity rotation.  None (the
+       default) leads to a threshold estimated based on the precision of the
+       input.
+
+    Returns
+    -------
+    theta : scalar
+       angle of rotation.
+    vector : array shape (3,)
+       axis around which rotation occurs.
+
+    Examples
+    --------
+    >>> vec, theta = quat2axangle([0, 1, 0, 0])
+    >>> vec
+    array([1., 0., 0.])
+    >>> np.allclose(theta, np.pi)
+    True
+
+    If this is an identity rotation, we return a zero angle and an arbitrary
+    vector:
+
+    >>> quat2axangle([1, 0, 0, 0])
+    (array([1., 0., 0.]), 0.0)
+
+    If any of the quaternion values are not finite, we return a NaN in the
+    angle, and an arbitrary vector:
+
+    >>> quat2axangle([1, np.inf, 0, 0])
+    (array([1., 0., 0.]), nan)
+
+    Notes
+    -----
+    A quaternion for which x, y, z are all equal to 0, is an identity rotation.
+    In this case we return a 0 angle and an arbitrary vector, here [1, 0, 0].
+
+    The algorithm allows for quaternions that have not been normalized.
+    '''
+    quat = np.asarray(quat)
+    Nq = np.sum(quat ** 2)
+    if not np.isfinite(Nq):
+        return np.array([1.0, 0, 0]), float('nan')
+    if identity_thresh is None:
+        try:
+            identity_thresh = np.finfo(Nq.type).eps * 3
+        except (AttributeError, ValueError): # Not a numpy type or not float
+            identity_thresh = _FLOAT_EPS * 3
+    if Nq < _FLOAT_EPS ** 2:  # Results unreliable after normalization
+        return np.array([1.0, 0, 0]), 0.0
+    if Nq != 1:  # Normalize if not normalized
+        s = math.sqrt(Nq)
+        quat = quat / s
+    xyz = quat[1:]
+    len2 = np.sum(xyz ** 2)
+    if len2 < identity_thresh ** 2:
+        # if vec is nearly 0,0,0, this is an identity rotation
+        return np.array([1.0, 0, 0]), 0.0
+    # Make sure w is not slightly above 1 or below -1
+    theta = 2 * math.acos(max(min(quat[0], 1), -1))
+    return  xyz / math.sqrt(len2), theta
+
+
+def axangle2u(axis, angle, is_normalized=False):
+    ''' Rotation matrix for rotation angle `angle` around `axis`
+
+    Parameters
+    ----------
+    axis : 3 element sequence
+       vector specifying axis for rotation.
+    angle : scalar
+       angle of rotation in radians.
+    is_normalized : bool, optional
+       True if `axis` is already normalized (has norm of 1).  Default False.
+
+    Returns
+    -------
+    mat : array shape (3,3)
+       rotation matrix for specified rotation
+
+    Notes
+    -----
+    From: http://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle
+    '''
+    x, y, z = axis
+    if not is_normalized:
+        n = math.sqrt(x*x + y*y + z*z)
+        x = x/n
+        y = y/n
+        z = z/n
+    c = math.cos(angle); s = math.sin(angle); C = 1-c
+    xs = x*s;   ys = y*s;   zs = z*s
+    xC = x*C;   yC = y*C;   zC = z*C
+    xyC = x*yC; yzC = y*zC; zxC = z*xC
+    return np.array([
+            [ x*xC+c,   xyC-zs,   zxC+ys ],
+            [ xyC+zs,   y*yC+c,   yzC-xs ],
+            [ zxC-ys,   yzC+xs,   z*zC+c ]])
+
+def euler2u(e):
+    # U matrix from Euler angles phi1, PHI, phi2 in radians.
+    # INPUT: phi, PHI, and phi2 in radians
+    # OUTPUT [U11 U12 U13; U21 U22 U23; U31 U32 U33]
+    phi1 = e[0]
+    PHI  = e[1]
+    phi2 = e[2]
+    U11 =  np.cos(phi1)*np.cos(phi2)-np.sin(phi1)*np.sin(phi2)*np.cos(PHI);
+    U21 =  np.sin(phi1)*np.cos(phi2)+np.cos(phi1)*np.sin(phi2)*np.cos(PHI);
+    U31 =  np.sin(phi2)*np.sin(PHI);
+    U12 =  -np.cos(phi1)*np.sin(phi2)-np.sin(phi1)*np.cos(phi2)*np.cos(PHI);
+    U22 =  -np.sin(phi1)*np.sin(phi2)+np.cos(phi1)*np.cos(phi2)*np.cos(PHI);
+    U32 =  np.cos(phi2)*np.sin(PHI);
+    U13 =  np.sin(phi1)*np.sin(PHI);   
+    U23 =  -np.cos(phi1)*np.sin(PHI);
+    U33 =  np.cos(PHI);
+    U = np.array([[U11, U12, U13],
+         [U21, U22, U23],
+         [U31, U32, U33]]);
+    return U
+
+
+def u2euler(mat, axes='rzxz'):
+    # github transforms3d/euler.py
+    # by default using Bunge convention
+    """Return Euler angles from rotation matrix for specified axis sequence.
+
+    Note that many Euler angle triplets can describe one matrix.
+
+    Parameters
+    ----------
+    mat : array-like shape (3, 3) or (4, 4)
+        Rotation matrix or affine.
+    axes : str, optional
+        Axis specification; one of 24 axis sequences as string or encoded
+        tuple - e.g. ``sxyz`` (the default).
+
+    Returns
+    -------
+    ai : float
+        First rotation angle (according to `axes`).
+    aj : float
+        Second rotation angle (according to `axes`).
+    ak : float
+        Third rotation angle (according to `axes`).
+
+    Examples
+    --------
+    >>> R0 = euler2mat(1, 2, 3, 'syxz')
+    >>> al, be, ga = mat2euler(R0, 'syxz')
+    >>> R1 = euler2mat(al, be, ga, 'syxz')
+    >>> np.allclose(R0, R1)
+    True
+    """
+    try:
+        firstaxis, parity, repetition, frame = _AXES2TUPLE[axes.lower()]
+    except (AttributeError, KeyError):
+        _TUPLE2AXES[axes]  # validation
+        firstaxis, parity, repetition, frame = axes
+
+    i = firstaxis
+    j = _NEXT_AXIS[i+parity]
+    k = _NEXT_AXIS[i-parity+1]
+
+    M = np.array(mat, dtype=np.float64, copy=False)[:3, :3]
+    if repetition:
+        sy = math.sqrt(M[i, j]*M[i, j] + M[i, k]*M[i, k])
+        if sy > _EPS4:
+            ax = math.atan2( M[i, j],  M[i, k])
+            ay = math.atan2( sy,       M[i, i])
+            az = math.atan2( M[j, i], -M[k, i])
+        else:
+            ax = math.atan2(-M[j, k],  M[j, j])
+            ay = math.atan2( sy,       M[i, i])
+            az = 0.0
+    else:
+        cy = math.sqrt(M[i, i]*M[i, i] + M[j, i]*M[j, i])
+        if cy > _EPS4:
+            ax = math.atan2( M[k, j],  M[k, k])
+            ay = math.atan2(-M[k, i],  cy)
+            az = math.atan2( M[j, i],  M[i, i])
+        else:
+            ax = math.atan2(-M[j, k],  M[j, j])
+            ay = math.atan2(-M[k, i],  cy)
+            az = 0.0
+
+    if parity:
+        ax, ay, az = -ax, -ay, -az
+    if frame:
+        ax, az = az, ax
+    return ax, ay, az

--- a/ImageD11/forward_model/pars_conversion.py
+++ b/ImageD11/forward_model/pars_conversion.py
@@ -1,0 +1,483 @@
+# pars_conversion.py
+# convert parameters defined in different codes to a common parameter dictionary (p), which are compatible with fwd-DCT, this includes:
+# 1) convert ImageD11 pars to p
+# 2) convert DCT parameters.mat to p
+# 3) convert pyFAI poni to p
+# 4) build_ImageD11par_from_poni
+# 5) build_poni_from_ImageD11par
+# Haixing Fang, haixing.fang@esrf.fr
+# Oct 27th, 2024
+
+import os
+import numpy as np
+import ImageD11.transformer
+import pyFAI
+from datetime import datetime
+from ImageD11.forward_model.io import read_matlab_file
+from scipy.optimize import minimize
+
+econst = 12.3984
+
+def convert_ImageD11pars2p(pars):
+    """
+    Convert ImageD11 parameters to specific geometry and detector parameters (unit in mm), which are compatible with fwd-DCT
+    
+    Arguments:
+    pars -- ImageD1.parameters object, e.g. pars = ImageD11.parameters.read_par_file(ds.parfile)
+    
+    Returns:
+    a dictionary of p, which has keys of rawfile, Lsam2det, tilt_xyz, RotDet, dety0, detz0, dety00, detz00, wedge, pixelysize, pixelzsize,
+                                         detysize, detzsize, BeamStopY, BeamStopZ, S, flip_lr_flag, flip_ud_flag, wavelength, Energy etc.
+    """
+    p = {}
+    p['rawfile'] = pars.parameters['filename']
+    p['Lsam2det'] = pars.parameters['distance']/1000.0
+    p['tilt_xyz'] = [np.rad2deg(pars.parameters['tilt_x']), np.rad2deg(pars.parameters['tilt_y']), np.rad2deg(pars.parameters['tilt_z'])]  # [deg]
+    p['RotDet'] = get_det_R(pars.parameters['tilt_x'], pars.parameters['tilt_y'], pars.parameters['tilt_z'])
+    p['pixelysize'] = pars.parameters['y_size']/1000.0
+    p['pixelzsize'] = pars.parameters['z_size']/1000.0
+    if pars.parameters['o11'] == -1 and pars.parameters['o22'] == -1:
+        p['detysize'] = 2162
+        p['detzsize'] = 2068
+        p['flip_lr_flag'] = False
+        p['flip_ud_flag'] = False
+    elif pars.parameters['o11'] == 1 and pars.parameters['o22'] == -1:
+        p['detysize'] = 2048
+        p['detzsize'] = 2048
+        p['flip_lr_flag'] = False
+        p['flip_ud_flag'] = True
+    else:
+        print('Note this detector configuration is not supported yet; Set to not have any flips - equivalent to Eiger !')
+        p['detysize'] = 2162
+        p['detzsize'] = 2068
+        p['flip_lr_flag'] = False
+        p['flip_ud_flag'] = False
+    p['dety0'] = pars.parameters['y_center']
+    p['detz0'] = pars.parameters['z_center']
+    p['dety00'] = 0.0
+    p['detz00'] = 0.0
+    p['wedge'] = pars.parameters['wedge']
+    if pars.parameters['omegasign'] > 0:
+        p['S'] = np.array([[1.0, 0, 0],
+             [0, 1.0, 0],
+             [0, 0, 1.0]])
+    else:
+        p['S'] = np.array([[1.0, 0, 0],
+             [0, -1.0, 0],
+             [0, 0, 1.0]])
+    p['wavelength'] = pars.parameters['wavelength'] # [Angstrom]
+    p['Energy'] = econst / pars.parameters['wavelength'] # [keV]
+    bs_margin = 2.5/(pars.parameters['y_size']/1000.0)   # assume a 5 mm beamstop [pixel]
+    p['BeamStopY'] = [pars.parameters['y_center']-bs_margin, pars.parameters['y_center']+bs_margin]
+    p['BeamStopZ'] = [pars.parameters['z_center']-bs_margin, pars.parameters['z_center']+bs_margin]
+    
+    return p
+    
+
+def convert_DCTpars2p(par_path, Binning = None):
+    """
+    Convert DCT parameters.mat to specific geometry and detector parameters (unit in mm), which are compatible with fwd-DCT
+    
+    Arguments:
+    par_path -- DCT parameters.mat
+    Binning  -- binning of the detector, None by default
+    Equivalent to get_para_from_parameters.m in DCT code
+    
+    Returns:
+    a dictionary of p, which has keys of rawfile, Lsam2det, tilt_xyz, RotDet, dety0, detz0, dety00, detz00, wedge, pixelysize, pixelzsize,
+                                         detysize, detzsize, BeamStopY, BeamStopZ, S, flip_lr_flag, flip_ud_flag, wavelength, Energy etc.
+    """
+    mat_data = read_matlab_file(par_path)
+    parameters = mat_data['parameters']
+    
+    p = {}
+    p['rawfile'] = par_path
+    if len(parameters['acq']['energy']) == 1:
+        p['Energy'] = parameters['acq']['energy']  # [keV]
+        p['wavelength'] = econst / parameters['acq']['energy']  # [Angstrom]
+    else:
+        p['Energy'] = parameters['acq']['energy'][0]  # [keV]
+        p['wavelength'] = econst / parameters['acq']['energy'][0]  # [Angstrom]
+    
+    # detector information
+    p['pixelysize'] = parameters['detgeo']['pixelsizeu'][0]
+    p['pixelzsize'] = parameters['detgeo']['pixelsizev'][0]
+    p['dety0']      = parameters['detgeo']['detrefu'][0]
+    p['detz0']      = parameters['detgeo']['detrefv'][0]
+    p['detysize']   = parameters['detgeo']['detsizeu'][0]
+    p['detzsize']   = parameters['detgeo']['detsizev'][0]
+    if len(parameters['acq']['bbdir']) == 4:
+        p['BeamStopY']  = [ parameters['acq']['bbdir'][0], parameters['acq']['bbdir'][0] + parameters['acq']['bbdir'][2]]
+        p['BeamStopZ']  = [ parameters['acq']['bbdir'][1], parameters['acq']['bbdir'][1] + parameters['acq']['bbdir'][3]]
+    else:
+        p['BeamStopY']  = [ parameters['acq']['bbdir'][0][0], parameters['acq']['bbdir'][0][0] + parameters['acq']['bbdir'][0][2]]
+        p['BeamStopZ']  = [ parameters['acq']['bbdir'][0][1], parameters['acq']['bbdir'][0][1] + parameters['acq']['bbdir'][0][3]] 
+    p['Qdet']       = parameters['detgeo']['Qdet']    
+    
+    # acquisition / geometry information
+    VoxSize         = parameters['recgeo']['voxsize'] # [mm]
+    detrefpos       = parameters['detgeo']['detrefpos']
+    detorig         = parameters['detgeo']['detorig'] # top left corner of the detector [mm]
+    acquisition_center=[0, 0, 0]
+    det_center      = detrefpos
+    # Note: shift in y is not needed, because the setup for tomo recon has been forced to bring y centered. shift Z needs to be considered
+    if len(parameters['acq']['bb']) == 4:
+        det_center[2]   = det_center[2] + (parameters['acq']['bb'][1] + parameters['acq']['bb'][3]/2 - p['detz0'])*p['pixelzsize'] # because parameters.acq.bb defines FOV for tomo recon [mm]
+    else:
+        det_center[2]   = det_center[2] + (parameters['acq']['bb'][0][1] + parameters['acq']['bb'][0][3]/2 - p['detz0'])*p['pixelzsize'] 
+    if det_center[2] != detrefpos[2]:
+        print('Shift in vertical axis (Z) is found: det_center changes from {:.5f} to {:.5f} mm'.format(detrefpos[2], det_center[2]))
+    p['Lsam2det']   = detrefpos[0] # more precise than parameters.acq.dist
+    p['dety00']     = det_center[1] - acquisition_center[1] # [mm]
+    p['detz00']     = det_center[2] - acquisition_center[2] # [mm]
+    p['RotAxisOffset'] = detrefpos[1]                       # not used but save this value [mm]
+    
+    det_normal      = parameters['detgeo']['detnorm'].ravel()
+    if np.abs(det_normal[0]+1) < 0.5:
+        det_normal = -det_normal # should be along the beam
+        print('Note: the original parameters.detgeo.detnorm is opposite to the beam direction.')
+        print('Now det_normal is along the beam direction')
+    detdiru = parameters['detgeo']['detdiru'].ravel()
+    if np.abs(detdiru[1] - 1) < 0.5:
+        detdiru = -detdiru
+        p['Qdet'][0,:] = -p['Qdet'][0,:]
+        flip_lr_flag = True
+        print('Note: the original parameters.detgeo.detdiru is pointing to the left')
+        print('Now detdiru points to the right => flip_lr_flag = True')
+    else:
+        flip_lr_flag = False
+    p['flip_lr_flag'] = flip_lr_flag
+    
+    detdirv = parameters['detgeo']['detdirv'].ravel()
+    if np.abs(detdirv[2] - 1) < 0.5:
+        detdirv = -detdirv
+        p['Qdet'][1,:] = -p['Qdet'][1,:]
+        flip_lr_flag = True
+        print('Note: the original parameters.detgeo.detdirv is pointing to upwards')
+        print('Now detdirv points downwards')
+    p['flip_ud_flag'] = False
+                                 
+    tilt_x, tilt_y, tilt_z = get_det_tilt(det_normal, detdiru, degree = False)
+    p['tilt_xyz'] = [np.rad2deg(tilt_x), np.rad2deg(tilt_y), np.rad2deg(tilt_z)] # [deg]
+    p['RotDet'] = get_det_R(tilt_x, tilt_y, tilt_z)           
+    p['wedge'] = 0.0
+                                 
+    # sample information
+    if len(parameters['acq']['dir']) == 2:
+        p['FileFolder'] = parameters['acq']['dir'][0]
+    else:
+        p['FileFolder'] = parameters['acq']['dir']
+    
+    if len(parameters['acq']['refon']) > 1:
+        parameters['acq']['refon'] = parameters['acq']['refon'][0]
+    if not ('labgeo' in parameters and 'omstep' in parameters['labgeo']):
+        if parameters['acq']['type'] == '360degree':
+            parameters['labgeo']['omstep'] = 360.0/parameters['acq']['refon']
+        else:
+            parameters['labgeo']['omstep'] = 180.0/parameters['acq']['refon']
+    p['rot_step']  = parameters['labgeo']['omstep']
+    if parameters['acq']['type'] == '360degree':
+        p['rot_start'] = 0.0
+        p['rot_end']   = 360.0
+        p['rot_angles'] = np.arange(p['rot_start'], p['rot_end'], p['rot_step'])
+    if len(parameters['acq']['name']) == 2:
+        p['prefix']   = parameters['acq']['name'][0]
+    else:
+        p['prefix']   = parameters['acq']['name']
+    p['SampleName'] = p['prefix']
+    p['ImageNr']  = parameters['acq']['refon']
+                                 
+    if Binning is not None and Binning != 1:
+        p['pixelysize'] = p['pixelysize']*Binning
+        p['pixelzsize'] = p['pixelzsize']*Binning
+        p['dety0']      = p['dety0']/Binning
+        p['detz0']      = p['detz0']/Binning
+        p['detysize']   = p['detysize']/Binning
+        p['detzsize']   = p['detzsize']/Binning
+        p['BeamStopY'][0]   = np.floor(p['BeamStopY'][0]/Binning)
+        p['BeamStopY'][1]   = np.ceil(p['BeamStopY'][1]/Binning)
+        p['BeamStopZ'][0]   = np.floor(p['BeamStopZ'][0]/Binning)
+        p['BeamStopZ'][1]   = np.ceil(p['BeamStopZ'][1]/Binning)
+        print('Detector images are binned to {:.1f} * {:.1f}'.format(Binning, Binning))    
+    return p
+    
+    
+def get_det_R(tilt_x, tilt_y, tilt_z):
+    """
+    Calculate detector rotation matrix from tilt angles around x, y, z axes in radians
+    Arguments:
+    tilt_x, tilt_y, tilt_z in radians
+    Returns:
+    RotDet, 3*3 numpy array
+    """
+    print('Detector tilt angles = [{:.4f} {:.4f} {:.4f}] deg'.format(np.rad2deg(tilt_x), np.rad2deg(tilt_y), np.rad2deg(tilt_z)))
+    # Define rotation matrices
+    RotX = np.array([[1, 0, 0], 
+                     [0, np.cos(tilt_x), -np.sin(tilt_x)], 
+                     [0, np.sin(tilt_x), np.cos(tilt_x)]])
+    
+    RotY = np.array([[np.cos(tilt_y), 0, np.sin(tilt_y)], 
+                     [0, 1, 0], 
+                     [-np.sin(tilt_y), 0, np.cos(tilt_y)]])
+    
+    RotZ = np.array([[np.cos(tilt_z), -np.sin(tilt_z), 0], 
+                     [np.sin(tilt_z), np.cos(tilt_z), 0], 
+                     [0, 0, 1]])
+    RotDet = np.dot(RotZ, np.dot(RotY, RotX))
+    
+    return RotDet
+
+
+def get_det_tilt(det_normal, detdiru, degree = False):
+    """
+    Calculate detector tilt angles around x, y, z axis from detector normal and detdiru
+    Arguments:
+    det_normal   --  unit vector of detector normal
+    detdiru      --  unit vector of detector u
+    
+    Returns:
+    tilt_x, tilt_y, tilt_z in radians if degree = False
+    """
+    tilt_x = (np.arccos(np.dot(detdiru, [0, 0, 1]))) - np.pi/2
+    tilt_y = (np.arccos(np.dot(det_normal * [1, 0, 1], [0, 0, 1]))) - np.pi/2
+    tilt_z = np.pi/2 - (np.arccos(np.dot(det_normal * [1, 1, 0], [0, 1, 0])))
+    if degree:
+        return np.rad2deg(tilt_x), np.rad2deg(tilt_y), np.rad2deg(tilt_z)
+    else:
+        return tilt_x, tilt_y, tilt_z
+
+
+def build_ImageD11par_from_poni(lattice_par, sgno, poni_file, par_path = 'demo.pars', detector = 'Eiger', verify = True):
+    """
+    build a ImageD11 par from a poni file
+    
+    Arguments:
+    lattice_par   -- lattice parameters
+    sgno          -- space group number
+    poni_file     -- poni file
+    par_path      -- the output ImageD11 par filename
+    detector      -- detector name, 'Eiger' or 'Frelon3'
+    verify        -- BOOL for verify the errors
+    
+    Returns:
+    an ImageD11 parameter object
+    
+    Example:
+    lattice_par = [5.43094, 5.43094, 5.43094, 90, 90, 90] # Si cube
+    sgno = 227
+    poni_file = 'demo.poni'
+    build_par_from_poni(lattice_par, sgno, poni_file, par_path = 'demo.pars', detector = 'Eiger')
+    """
+    poni_results = pyFAI.load(poni_file).getImageD11()
+    write_ImageD11pars_from_poni(lattice_par, sgno, poni_results, par_path = par_path, detector = detector)
+    trn = ImageD11.transformer.transformer()
+    trn.loadfileparameters(par_path)
+    if verify:
+        err = calc_err(trn.pars, poni_path)
+    return trn.pars
+
+
+def build_poni_from_ImageD11par(par_file, spatial_file = None, poni_file = 'demo.poni', detector = 'Eiger', verify = True):
+    
+    """
+    convert ImageD11 .par to poni:
+    Poin1 = z_center*pixel_size [m]
+    Poin2 = y_center*pixel_size [m]
+    Rot1 = -tilt_z [radian]
+    Rot2 = tilt_y [radian]
+    Rot3 = tilt_x [radian]
+    
+    In ImageD11  --- flip story: eiger has no flip, while frelon3 is flipped up and down
+    For Eiger:
+    'o11': -1,
+    'o12': 0,
+    'o21': 0,
+    'o22': -1,
+    For Frelon:
+    'o11': 1,
+    'o12': 0,
+    'o21': 0,
+    'o22': -1,
+    """    
+    
+    if spatial_file is None:
+        spatial_file = auto_load_spatial_file(detector)
+    
+    trn = ImageD11.transformer.transformer()
+    trn.loadfileparameters(par_file)
+
+    wavelength = trn.pars['wavelength']
+    distance = float(trn.pars['distance'])
+    y_center = trn.pars['y_center']
+    z_center = trn.pars['z_center']
+    pixel_sizey = trn.pars['y_size']
+    pixel_sizez = trn.pars['z_size']
+    tilt_x = trn.pars['tilt_x']
+    tilt_y = trn.pars['tilt_y']
+    tilt_z = trn.pars['tilt_z']
+    poni1 = z_center*pixel_sizez/1e6
+    poni2 = y_center*pixel_sizey/1e6
+    print('Initial poni1 = {}'.format(poni1))
+    print('Initial poni2 = {}'.format(poni2))
+    current_time = datetime.now()
+    formatted_time = current_time.strftime("%a %b %d %H:%M:%S %Y")
+    # write a first poni file
+    write_poni(poni_path, formatted_time, spatial_file, distance, poni1, poni2, tilt_x, tilt_y, tilt_z, wavelenth)
+    
+    pyFAI_pars = pyFAI.load(poni_path)
+    print(pyFAI_pars)
+    poni_results = pyFAI.load(poni_path).getImageD11()
+    print(poni_results)
+    
+    # minimize the errors of distance, poni1 and poni2
+    params0 = [trn.pars['distance'], poni1, poni2]
+    print('Initial guess: {}'.format(params0))
+    result = minimize(error_function, x0 = params0, args=(trn.pars, poni_path, formatted_time, spatial_file, tilt_x, tilt_y, tilt_z, wavelenth), method = 'BFGS')
+    
+
+    print('Initial guess: {}'.format(params0))
+    print('Final fitted results: {}'.format(result.x))
+    
+    # check the errors again
+    err = calc_err(trn.pars, poni_path)
+    print('{} poni has been exported.'.format(poni_path))
+    
+    return err    
+    
+    
+def auto_load_spatial_file(detector):
+    if detector in ['Eiger', 'eiger']:
+        spatial_file = '/data/id11/nanoscope/Eiger/newSpatial_E-08-0144_20240205.h5'
+    elif detector in ['Frelon36', 'frelon36']:
+        spatial_file = "/data/id11/3dxrd/inhouse/Frelon36/frelon36_spline_20240604_full.h5"
+    elif detector in ['Frelon4M', 'frelon4M', 'frelon4m']:
+        spatial_file = "/data/id11/3dxrd/inhouse/Frelon4M/frelon4m.spline"
+    else:
+        print('{} has not been identified; currently Eiger, Frelon36 and Frelon4M are supported only.'.format(detector))
+        spatial_file = None
+    return spatial_file
+
+
+def write_ImageD11pars_from_poni(lattice_par, sgno, poni_results, par_path = 'demo.pars', detector = 'Eiger'):
+    """
+    write ImageD11 pars from a pyFAI poni file   
+
+    Example:
+    lattice_par = [5.43094, 5.43094, 5.43094, 90, 90, 90] # Si cube
+    sgno = 227
+    poni_results = pyFAI.load('demo.poni').getImageD11()
+    write_pars_from_poni(lattice_par, sgno, poni_results, par_path = 'demo.pars', detector = 'Eiger')
+    """
+    
+    if detector in ['Eiger', 'eiger']:
+        poni_results["o11"] = -poni_results["o11"]
+
+    par_string = f"""cell__a {lattice_par[0]}
+cell__b {lattice_par[1]}
+cell__c {lattice_par[2]}
+cell_alpha {lattice_par[3]}
+cell_beta {lattice_par[4]}
+cell_gamma {lattice_par[5]}
+cell_lattice_[P,A,B,C,I,F,R] {sgno}
+chi 0.0
+distance {poni_results["distance"]}
+fit_tolerance 0.05
+min_bin_prob 1e-05
+no_bins 10000
+o11 {poni_results["o11"]}
+o12 {poni_results["o12"]}
+o21 {poni_results["o21"]}
+o22 {poni_results["o22"]}
+omegasign 1.0
+t_x 0
+t_y 0
+t_z 0
+tilt_x {poni_results["tilt_x"]}
+tilt_y {poni_results["tilt_y"]}
+tilt_z {poni_results["tilt_z"]}
+wavelength {poni_results["wavelength"]*10}
+wedge 0.0
+weight_hist_intensities 0
+y_center {poni_results["y_center"]-0.5}
+y_size {poni_results["y_size"]}
+z_center {poni_results["z_center"]-0.5}
+z_size {poni_results["z_size"]}"""
+
+    # Save it to file
+    with open(par_path, "w") as f:
+        f.writelines(par_string)
+        print('write par file: {}'.format(par_path))
+        
+
+def write_poni(poni_path, formatted_time, spatial_file, distance, poni1, poni2, tilt_x, tilt_y, tilt_z, wavelenth):
+    poni_string = f"""# Nota: C-Order, 1 refers to the Y axis, 2 to the X axis 
+# Calibration done at {formatted_time}
+poni_version: 2
+Detector: NexusDetector
+Detector_config: {{"filename": "{spatial_file}"}}
+Distance: {distance*1e-6}
+Poni1: {poni1}
+Poni2: {poni2}
+Rot1: {-tilt_z}
+Rot2: {tilt_y}
+Rot3: {tilt_x}
+Wavelength: {wavelength*1e-10}"""
+    # Save it to file
+    with open(poni_path, "w") as f:
+        f.writelines(poni_string)
+        print('write poni file: {}'.format(poni_path))
+
+
+def error_function(params, ImageD11_pars, poni_path, formatted_time, spatial_file, tilt_x, tilt_y, tilt_z, wavelenth):
+    """
+    calculate errors of distance, poni1 and poni2 between ImageD11_pars and poni
+    Arguments:
+    params         -- distance, poni1, poni2
+    ImageD11_pars  -- ImageD11 parameter object
+    others:        -- poni_path, formatted_time, spatial_file, distance, poni1, poni2, tilt_x, tilt_y, tilt_z, wavelenth
+    
+    Returns:
+    err  -- sum of squared errors
+    
+    Example:
+    trn = ImageD11.transformer.transformer()
+    trn.loadfileparameters(par_path)
+    err = calc_err(trn.pars, poni_path) or err = calc_err(trn.pars, poni_path, parameter = 'distance')
+    """ 
+    
+    distance, poni1, poni2 = params
+    keys = ['distance', 'y_center']
+    write_poni(poni_path, formatted_time, spatial_file, distance, poni1, poni2, tilt_x, tilt_y, tilt_z, wavelenth)
+    err = calc_err(ImageD11_pars, poni_path)
+    return err['distance']**2 + err['y_center']**2 + err['z_center']**2
+
+
+def calc_err(ImageD11_pars, poni_path, parameter = None):
+    """
+    calculate difference between ImageD11_pars and poni for each parameter attribute
+    Arguments:
+    ImageD11_pars -- ImageD11 parameter object
+    poni_path      -- pyFAI poni file name
+    
+    Returns:
+    err  -- difference between each parameter attribute
+    
+    Example:
+    trn = ImageD11.transformer.transformer()
+    trn.loadfileparameters(par_path)
+    err = calc_err(trn.pars, poni_path) or err = calc_err(trn.pars, poni_path, parameter = 'distance')
+    """    
+    poni_results = pyFAI.load(poni_path).getImageD11()
+    if parameter is None:
+        err = {}
+        for key in poni_results.keys():
+            if key == 'wavelength':
+                err[key] = poni_results[key]*10 - ImageD11_pars[key]
+            elif key == 'y_center' or key == 'z_center':
+                err[key] = poni_results[key] - ImageD11_pars[key] - 0.5  # poni has 0.5 pixels bigger than ImageD11, which is due to difference in counting from the side or the center of the first pixel
+            else:
+                err[key] = poni_results[key] - ImageD11_pars[key]
+            print('{} error: {:.6f}'.format(key, err[key]))
+    else:
+        err = poni_results[parameter] - ImageD11_pars[parameter]
+    return err

--- a/ImageD11/forward_model/sample_environment.py
+++ b/ImageD11/forward_model/sample_environment.py
@@ -1,0 +1,107 @@
+# interact with the sample environment
+# 1) ADMET tensile rig for now
+# 2) ...
+# Haixing Fang, haixing.fang@esrf.fr
+# May 28, 2024
+
+import os
+import glob
+
+import numpy as np
+import matplotlib.pyplot as plt
+import h5py
+import matplotlib
+import xml.etree.ElementTree as ET
+
+
+    
+class admet:
+    '''
+    read data from ADMET stress rig, which is normally save as .mtxData file
+    example:
+    filename = '/home/esrf/haixing0a/Downloads/ADMET_testing_20240327/ma5607_HEA2.mtwData'
+    stress = admet(filename)
+    '''
+    def __init__(self, filename = None, outname = None):
+        self.filename = filename
+        self.header = "Position(mm), Load(N)"
+        self.outname = outname
+        if filename is not None:
+            self.data, self.key_names = self.read_data()
+        else:
+            self.data = None
+            self.key_names = None
+    
+    def read_data(self):
+        if os.path.exists(self.filename):
+            sample = self.parse_xml_file(self.filename)
+            sample['Sample@TIME']=np.array(sample['Sample@TIME'])/1000   # [s]
+            sample['Sample@POSN']=np.array(sample['Sample@POSN'])*1000   # [mm]
+            sample['Sample@LOAD']=np.array(sample['Sample@LOAD'])*10     # [N]
+            key_names = []
+            for key in sample.keys():
+                key_names.append(key)
+            return sample, key_names
+        else:
+            print('{} is not found'.format(self.filename))
+            return None
+    
+    def save_data(self, output_name = 'test.dat'):
+        if self.outname is None:
+            self.outname = output_name
+            
+        # Write header and data to the file
+        with open(self.outname, 'w') as file:
+            file.write(self.header + '\n')
+            for row in zip(self.data['Sample@POSN'], self.data['Sample@LOAD']):
+                file.write(','.join(map(str, row)) + '\n')
+        print('Data has been written to {}'.format(self.outname))            
+        
+    def plot_data(self):
+        if self.data is not None:
+            plt.figure()
+            plt.plot(self.data['Sample@POSN'], self.data['Sample@LOAD'], 'o')
+            plt.xlabel('Position (mm)',fontsize=20)
+            plt.ylabel('Load (N)',fontsize=20)
+            plt.tick_params(axis='both',labelsize=16)
+            plt.tight_layout()
+            plt.show()
+    
+    def parse_xml_file(self, xml_file):
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+
+        data, sample = self.read_xml_data(root)
+        return sample   
+
+    def read_xml_data(self, element):
+        data_values = {}
+        sample_values = {}
+
+        if element.text:
+            data_values[element.tag] = element.text.strip()
+
+        for child in element:
+            child_data, child_sample_values = self.read_xml_data(child)
+
+            if child.tag in data_values:
+                if isinstance(data_values[child.tag], list):
+                    data_values[child.tag].append(child_data)
+                else:
+                    data_values[child.tag] = [data_values[child.tag], child_data]
+            else:
+                data_values[child.tag] = child_data
+
+            if child.tag == 'Sample':
+                if child.attrib:
+                    for attr_key, attr_value in child.attrib.items():
+                        attr_tag = child.tag + "@" + attr_key
+                        if attr_tag in sample_values:
+                            sample_values[attr_tag].append(float(attr_value))
+                        else:
+                            sample_values[attr_tag] = [float(attr_value)]
+            elif child_sample_values:
+                sample_values.update(child_sample_values)
+
+        return data_values, sample_values
+

--- a/ImageD11/forward_model/schmidt_factor.py
+++ b/ImageD11/forward_model/schmidt_factor.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Feb 12 13:51:26 2020
+
+@author: Arsenic
+"""
+import numpy as np
+from math import cos,sin, pi,atan2,asin
+
+def degToRad(deg):
+    rad = np.array(deg)*pi/180
+    return rad
+
+def radToDeg(rad):
+    deg = np.array(rad)*180/pi
+    return deg
+
+def rot_matrix(eulers):
+    "macro base in crystal frame"
+    "RD = rotated_matrix[0,:]"
+    "TD = rotated_matrix[1,:]"
+    "ND = rotated_matrix[2,:]"
+    eulers = degToRad(eulers)
+    rotated_matrix = np.zeros((3,3))
+    rotated_matrix[0,0] = cos(eulers[0])*cos(eulers[2])-sin(eulers[0])*sin(eulers[2])*cos(eulers[1])
+    rotated_matrix[0,1] = -cos(eulers[0])*sin(eulers[2])-sin(eulers[0])*cos(eulers[2])*cos(eulers[1])
+    rotated_matrix[0,2] = sin(eulers[0])*sin(eulers[1])
+    rotated_matrix[1,0] = sin(eulers[0])*cos(eulers[2])+cos(eulers[0])*sin(eulers[2])*cos(eulers[1])
+    rotated_matrix[1,1] = -sin(eulers[0])*sin(eulers[2])+cos(eulers[0])*cos(eulers[2])*cos(eulers[1])
+    rotated_matrix[1,2] = -cos(eulers[0])*sin(eulers[1])
+    rotated_matrix[2,0] = sin(eulers[2])*sin(eulers[1])
+    rotated_matrix[2,1] = cos(eulers[2])*sin(eulers[1])
+    rotated_matrix[2,2] = cos(eulers[1])
+    return rotated_matrix
+
+def gen_directions(lattice):
+    "generates the possible slip directions"
+    if lattice == 'BCC':
+        directions = np.array([[1,1,1],[-1,1,1],[1,-1,1],[1,1,-1]])
+    if lattice == 'FCC':
+        directions = np.array([[0,1,1], [0,-1,1], [1,0,1], [-1,0,1],[-1,1,0],[1,1,0]])
+    return directions
+
+def gen_planes(plane_type):
+    if plane_type == '110':
+        planes = np.array([[1,1,0],[1,0,1],[0,1,1],[-1,1,0],[-1,0,1],[0,-1,1]])
+        return planes
+    if plane_type == '112':
+        planes = np.array([[1,1,2],[1,2,1],[2,1,1],[1,1,-2],[1,-2,1],[-2,1,1],[-1,1,2],[2,-1,1],[1,2,-1],[1,-1,2],[2,1,-1],[-1,2,1]])
+        return planes
+    if plane_type == '123':
+        planes = np.array([[1,2,3],[3,1,2],[2,3,1],[-1,2,3],[3,-1,2],[2,3,-1],[1,-2,3],[3,1,-2],[2,-3,1],[1,2,-3],[-3,1,2],[2,-3,1],[3,2,1],[2,1,3],[1,3,2],[-3,2,1],[2,1,-3],[1,-3,2],[3,-2,1],[-2,1,3],[1,3,-2],[3,2,-1],[2,-1,3],[-1,3,2]])
+        return planes
+    if plane_type == '134':
+        planes = np.array([[1,3,4],[4,1,3],[3,4,1],[-1,3,4],[4,-1,3],[3,4,-1],[1,-3,4],[4,1,-3],[-3,4,1],[1,3,-4],[-4,1,3],[3,-4,1],[4,3,1],[3,1,4],[1,4,3],[-4,3,1],[3,1,-4],[1,-4,3],[4,-3,1],[-3,1,4],[1,4,-3],[4,3,-1],[3,-1,4],[-1,4,3]])
+        return planes
+    if plane_type == '111':
+        planes = np.array([[-1,1,1],[1,1,1],[-1,-1,1],[1,-1,1]])
+        return planes
+    else:
+        print("unregistered plane type")
+
+def calc_sfs(eulers,slipPlane,lattice):
+    rotated_matrix = rot_matrix(eulers)
+    planes = gen_planes(slipPlane)
+    schmidFact = []
+    dirs = gen_directions(lattice)
+    for plane in range(planes.shape[0]):
+        for direction in range(dirs.shape[0]):
+            if np.dot(planes[plane],dirs[direction]) == 0:
+                schmidFact.append((np.abs(np.multiply(np.dot(rotated_matrix[1,:],planes[plane]),np.dot(rotated_matrix[1,:],dirs[direction]))))/(np.multiply(np.linalg.norm(planes[plane]),np.linalg.norm(dirs[direction]))))
+    return schmidFact
+    
+def plane_trace_components(plane,eulers):
+    "calculates the trace angle of given plane in given crystal onto sample surface"
+    "opening convention from left to right, convention '2' from ImageJ"
+    matrix = rot_matrix(eulers)
+    trace_x = np.dot(np.cross(plane, matrix[2,:]), matrix[1,:])/np.linalg.norm(np.cross(plane, matrix[2,:]))  # divide by norm of vector
+    trace_y = -np.dot(np.cross(plane, matrix[2,:]), matrix[0,:])/np.linalg.norm(np.cross(plane, matrix[2,:]))  # divide by norm of vector
+    return trace_x, trace_y
+
+
+def project_direction(direction,eulers):
+    "calculates the normed components of a given direction in sample reference frame"
+    matrix = rot_matrix(eulers)
+    b_x = np.dot(matrix[0,:],direction)
+    b_y = np.dot(matrix[1,:],direction)
+    return b_x,b_y
+
+def get_gamma_angle(plane,direction,eulers):
+    "calculates the gamma angle associated to a slip system"
+    b_x, b_y = project_direction(direction,eulers)
+    plane_trace_x, plane_trace_y = plane_trace_components(plane,eulers)
+    longi = plane_trace_x*b_x + plane_trace_y*b_y
+    transv = -(plane_trace_y)*b_x + (plane_trace_x)*b_y
+    gamma = atan2(longi,transv)
+    return gamma
+
+def random_quats(n):
+    "uniform quats population"
+    u1,u2,u3 = np.random.rand(3,n)
+    return np.array([np.sqrt(1 - u1) * np.sin(2 * np.pi * u2),
+                     np.sqrt(1 - u1) * np.cos(2 * np.pi * u2),
+                     np.sqrt(u1)     * np.sin(2 * np.pi * u3),
+                     np.sqrt(u1)     * np.cos(2 * np.pi * u3)]).T
+
+def quats_to_euler(quats):
+    "conversion from quaternions to euler angles"
+    "/!\ resulting euler angles in radians"
+    numQuats = quats.shape[0]
+    eulers = np.zeros((numQuats,3),dtype=float)
+    for quat in range(numQuats):
+        eulers[quat,0] = atan2(2*(quats[quat,0]*quats[quat,1]+quats[quat,2]*quats[quat,3]),1-2*(quats[quat,1]*quats[quat,1]+quats[quat,2]*quats[quat,2]))
+        eulers[quat,1] = asin(2*(quats[quat,0]*quats[quat,2]-quats[quat,3]*quats[quat,1]))
+        eulers[quat,2]= atan2(2*(quats[quat,0]*quats[quat,3]+quats[quat,1]*quats[quat,2]),1-2*(quats[quat,2]*quats[quat,2]+quats[quat,3]*quats[quat,3]))
+    return eulers


### PR DESCRIPTION
The aim is to exploit forward model for the following purposes:
1) facilitate analysis for (s)3DXRD by filtering and cleaning peaks for indexed grains, calculating completeness
2) bridging the combined analysis between DCT and (s)3DXRD for the same sample but measured in different geometries/instruments
3) forward model based reconstruction for both near-field and far-field geometries
4) parameters conversion among ImageD11 par, DCT parameters, poni, which all can be converted to a dictionary and compatible with fwd-DCT parameters
5) other auxillary tools for multi-modality analysis, including interacting with PCT, sample environment, orientation conversion, deformation analysis (schmidt factor calc) etc.
A lot more is under development...