### PR TITLE
frelon_peaksearch: allow to pass `kwargs` to `process_map` in `process` function

### DIFF
--- a/ImageD11/frelon_peaksearch.py
+++ b/ImageD11/frelon_peaksearch.py
@@ -360,7 +360,7 @@ PKSAVE = [
 PKCOL = [getattr(ImageD11.cImageD11, p) for p in PKSAVE]
 
 
-def process(ds, worker_args, ncpu=None, tqdm_class=None, task_instance=None, **kwargs):
+def process(ds, worker_args, ncpu=None, **process_map_kwargs):
     """
     Runs over the first scan in a dataset in parallel
 
@@ -384,15 +384,7 @@ def process(ds, worker_args, ncpu=None, tqdm_class=None, task_instance=None, **k
     args = [(hname, frames_dset, i, omega[i], worker_args) for i in range(n_frames)]
     
 
-    if tqdm_class and task_instance:
-        all_peaks = process_map(
-            pps, args, chunksize=1, max_workers=nthreads, 
-            tqdm_class=tqdm_class,
-            task_instance=task_instance,
-        )
-    else:
-        all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads)
-    
+    all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads, **process_map_kwargs)
 
     # make a dict to hold our results in
     cf_2d_dict = {}

--- a/ImageD11/frelon_peaksearch.py
+++ b/ImageD11/frelon_peaksearch.py
@@ -360,7 +360,7 @@ PKSAVE = [
 PKCOL = [getattr(ImageD11.cImageD11, p) for p in PKSAVE]
 
 
-def process(ds, worker_args, ncpu=None):
+def process(ds, worker_args, ncpu=None, **kwargs):
     """
     Runs over the first scan in a dataset in parallel
 
@@ -383,7 +383,7 @@ def process(ds, worker_args, ncpu=None):
 
     args = [(hname, frames_dset, i, omega[i], worker_args) for i in range(n_frames)]
 
-    all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads)
+    all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads, **kwargs)
 
     # make a dict to hold our results in
     cf_2d_dict = {}

--- a/ImageD11/frelon_peaksearch.py
+++ b/ImageD11/frelon_peaksearch.py
@@ -360,7 +360,7 @@ PKSAVE = [
 PKCOL = [getattr(ImageD11.cImageD11, p) for p in PKSAVE]
 
 
-def process(ds, worker_args, ncpu=None, **kwargs):
+def process(ds, worker_args, ncpu=None, tqdm_class=None, **kwargs):
     """
     Runs over the first scan in a dataset in parallel
 
@@ -383,7 +383,7 @@ def process(ds, worker_args, ncpu=None, **kwargs):
 
     args = [(hname, frames_dset, i, omega[i], worker_args) for i in range(n_frames)]
 
-    all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads, **kwargs)
+    all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads, tqdm_class=tqdm_class, **kwargs)
 
     # make a dict to hold our results in
     cf_2d_dict = {}

--- a/ImageD11/frelon_peaksearch.py
+++ b/ImageD11/frelon_peaksearch.py
@@ -360,7 +360,7 @@ PKSAVE = [
 PKCOL = [getattr(ImageD11.cImageD11, p) for p in PKSAVE]
 
 
-def process(ds, worker_args, ncpu=None, tqdm_class=None, **kwargs):
+def process(ds, worker_args, ncpu=None, tqdm_class=None, task_instance=None, **kwargs):
     """
     Runs over the first scan in a dataset in parallel
 
@@ -382,8 +382,17 @@ def process(ds, worker_args, ncpu=None, tqdm_class=None, **kwargs):
     n_frames = omega.shape[0]
 
     args = [(hname, frames_dset, i, omega[i], worker_args) for i in range(n_frames)]
+    
 
-    all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads, tqdm_class=tqdm_class, **kwargs)
+    if tqdm_class and task_instance:
+        all_peaks = process_map(
+            pps, args, chunksize=1, max_workers=nthreads, 
+            tqdm_class=lambda *args, **kwargs: tqdm_class(task_instance, *args, **kwargs),
+            **kwargs
+        )
+    else:
+        all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads)
+    
 
     # make a dict to hold our results in
     cf_2d_dict = {}

--- a/ImageD11/frelon_peaksearch.py
+++ b/ImageD11/frelon_peaksearch.py
@@ -387,8 +387,8 @@ def process(ds, worker_args, ncpu=None, tqdm_class=None, task_instance=None, **k
     if tqdm_class and task_instance:
         all_peaks = process_map(
             pps, args, chunksize=1, max_workers=nthreads, 
-            tqdm_class=lambda *args, **kwargs: tqdm_class(task_instance, *args, **kwargs),
-            **kwargs
+            tqdm_class=tqdm_class,
+            task_instance=task_instance,
         )
     else:
         all_peaks = process_map(pps, args, chunksize=1, max_workers=nthreads)


### PR DESCRIPTION
Fix #383 