### PR TITLE
Fix bug with creating PBPMap from multi-layer TensorMap

### DIFF
--- a/ImageD11/sinograms/tensor_map.py
+++ b/ImageD11/sinograms/tensor_map.py
@@ -1281,12 +1281,12 @@ class TensorMap:
                 # get the si, sj values
                 si, sj = recon_to_step(ri, rj, ubi_pbpmap_order.shape[:2])
                 # get the mi, mj, mk values
-                mi, mj, mk = self.recon_index_to_map(ri, rj, ubi_pbpmap_order.shape[1])
+                _, mj, mk = self.recon_index_to_map(ri, rj, ubi_pbpmap_order.shape[1])
                 si_col[row_idx] = si
                 sj_col[row_idx] = sj
                 # do we have anything at this reconstruction point?
                 # otherwise we have nothing
-                if self.phase_ids[mi, mj, mk] > -1:
+                if self.phase_ids[z_layer, mj, mk] > -1:
                     npks_col[row_idx] = default_npks
                     nuniq_col[row_idx] = default_nuniq
                 row_idx += 1


### PR DESCRIPTION
Unlikely to have caused problems in current usage - regular notebook workflow doesn't initiate a refinement from a TensorMap with more than one z layer (z stacking comes later). In the previous code, `mi` was always 0, because `recon_index_to_map` (correctly) defaults to a 2D slice. We should be checking the `self.phase_ids` phase mask at the user-supplied `z_layer` value rather than 0.