### PR TITLE
add forward_projector, grainmaps and updates with forward_model etc to forward compute

### DIFF
--- a/ImageD11/forward_model/__init__.py
+++ b/ImageD11/forward_model/__init__.py
@@ -1,12 +1,13 @@
 """
-forward model for 3DXRD and s3DXRD
+forward model for box-beam 3DXRD and s3DXRD using point-focused beam
 The aim is to exploit forward model for the following purposes:
 1) facilitate analysis for (s)3DXRD by filtering and cleaning peaks for indexed grains, calculating completeness
 2) bridging the combined analysis between DCT and (s)3DXRD for the same sample but measured in different geometries/instruments
 3) forward model based reconstruction for both near-field and far-field geometries
 4) parameters conversion among ImageD11 par, DCT parameters, poni, which all can be converted to a dictionary and compatible with fwd-DCT parameters
-5) other auxillary tools for multi-modality analysis, including interacting with PCT, sample environment, orientation conversion, deformation analysis (schmidt factor calc) etc.
-Copyright (C) 2023-present  Haixing Fang
+5) forward projector and back projector, aiming to improving/refining the grain and strain maps (under development)
+6) other auxillary tools for multi-modality analysis, including interacting with PCT, sample environment, orientation conversion, deformation analysis (schmidt factor calc) etc.
+Developed since Oct 2023
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -22,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
- 
-__version__ = "1.0.0"
+
+__version__ = "1.0.1"
 __author__ = 'Haixing Fang',
 __author_email__ = 'haixing.fang@esrf.fr'

--- a/ImageD11/forward_model/forward_model.py
+++ b/ImageD11/forward_model/forward_model.py
@@ -5,6 +5,7 @@
 # 3) forward_match_peaks to find matched peaks and compute completeness
 # Haixing Fang, haixing.fang@esrf.fr
 # Oct 4th, 2024
+# updated on January 30, 2025
 
 import numpy as np
 import ImageD11.columnfile
@@ -12,11 +13,13 @@ import ImageD11.unitcell
 import ImageD11.transformer
 from ImageD11.forward_model import pars_conversion
 from matplotlib import pyplot as plt
+import logging
+from numba import njit
 
 econst = 12.3984
+logging.basicConfig(level=logging.INFO, force=True)
 
-
-def forward_match_peaks(cf_strong, grains, ds, ucell, pars, ds_max = 2.0, tol_angle=1, tol_pixel=10, thres_int = None):
+def forward_match_peaks(cf_strong, grains, ds, ucell, pars, ds_max = 2.0, tol_angle=1, tol_pixel=10, thres_int = None, verbose = 1):
     """
     Perform forward calculation to find the matched fwd peaks and exp peaks
 
@@ -31,6 +34,7 @@ def forward_match_peaks(cf_strong, grains, ds, ucell, pars, ds_max = 2.0, tol_an
     tol_angle -- tolerance of angles for matching peaks
     tol_piexl -- tolerance of pixels for matching peaks
     thres_int -- intensity threshold, None as default to not remove peaks
+    verbose   -- verbose level for displaying print out
 
     Returns:
     cf_matched_all -- list of matched peaks for each of the grain, list of ImageD11.columnfile
@@ -52,7 +56,7 @@ def forward_match_peaks(cf_strong, grains, ds, ucell, pars, ds_max = 2.0, tol_an
         U = grains[i].U
         B = grains[i].B
 
-        fwd, Nr_simu = forward_comp(pos, U, B, ucell, pars, ds_max = ds_max, rot_start = rot_min, rot_end = rot_max, rot_step = rot_step)
+        fwd, Nr_simu = forward_comp(pos, U, B, ucell, pars, ds_max = ds_max, rot_start = rot_min, rot_end = rot_max, rot_step = rot_step, verbose = verbose)
         cf_matched, fwd_matched, ij, Completeness = find_matching_peaks(cf_strong, fwd, dsmax = ds_max, tol_angle=tol_angle, tol_pixel=tol_pixel)
         if thres_int is not None:
              cf_matched = cf_remove_weak_peaks(cf_matched, thres_int = thres_int)
@@ -60,9 +64,8 @@ def forward_match_peaks(cf_strong, grains, ds, ucell, pars, ds_max = 2.0, tol_an
         cf_matched_all.append(cf_matched)
     return cf_matched_all, Comp_all
     
-        
-    
-def forward_comp(pos, U, B, ucell, pars, ds_max = 1.2, rot_start = -91, rot_end = 91, rot_step = 0.05):
+
+def forward_comp(pos, U, B, ucell, pars, ds_max = 1.2, rot_start = -91, rot_end = 91, rot_step = 0.05, verbose = 1):
     """
     Given pos, U, B, ucell, pars, forward calculate the expected intersection position on the detector.
 
@@ -76,6 +79,7 @@ def forward_comp(pos, U, B, ucell, pars, ds_max = 1.2, rot_start = -91, rot_end 
     rot_start -- starting omega angle [deg]
     rot_step -- step size of the omega rotation [deg]
     rot_end -- end omega angle [deg]
+    verbose   -- verbose level for displaying print out
 
     Returns:
     fwd -- list of expected peak positions: [rot in degrees, hkl, 2-theta in degrees, Gt, dety, detz, dety_mm, detz_mm, HitDetFlag]
@@ -91,7 +95,7 @@ def forward_comp(pos, U, B, ucell, pars, ds_max = 1.2, rot_start = -91, rot_end 
     Ki = np.array([p['Energy']/econst, 0, 0]) # note that there is no 2*pi here
     Klen = np.linalg.norm(Ki) # [A^-1]
 
-    ds_all, hkls = get_hkls(ucell, dsmax = ds_max)
+    ds_all, hkls = get_hkls(ucell, dsmax = ds_max, verbose = verbose)
     
     Gw = np.dot(p['S'], np.dot(U, np.dot(B, hkls.T)))
     # Glen = np.sqrt(Gw[0, :]**2 + Gw[1, :]**2 + Gw[2, :]**2)
@@ -108,9 +112,10 @@ def forward_comp(pos, U, B, ucell, pars, ds_max = 1.2, rot_start = -91, rot_end 
         omega_all[i,:] = find_omega(a[i], b[i], c[i], d[i], sqD[i])
     if rot_start < 0:
         omega_all[omega_all > (2*np.pi + np.deg2rad(rot_start))] -= 2*np.pi # bring the omega solution from [0, 2*pi] to [rot_start, 2*pi+rot_start]
-        
-    print('Investigating {} possible omega angle solutions ...'.format(omega_all.shape))
-    print('Omega angle range: [{}, {}]'.format(np.rad2deg(np.nanmin(omega_all)), np.rad2deg(np.nanmax(omega_all))))
+    
+    if verbose >= 2:
+        logging.debug('Investigating {} possible omega angle solutions ...'.format(omega_all.shape))
+        logging.debug('Omega angle range: [{}, {}]'.format(np.rad2deg(np.nanmin(omega_all)), np.rad2deg(np.nanmax(omega_all))))
 
     # print(np.rad2deg(omega_all))
     # computation in lab system
@@ -125,9 +130,11 @@ def forward_comp(pos, U, B, ucell, pars, ds_max = 1.2, rot_start = -91, rot_end 
                 if HitDetFlag == True:
                     Nr_simu += 1
                 fwd.append([rot, hkls[ii,:], np.rad2deg(theta[ii])*2, Gt, dety, detz, dety_mm, detz_mm, HitDetFlag])
-                
-    print('Done! {} peaks expected on the detector by investigating {}*2 hkl reflections for rotation angle range between {} and {} degrees'.format(Nr_simu, hkls.shape[0], rot_start, rot_end))
-    print('fwd list contains: [rot in degrees, hkl, 2-theta in degrees, Gt, dety, detz, dety_mm, detz_mm, HitDetFlag]')
+    
+    if verbose >= 1:
+        logging.info('Done! {} peaks expected on the detector by investigating {}*2 hkl reflections for rotation angle range between {} and {} degrees'.format(Nr_simu, hkls.shape[0], rot_start, rot_end))
+    if verbose >= 2:
+        logging.debug('fwd list contains: [rot in degrees, hkl, 2-theta in degrees, Gt, dety, detz, dety_mm, detz_mm, HitDetFlag]')
     return fwd, Nr_simu
 
 
@@ -200,6 +207,80 @@ def forward_det_pos(pos, omega, Gw, theta, p):
     return dety, detz, dety_mm, detz_mm, Gt.T, HitDetFlag
 
 
+@njit
+def beam_attenuation(pos_lab, Lsam2det, dety_mm, detz_mm, Rsample = 0.3, Lsam2sou = 97e3, beam_name = 'pencil_beam', rou = 2.7, mass_abs = 0.5685):
+    """
+    calculate the beam path length along the sample
+    incoming beam length + outcoming diffracting beam length
+    diffraction occurring at (x,y,z)
+    I/I0 = exp(-mass_abs * rou * beam_length)
+    mass_abs: mass-energy absorption coefficient, obtained from e.g. NIST table [cm^2/g]
+    rou: density of the sample [g/cm^3]
+    beam_length: total length of the X-ray beam path in the sample
+    by default, values of mass_abs and rou is for Aluminium at 40 keV
+    
+    Args:
+        pos_lab (float): positions in lab coordinate system [mm]
+        Lsam2det (float): sample-to-detector distance [mm]
+        dety_mm (float): peak position Y [mm]
+        detz_mm (float): peak position Z [mm]
+        Rsample (float): sample radius [mm]
+        Lsam2sou (float): sample-to-source distance [mm]
+        beam_name (string): name of the beam shape, 'pencil_beam', 'cone_beam', 'parallel_beam'
+        rou (float): sample density [g/cm^3]
+        mass_abs (float): mass-energy absorption coefficient [cm^2/g]
+    Returns:
+        trans_factor (float): transmission factor to quantify I/I0
+        L_total (float): total length of the X-ray beam path in the sample [mm]
+    """
+    
+    # length of incoming beam path
+    if beam_name == 'cone_beam':
+        # conical beam case
+        if (Rsample**2 * (Lsam2sou + pos_lab[0])**2 + pos_lab[1]**2 * (Rsample**2 - Lsam2sou**2)) >= 0:
+            t1 = (Lsam2sou*(Lsam2sou + pos_lab[0]) - np.sqrt(Rsample**2 * (Lsam2sou+pos_lab[0])**2 +
+                 pos_lab[1]**2 * (Rsample**2 - Lsam2sou**2))) / ((Lsam2sou + pos_lab[0])**2 + pos_lab[1]**2)
+        else:
+            t1 = 1 - Rsample/Lsam2sou # approximate solution is used when Rsample is not accurately estimated
+        xn = -Lsam2sou + t1*(Lsam2sou+pos_lab[0])
+        yn = t1*pos_lab[1]
+        zn = t1*pos_lab[2]
+        L_NM = np.sqrt((xn-pos_lab[0])**2 + (yn-pos_lab[1])**2 + (zn-pos_lab[2])**2)
+    else:
+        # parallel beam case including point focused beam
+        if pos_lab[0] + Rsample/2 > 0:
+            L_NM = pos_lab[0] + Rsample/2
+        else:
+            L_NM = 0.0
+            
+    # length of diffracted beam path
+    if (2*pos_lab[0]*pos_lab[1]*(Lsam2det-pos_lab[0])*(dety_mm-pos_lab[1]) +
+        Rsample**2 * ((Lsam2det-pos_lab[0])**2 + (dety_mm-pos_lab[1])**2) -
+        pos_lab[0]**2 * (dety_mm-pos_lab[1])**2 - pos_lab[1]**2 * (Lsam2det-pos_lab[0])**2) >= 0:
+        
+        t2 = (-pos_lab[0]*(Lsam2det-pos_lab[0]) - pos_lab[1]*(dety_mm-pos_lab[1]) +
+             np.sqrt(2*pos_lab[0]*pos_lab[1] * (Lsam2det-pos_lab[0])*(dety_mm-pos_lab[1]) +
+             Rsample**2 * ((Lsam2det-pos_lab[0])**2 + (dety_mm-pos_lab[1])**2) -
+             pos_lab[0]**2 * (dety_mm-pos_lab[1])**2 - pos_lab[1]**2 * (Lsam2det-pos_lab[0])**2)) / ((Lsam2det-pos_lab[0])**2 + (dety_mm-pos_lab[1])**2)
+    elif Rsample >= np.abs(pos_lab[1]):
+        t2 = (-pos_lab[0] + np.sqrt(Rsample**2 - pos_lab[1]**2)) / Lsam2det # approximate solution is used when Rsample is not accurately estimated
+    else:
+        t2 = -pos_lab[0] / Lsam2det
+    xq1 = pos_lab[0] + t2*(Lsam2det-pos_lab[0])
+    yq1 = pos_lab[1] + t2*(dety_mm-pos_lab[1])
+    zq1 = pos_lab[2] + t2*(detz_mm-pos_lab[2])
+    L_MQ1 = np.sqrt((xq1-pos_lab[0])**2 + (yq1-pos_lab[1])**2 + (zq1-pos_lab[2])**2)
+
+    # total X-ray beam path in the sample
+    L_total = L_NM + L_MQ1 # [mm]
+    
+    # transmission factor
+    trans_factor = np.exp(- mass_abs * L_total * 0.1 * rou )
+
+    return trans_factor, L_total
+
+
+@njit
 def get_omega_matrix(omega):
     """
     Calculate the rotation matrix (Omega) for a rotation angle around Z vertical axis in right-hand coordinate system
@@ -212,6 +293,7 @@ def get_omega_matrix(omega):
     return omega_matrix
     
 
+@njit
 def find_omega(a, b, c, d, sqD):
     """
     Finds the omega (rotation angle) that generates the diffraction.
@@ -250,7 +332,7 @@ def find_omega(a, b, c, d, sqD):
     return Omega
 
 
-def get_hkls(ucell, dsmax = 1.2):
+def get_hkls(ucell, dsmax = 1.2, verbose = 1):
     """
     get hkl list from the ucell provided by ImageD11
 
@@ -284,8 +366,9 @@ def get_hkls(ucell, dsmax = 1.2):
         hkls.append(unique_arrays[key])
     ds_all = np.vstack(ds_all)
     hkls = np.vstack(hkls)
-    print('Got {} hkl lattice planes in total out of {} hkl families'.format(hkls.shape[0], ds_all.shape[0]))
-    print('ds range for {} hkl families: [{}, {}]'.format(ds_all.shape[0], np.min(ds_all), np.max(ds_all)))
+    if verbose >= 1:
+        logging.info('Got {} hkl lattice planes in total out of {} hkl families'.format(hkls.shape[0], ds_all.shape[0]))
+        logging.info('ds range for {} hkl families: [{}, {}]'.format(ds_all.shape[0], np.min(ds_all), np.max(ds_all)))
 
     return ds_all, hkls
                             
@@ -353,6 +436,7 @@ def find_matching_peaks(cf, fwd, dsmax=1.5, tol_angle=0.1, tol_pixel=0.55):
     fwd_tth = np.array([row[2] for row in fwd])
     fwd_fc = np.array([row[4] for row in fwd])
     fwd_sc = np.array([row[5] for row in fwd])
+    fwd_HitDetFlag = np.array([row[8] for row in fwd])
     
     # Vectorized differences
     diff_omega = np.abs(cf_omega[:, np.newaxis] - fwd_omega)
@@ -381,8 +465,8 @@ def find_matching_peaks(cf, fwd, dsmax=1.5, tol_angle=0.1, tol_pixel=0.55):
     ij = list(zip(matched_cf_indices, matched_fwd_indices))
     
     # Calculate the completeness
-    Completeness = len(fwd_matched) / len(fwd)
-    print('Found {}/{} matched peaks, completeness = {}'.format(len(fwd_matched), len(fwd), Completeness))
+    Completeness = len(fwd_matched) / np.where(fwd_HitDetFlag==True)[0].shape[0]
+    print('Found {}/{} matched peaks, completeness = {}'.format(len(fwd_matched), np.where(fwd_HitDetFlag==True)[0].shape[0], Completeness))
     
     return cf_matched, fwd_matched, ij, Completeness
 
@@ -463,6 +547,8 @@ def cf_set_difference(cf1, cf2, tol = 0.001):
     
     print('Found {}/{} different peaks for cf1'.format(cf1_diff.nrows, cf1.nrows))
     print('Found {}/{} different peaks for cf2'.format(cf2_diff.nrows, cf2.nrows))
+    
+    del cf1, cf2  # Removes the local references to free memory use
 
     return cf1_diff, cf2_diff
 

--- a/ImageD11/forward_model/forward_projector.py
+++ b/ImageD11/forward_model/forward_projector.py
@@ -1479,7 +1479,7 @@ def make_projs_and_sparse_file(fwd_peaks, destname, omega_angles, opts_seg, dete
     start = time.time()
     with h5py.File(destname, "w") as hout:
         print("# ", fwd_peaks.shape, destname)
-        print("# time now", time.ctime(), "\n#", end=" ")
+        print("# time now", time.ctime(), "\n#")
         g = hout.require_group(dataset)
         g.create_dataset("rot", data = omega_angles, dtype='float')
         g.create_dataset("rot_center", data = omega_angles, dtype='float')

--- a/ImageD11/forward_model/forward_projector.py
+++ b/ImageD11/forward_model/forward_projector.py
@@ -1575,7 +1575,7 @@ def segment_frms(frms, destname, opts_seg, detector = 'eiger'):
     start = time.time()
     with h5py.File(destname, "a") as hout:
         print("# ", frms.shape, destname)
-        print("# time now", time.ctime(), "\n#", end=" ")
+        print("# time now", time.ctime(), "\n#")
         g = hout.require_group(dataset)
         row = g.create_dataset("row", (0,), dtype=np.uint16, **opts)
         col = g.create_dataset("col", (0,), dtype=np.uint16, **opts)

--- a/ImageD11/forward_model/forward_projector.py
+++ b/ImageD11/forward_model/forward_projector.py
@@ -1592,9 +1592,9 @@ def segment_frms(frms, destname, opts_seg, detector = 'eiger'):
         for i, spf in enumerate(reader_frms(frms, detector_mask, opts_seg)):
             if i % 100 == 0:
                 if spf is None:
-                    print("%4d 0" % (i), end=",")
+                    print("%4d 0, " % (i))
                 else:
-                    print("%4d %d" % (i, spf.nnz), end=",")
+                    print("%4d %d, " % (i, spf.nnz))
                 sys.stdout.flush()
             if spf is None:
                 nnz[i] = 0
@@ -1740,7 +1740,7 @@ def assemble_sparsefiles(sparsefiles_folder, dtys, outname_sparse = "fwd_sparse.
                 g.create_dataset("col", data = fsparse_pks['col'], dtype=np.uint16)
                 g.create_dataset("nnz", data = fsparse_pks['nnz'], dtype=np.uint32)
                 g.create_dataset("intensity", data = fsparse_pks['intensity'], dtype=g.attrs["itype"])
-            print(scan, end=", ")
+            print(scan, ", ")
         print()
     return outname_sparse
 

--- a/ImageD11/forward_model/forward_projector.py
+++ b/ImageD11/forward_model/forward_projector.py
@@ -1,0 +1,1830 @@
+# forward_projector.py
+# Providing beam, sample and forward projector to compute forward projected peaks, thus creating forward projected diffraction images, therefore cf_2d, cf_3d or cf_4d peaks
+# Beam shape and profile, sample structure factor (to be better computed), absorption, Lorentz, Polarization and detector point spread have all been considered
+# Suitable for both s3DXRD using pencil beam and box-beam 3DXRD
+# Haixing Fang, haixing.fang@esrf.fr
+# Jan 2nd, 2025
+# updated on January 30, 2025
+
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.colors import LogNorm
+
+from numba import njit
+from scipy.spatial import cKDTree
+from scipy.ndimage import gaussian_filter
+from sklearn.cluster import DBSCAN
+import h5py
+
+import os, sys
+import time
+import logging
+from tqdm import tqdm
+from joblib import Parallel, delayed
+import inspect
+import multiprocessing
+import tempfile
+
+from ImageD11.forward_model import forward_model
+from ImageD11.forward_model import grainmaps
+from ImageD11.forward_model import pars_conversion
+from ImageD11.forward_model import io
+
+import ImageD11.parameters
+import ImageD11.unitcell
+from ImageD11.sinograms import lima_segmenter
+from ImageD11.columnfile import colfile_to_hdf
+from ImageD11.columnfile import colfile_from_hdf
+from ImageD11.nbGui.nb_utils import slurm_submit_and_wait
+
+econst = 12.3984
+logging.basicConfig(level=logging.INFO, force=True)
+os.environ["JOBLIB_TEMP_FOLDER"] = "/tmp_14_days/slurm/log"
+
+"""
+The right-handed laboratory coodinate system is defined as follows:
+X - along the X-ray beam
+Y - transversely perpendicular to the X-ray beam and rotation axis, pointing outwards the synchrotron
+Z - vetical up
+omega - rotation about Z axis as positive direction defined as counter clock-wise when looking top-down on the diffractometer
+Note that length unit may be used as mm or um (for dty, y0_offset, beam size, voxel size etc.), see the comments for the variables
+"""
+
+class beam:
+    """
+    Beam class to define X-ray beam size, source-to-sample distance, wavelength, bandwidth and profile
+    Possible to create parallel box-beam, cone beam or pencil beam with different combinations
+    example:
+    ss = beam(Lss = 0, FWHM = [0.001, 0.001], energy = 43.56)   # pencil beam 0.001*0.001 mm^2
+    ss = beam(Lss = 97e3, FWHM = [0.5, 0.2], energy = 43.56)    # parallel box beam 0.5*0.2 mm^2
+    ss = beam(Lss = 10, FWHM = [0.001, 0.001], energy = 43.56)  # cone beam 0.001*0.001 mm^2
+    """
+    
+    def __init__(self, Lss = 0.0, FWHM = [0.001, 0.001], energy = 43.56, propagation_direction = [1, 0, 0], bandwidth = 0.001,
+                       polarization = [0, 0.95, 0], flux = 5e14, beam_profile = "gaussian", cutoff = 0.1):
+
+        self.Lss = Lss       # source-to-rotation axis distance [mm]
+        self.FWHM = FWHM     # FWHM dimensions in width x height [mm^2]
+        self.energy = energy # X-ray energy [keV]
+        self.wavelength = econst / energy # X-ray wavelength [angstrom]
+        self.propagation_direction = np.array(propagation_direction) # X-ray direction, along X
+        self.bandwidth = bandwidth
+        self.polarization = polarization      # along Y axis by default
+        self.flux = flux / (FWHM[0]*FWHM[1])  # flux at sample position [photons/s/mm^2]
+        self.beam_profile = beam_profile      # name of beam profile function, "gaussian", "lorentzian", "pseudo voigt"
+        self.cutoff = cutoff                  # cutoff value for considering intensity/weight
+        
+        self.wave_vector = ((2 * np.pi / self.wavelength) * self.propagation_direction / np.linalg.norm(self.propagation_direction))
+        
+        if self.Lss > 5e3:
+            self.name = 'parallel_beam'     # including box and line-beam
+        elif self.Lss >= 0.5 and self.Lss < 100 and self.FWHM[0] < 0.01 and self.FWHM[1] < 0.01:
+            self.name = 'cone_beam'
+        elif self.Lss < 0.02 and self.FWHM[0] < 0.01 and self.FWHM[1] < 0.01:
+            self.name = 'pencil_beam'
+            if self.FWHM[0] >= 0.5 or self.FWHM[1] >= 0.5:
+                self.FWHM[0] /= 1000.0   # guess the input FWHM was wrongly input as in um, now it is corrected to be in [mm]
+                self.FWHM[1] /= 1000.0
+            self.set_beam_shape()
+        else:
+            self.name = None
+            print('Beam character cannot be identified; Only supporting parallel, cone and pencil beam for now !')
+    
+    def set_beam_spectrum(self, plot_flag = False):
+        """
+        set beam spectrum by considering the bandwidth
+        NOTE: this has not been considered in the forward computation yet
+        """
+        Energy_spectra = np.linspace(self.energy * (1 - self.bandwidth), self.energy * (1 + self.bandwidth), 1000)  # Photon energy [keV]
+        Int_spectra = self.flux * 1 / (2 * np.pi * self.bandwidth) * np.exp(-(Energy_spectra - self.energy) ** 2 / (2 * self.bandwidth ** 2))
+        print(Energy_spectra.shape)
+        print(type(Int_spectra))
+        self.spectrum = np.vstack([Energy_spectra, Int_spectra]).T
+        if plot_flag:
+            plt.figure()
+            plt.plot(self.spectrum[:,0], self.spectrum[:,1],'r.', linewidth=1, markersize=6)
+            plt.xlabel('X-ray energy (keV)', fontsize = 16)
+            plt.ylabel('Intensity (a.u.)', fontsize = 16)
+            plt.tick_params(axis='both', which='major', labelsize=14, width=1.5, length=4)
+            plt.show()
+
+    def set_beam_shape(self, plot_flag = False):
+        """
+        beam shape is used as weights for scaling the voxel contribution as a function of its distance to the ray center and source intensity scaling factor, i.e. two effects
+        Gaussian, Lorentzian and pseudo_voigt profiles are available
+        """
+        x = np.arange(0, 5*np.mean(self.FWHM), np.mean(self.FWHM)/3.0) # 5 times of the beam FWHM is considered as potential effective width for interacting with the sample
+        if self.beam_profile.lower() in "gaussian":
+            intensities = self.gaussian(x)
+        elif self.beam_profile.lower() in "lorentzian":
+            intensities = self.lorentzian(x)
+        elif self.beam_profile.lower() in ["pseudo", "pseudo_voigt", "pseudo voigt"]:
+            intensities = self.pseudo_voigt(x, frac = 0.5)
+        else:
+            logging.info('{} not identified; I will use gaussian beam profile'.format(self.beam_profile))
+            self.beam_profile = "gaussian"
+            intensities = self.gaussian(x)
+        
+        indices = np.where(intensities > self.cutoff)[0]
+        self.weight_pos = x[indices] / np.mean(self.FWHM) + 0.5 # consider extra half pixel for the fact the pixel-center-to-ray-center distance can't tell smaller half distance
+        self.weight = intensities[indices]
+        if plot_flag:
+            plt.figure()
+            plt.plot(self.weight_pos, self.weight,'r.', linewidth=1, markersize=6)
+            plt.xlabel('Distance to the ray center / beam FWHM (-)', fontsize = 16)
+            plt.ylabel('Weight (a.u.)', fontsize = 16)
+            plt.tick_params(axis='both', which='major', labelsize=14, width=1.5, length=4)
+            plt.show()
+        
+    def gaussian(self, x):
+        """
+        Gaussian function for describing the beam profile, transformed to weights as a function of distance to the ray center.
+        Args:
+            x (array): distances, e.g. x = np.arange(0, 5, 20)
+        Returns:
+            intensities (array)
+        """
+        # back calculate the sigma value when we know the beam FWHM
+        sigma_squared = - np.mean(self.FWHM)**2 / (2*np.log(0.5))   # sigma^2
+        return np.exp(-((x - 0.0) ** 2) / (2 * sigma_squared))
+
+    def lorentzian(self, x):
+        """
+        Lorentzian function for describing the beam profile, translated to weights as a function of distance.
+        Args:
+            x (array): distances, e.g. x = np.arange(0, 5, 50)
+        Returns:
+            intensities (array)
+        """
+        gamma = np.mean(self.FWHM) / 2.0
+        return (gamma ** 2) / ((x - 0.0) ** 2 + gamma ** 2)
+
+    def pseudo_voigt(self, x, frac = 0.5):
+        """
+        Pseudo-Voigt function (combination of Gaussian and Lorentzian).
+        Args:
+            x (array): distances, e.g. x = np.arange(0, 5, 50)
+            frac (float): fraction of lorentzian part
+        Returns:
+            intensities (array)
+        """
+        assert frac >= 0 and frac <= 1, "frac must be in [0, 1]"
+        intensities_gaussian = self.gaussian(x)
+        intensities_lorentzian = self.lorentzian(x)
+        return frac * intensities_lorentzian + (1 - frac) * intensities_gaussian   
+
+
+class sample:
+    """
+    Sample class to define the sample illuminated by the X-ray beam
+    It can be obtained from experimentally reconstructed sample (available for now) or virtually created sample (TODO)
+    """
+    def __init__(self, filename = None, outname = None, min_misori = 3, crystal_system = 'cubic', dis_tol = np.sqrt(3), remove_small_grains = True, min_vol = 3):
+        self.filename = filename
+        self.outname = outname
+        if self.outname is None and self.filename is not None:
+            self.outname = os.path.join(os.path.split(self.filename)[0], 'DS.h5')
+        self.min_misori = min_misori
+        self.crystal_system = crystal_system
+        self.dis_tol = dis_tol
+        self.remove_small_grains = remove_small_grains
+        self.min_vol = min_vol
+        print('****************************************** Parameters for operating the grain map: ')
+        print('Output file name: {}'.format(self.outname))
+        print('min_misori = {}'.format(self.min_misori))
+        print('crystal_system: {}'.format(self.crystal_system))
+        print('dis_tol: {}'.format(self.dis_tol))
+        print('remove_small_grains = {}'.format(self.remove_small_grains))
+        print('min_vol = {} voxels'.format(self.min_vol))
+        if self.filename is not None:
+            self.read_grainmap()
+            self.get_Rsample()
+        else:
+            self.DS = None
+           
+    def set_rou(self, rou = 2.7):
+        'set sample density [g/cm^3]'
+        self.rou = rou # default for Al
+    
+    def set_mass_abs(self, mass_abs = 0.5685):
+        'set mass-energy absorption coefficient [cm^2/g]'
+        self.mass_abs = mass_abs # default for Al at 40 keV
+    
+    def get_Rsample(self):
+        'get sample radius by assuming a cylinder-like sample shape from the grain map dimensions [mm]'
+        try:
+            ind_mask = np.argwhere(self.DS['labels'] > -1)
+            Rsample = np.linalg.norm( ind_mask[-1,:] - ind_mask[0,:] ) * np.mean(self.DS['voxel_size'][1:3]) / 2000.0  # [mm]           
+            self.Rsample = Rsample
+        except KeyError as e:
+            print("Key error: {}".format(e))
+        except Exception as e:
+            print("An unexpected error occurred: {}".format(e))
+    
+    def read_grainmap(self):
+        # read grain map from different types of files: pbp_tensormap_refined.h5, xxx_grains.h5 or DS.h5
+        if "DS" in self.filename:
+            # first try with DS
+            try:
+                self.read_DS()
+                logging.info("DS file '{}' loaded successfully".format(self.filename))
+            except Exception as e1:
+                logging.info("An unexpected error occurred: {}".format(e1))
+                try:
+                    # attempt to read the input of a tensor map from pbp_tensormap_refined.h5 or xxx_grains.h5
+                    self.read_tensormap()
+                    logging.info("Tensor map '{}' loaded successfully".format(self.filename))
+                except Exception as e2:
+                    logging.info("Failed to load tensor map: {}".format(e2))
+        else:
+            try:
+                # attempt to read the input of a tensor map from pbp_tensormap_refined.h5 or xxx_grains.h5
+                self.read_tensormap()
+                logging.info("Tensor map '{}' loaded successfully".format(self.filename))
+            except Exception as e1:
+                logging.info("Failed to load tensor map: {}".format(e1))
+                try:
+                    # attempt to read the input of a DS like file, e.g. DS.h5
+                    self.read_DS()
+                    logging.info("DS file '{}' loaded successfully".format(self.filename))
+                except Exception as e2:
+                    logging.info("Failed to load DS file: {}".format(e2))
+                    raise RuntimeError("Unable to load input as either a tensor map or a DS file.")   
+    
+    def read_DS(self):
+        self.DS = io.read_h5_file(self.filename)
+        
+    def read_tensormap(self):
+        # support s3DXRD outputs such as pbp_tensormap_refined.h5, xxx_grains.h5
+        gm = grainmaps.grainmap(filename = self.filename, min_misori = self.min_misori,
+                                crystal_system = self.crystal_system, remove_small_grains = self.remove_small_grains, min_vol = self.min_vol)
+        gm.merge_and_identify_grains(dis_tol = self.dis_tol)
+        self.DS = gm.DS
+        
+    def write_DS(self):
+        """
+        write DS to an h5 file with filename defined as self.outname'
+        """
+        if not self.outname.endswith(('.h5', '.hdf5')):
+            self.outname = self.outname + '.h5'
+        
+        with h5py.File(self.outname, 'w') as hout:
+            for key, value in self.DS.items():
+                hout.create_dataset(key, data = value)
+        print('Done with saving DS to {}'.format(self.outname))
+        
+    """
+    TODO
+    Virtually creating microstructure as DS-like data
+    """
+
+
+class forward_projector:
+    """
+    forward_projector class to compute forward diffraction patterns for a given X-ray beam illuminating a sample
+    """
+    def __init__(self, sample_filename, pars_filename, phase_name, output_folder = None, gids_mask = None,
+                 verbose = 1, auto_set = True, detector_mask = None, to_sparse = False, read_fwd_peaks_from_file = True, **kwargs):
+        """
+        Providing sample_filename, pars_filename, phase_name etc to set the forward_projector.
+        if auto_set is True, it will automatically set the inputs of the beam and sample, as well as acquisition parameters
+        
+        For computing fwd_peaks for selected grains, use gids_mask for the grains of interest;
+        For accounting the detector mask, input detector_mask (2D array), where 1 for active and 0 for inactive
+        """
+        # get essential input arguments
+        self.sample_filename = sample_filename       # sample file name, e.g. pbp_tensormap_refined.h5, xxx_grains.h5 or DS.h5
+        self.pars_filename = pars_filename           # ImageD11 parameter file, normally pars.json
+        self.phase_name = phase_name                 # phase name specified in the pars.json, e.g. "Al"
+        if output_folder is None:
+            output_folder = os.path.join(os.getcwd(), "output_fwd")
+        self.output_folder = output_folder
+        if not os.path.exists(self.output_folder):
+            os.makedirs(self.output_folder)
+        self.gids_mask = gids_mask                   # grain IDs for masking the sample
+        self.verbose = verbose                       # logging level, 0, 1 or 2
+        self.auto_set = auto_set
+        self.to_sparse = to_sparse
+        self.detector_mask = detector_mask
+        self.read_fwd_peaks_from_file = read_fwd_peaks_from_file  # if the pwd_peaks file already exists, it will read directly from the file without the need to compute again
+        self.cf_2d_file = os.path.join(self.output_folder, 'fwd_cf_2d.h5')
+        self.cf_3d_file = os.path.join(self.output_folder, 'fwd_cf_3d.h5')
+        self.cf_4d_file = os.path.join(self.output_folder, 'fwd_cf_4d.h5')
+        
+        # get other optional input arguments
+        args = {
+        "energy": kwargs.get("energy", 43.56),                 # [keV]
+        "beam_size": kwargs.get("beam_size", [1e-3, 1e-3]),    # [mm]
+        "beam_profile": kwargs.get("beam_profile", "gaussian"),# [-]
+        "flux": kwargs.get("flux", 5e14),                      # [photons/s]
+        "Lss": kwargs.get("Lss", 0.0),                         # [mm]
+        "min_misori": kwargs.get("min_misori", 3.0),           # [deg]
+        "crystal_system": kwargs.get("crystal_system", 'cubic'),
+        "remove_small_grains": kwargs.get("remove_small_grains", True),
+        "min_vol": kwargs.get("min_vol", 3),                   # [voxel]
+        "rou": kwargs.get("rou", 2.7),                         # [g/cm^3]
+        "mass_abs": kwargs.get("mass_abs", 0.56685),           # [cm^2/g]
+        "y0_offset": kwargs.get("y0_offset", 0.0),             # [um]
+        "exp_time": kwargs.get("exp_time", 0.002),             # [s]
+        "rot_start": kwargs.get("rot_start", -89.975),         # [deg]
+        "rot_end": kwargs.get("rot_end", 90.9668),             # [deg]
+        "rot_step": kwargs.get("rot_step", 0.05),              # [deg]
+        "sparse_omega": kwargs.get("sparse_omega", True),
+        "halfy": kwargs.get("halfy", 182.0),                   # [um]
+        "dty_step": kwargs.get("dty_step", 1.0),               # [um]
+        "ds_max": kwargs.get("ds_max", 1.2),                   # [1/angstrom]
+        "plot_peaks": kwargs.get("plot_peaks", False),
+        "plot_flag": kwargs.get("plot_flag", False),
+        "detector": kwargs.get("detector", "eiger"),
+        "int_factors": kwargs.get("int_factors", (0.1065, 0.7807, 0.1065)),
+        "dety_merge_range": kwargs.get("dety_merge_range", 10), # within this range 2D peaks will be merged if the signal comes from the same reflection [pixel]
+        "detz_merge_range": kwargs.get("detz_merge_range", 10), # within this range 2D peaks will be merged if the signal comes from the same reflection [pixel]
+        "use_cluster": kwargs.get("use_cluster", True),
+        "slurm_folder": kwargs.get("slurm_folder", "slurm_fwd_proj")
+        }
+        
+        self.args = args
+        if self.verbose >= 1:
+            logging.info("Got the following optional arguments: {}".format(self.args))
+            logging.info("Output folder: {}".format(self.output_folder))
+        if self.auto_set:
+            self.set_all()
+            # update energy and the beam source
+            self.args["energy"] = econst / self.pars.parameters['wavelength']
+            self.set_beam()
+            if self.verbose >= 1:
+                logging.info("Updated X-ray energy = {} keV".format(self.args["energy"]))
+    
+    def set_all(self):
+        """
+        set all the inputs for the projector: beam, sample, pars, mask and acquisition.
+        """
+        self.set_beam()
+        self.set_sample()
+        self.set_pars()
+        self.set_sample_mask()
+        self.set_acquisition()
+        self.set_opts_seg()
+        self.set_image_size()
+    
+    def set_beam(self):
+        """
+        set the X-ray beam source, including beam energy, FWHM, flux, shape, source-to-sample distance, name etc.
+        """
+        self.beam_input = beam(energy = self.args['energy'], FWHM = self.args['beam_size'], flux = self.args['flux'], Lss = self.args['Lss'], beam_profile = self.args['beam_profile'])
+        
+    def set_sample(self):
+        """
+        set the sample properties: including the grain map, voxel size, .
+        """
+        self.sample_input = sample(self.sample_filename, min_misori = self.args['min_misori'], crystal_system = self.args['crystal_system'],
+                                      remove_small_grains = self.args['remove_small_grains'], min_vol = self.args['min_vol'])    
+        self.sample_input.set_rou(rou = self.args['rou'])
+        self.sample_input.set_mass_abs(mass_abs = self.args['mass_abs'])
+    
+    def set_pars(self):
+        """
+        set the parameter file.
+        """
+        self.pars = ImageD11.parameters.read_par_file(self.pars_filename)
+        phases = ImageD11.unitcell.Phases(self.pars_filename)
+        if self.verbose >= 1:
+            logging.info("Got phases: {} and phase name: {}".format(phases, self.phase_name))
+        self.ucell = ImageD11.unitcell.unitcell(phases.unitcells[self.phase_name].lattice_parameters, phases.unitcells[self.phase_name].spacegroup)
+        
+    def set_sample_mask(self):
+        """
+        set sample mask for computation by grain IDs (gids_mas)
+        Args:
+            gids (list): a list of grain IDs for making the mask, i.e. only these grains are considered for computation
+        """
+        if self.gids_mask is not None:
+            for i, gid_mask in enumerate(self.gids_mask):
+                if i == 0:
+                    mask = (self.sample_input.DS['labels'] == gid_mask) & (~np.isnan(self.sample_input.DS['U'][:, :, :, 0, 0]))
+                else:
+                    mask += (self.sample_input.DS['labels'] == gid_mask) & (~np.isnan(self.sample_input.DS['U'][:, :, :, 0, 0]))
+            mask = np.moveaxis(mask, 0, 2)
+            self.sample_mask = mask
+        else:
+            self.sample_mask = None
+    
+    def set_acquisition(self):
+        """
+        set acquisition parameters: omega angles and dty range for scanning 3DXRD or box-beam 3DXRD
+        """
+        # set omega angles, for computing the peaks omega step can be larger, e.g. 0.5 deg for accelerating the computation
+        self.omega_angles = np.arange(self.args['rot_start'], self.args['rot_end']+self.args['rot_step']/2.0, self.args['rot_step'])
+        self.omega_angles_sparse = np.arange(self.args['rot_start'], self.args['rot_end']+self.args['rot_step']/2.0, np.max([self.args['rot_step'], 0.5]))
+        
+        if not hasattr(self, 'beam_input'):
+            self.set_beam()            
+        if self.beam_input.name == 'pencil_beam':
+            self.set_dty(scanning_mode = True)   # a list of dty position for scanning
+        else:
+            self.set_dty(scanning_mode = False)  # only 1 dty position if it is not in scanning mode
+            
+    def set_dty(self, scanning_mode = True):
+        """
+        set dty range for data collection
+        """
+        if scanning_mode:
+            halfy = np.abs(self.args['halfy'])
+            dty_step = np.abs(self.args['dty_step'])
+            self.dtys = np.arange(-halfy, halfy+dty_step/2.0, dty_step)
+            if self.verbose >= 1:
+                logging.info("dty range: [{} {}] with {} step size (um)".format(self.dtys[0], self.dtys[-1], dty_step))
+        else:
+            self.dtys = [0.0,]
+            if self.verbose >= 1:
+                logging.info("Not scanning mode !!! dtys = {} (um)".format(self.dtys))
+                
+    def set_opts_seg(self, bg = None, cut = 1, pixels_in_spot = 1):
+        """
+        set segmentation parameters
+        """
+        self.opts_seg = get_opts_seg(mask = self.detector_mask, bg = bg, cut = cut, pixels_in_spot = pixels_in_spot)
+        
+    def set_image_size(self):
+        """
+        set image size for the projection images
+        """
+        p = pars_conversion.convert_ImageD11pars2p(self.pars)
+        self.image_size = (p['detysize'], p['detzsize'])
+    
+    def run_all(self):
+        """
+        run all dty positions with forward projection either on cluster or on local machine
+        """
+        if self.args['use_cluster']:
+            bash_script_path = self.generate_slurm_script()
+            print("Submitted {} SLURM jobs for dty computation.".format(bash_script_path))
+            slurm_submit_and_wait(bash_script_path, wait_time_sec=60)
+        else:
+            self.run_series_dty()
+        
+    def run_series_dty(self, dtys = None):
+        """
+        run multiple dty positions with forward projection
+        Args:
+            dty (None or list): None means run all the dty positions in the class
+        """
+        if dtys is None:
+            dtys = self.dtys
+        for i, dty in enumerate(dtys):
+            self.run_single_dty(dty)
+            if self.verbose >=1 and (i > 1 and i % 10 == 0):
+                logging.info("Done for {} / {} dty steps".format(i, len(dtys)))
+                
+    def run_single_dty(self, dty = 0.0):
+        """
+        run single dty forward projection
+        computing time: ~12 s for computing fwd_peaks and ~25 s for segmenting and generating peak sparse file for 3620 omega angles for 361*361 grain map
+        """
+        if not os.path.exists(self.output_folder):
+            os.makedirs(self.output_folder)
+        if self.args['sparse_omega']:
+            omega_angles_to_calc = self.omega_angles_sparse
+        else:
+            omega_angles_to_calc = self.omega_angles
+        # check existence of fwd_peaks_file and reads it from file if exists
+        fwd_peaks_exists = False
+        fwd_peaks_3d_exists = False
+        if self.read_fwd_peaks_from_file:
+            fwd_peaks_file = os.path.join(self.output_folder, 'fpks_dty_' + str(round(dty, 2)).replace('.', 'p') + '.h5')
+            if os.path.exists(fwd_peaks_file):
+                fwd_peaks = io.read_fwd_peaks(fwd_peaks_file, verbose=self.verbose)
+                fwd_peaks_exists = True
+                
+            fwd_peaks_3d_file = os.path.join(self.output_folder, 'fpks_3d_dty_' + str(round(dty, 2)).replace('.', 'p') + '.h5')
+            if os.path.exists(fwd_peaks_3d_file):
+                fwd_peaks_3d = io.read_fwd_peaks(fwd_peaks_3d_file, verbose=self.verbose)
+                fwd_peaks_3d_exists = True
+        
+        # Compute fwd_peaks
+        if not fwd_peaks_exists:
+            fwd_peaks = forward_peaks_voxels(self.beam_input, self.sample_input, omega_angles_to_calc, self.ucell, self.pars, dty = dty, mask = self.sample_mask,
+                         ds_max = self.args['ds_max'], exp_time = self.args['exp_time'], plot_peaks = self.args['plot_peaks'],
+                         verbose = self.verbose, use_cluster = self.args['use_cluster'], y0_offset = self.args['y0_offset'], plot_flag = self.args['plot_flag'], detector = self.args['detector'])
+        # write fwd_peaks
+        if fwd_peaks.size > 0:
+            # merge 2D peaks to 3D peaks
+            if not fwd_peaks_3d_exists:
+                fwd_peaks_3d, clusters = merge_rows(fwd_peaks, columns_to_cluster=[0, 9, 12, 13, 14, 18, 19],
+                                                    epsilons=[0.1, 2, 0.1, 0.1, 0.1, self.args['dety_merge_range'], self.args['detz_merge_range']],
+                                                    special_col_index=23, min_samples = 1, weighted_avg=True)
+                io.write_fwd_peaks(fwd_peaks_3d, output_folder=self.output_folder, fname_prefix='fpks_3d', verbose=self.verbose)
+            if not fwd_peaks_exists:
+                io.write_fwd_peaks(fwd_peaks, output_folder=self.output_folder, fname_prefix=None, verbose=self.verbose)
+                
+            if self.to_sparse:
+                # processing frame-by-frmae by making the projection and immediately segmenting sparse peaks
+                # ~32 s for 3620 omega angles, 3.6 times faster
+                destname = os.path.join(self.output_folder, 'fsparse_dty_' + str(round(dty, 2)).replace('.', 'p') + '.h5')
+                make_projs_and_sparse_file(
+                    fwd_peaks,
+                    destname,
+                    self.omega_angles,
+                    self.opts_seg,
+                    detector_mask = self.detector_mask,
+                    detector = self.args['detector'],
+                    image_size=self.image_size,
+                    int_factors=self.args['int_factors']
+                )
+
+                # # an older version:  generate frames over rotation angles and then segmenting, memory consuming and too slower
+                # # ~80 s (making projs) + 34 s (segmenting peaks) for 3620 projs
+                # frms, _ = make_projections_with_psf(
+                #     fwd_peaks,
+                #     self.omega_angles,
+                #     image_size=self.image_size,
+                #     detector=self.args['detector'],
+                #     int_factors=self.args['int_factors']
+                # )
+                # segment_frms(frms, destname, detector=self.args['detector'], opts_seg = self.opts_seg)
+        else:
+            print("No peaks expected for dty = {}".format(dty))
+    
+
+    def generate_slurm_script(self, script_name="fwd_projector_slurm.sh"):
+        """
+        Generate a SLURM submission script to run `run_series_dty` with grouped dty values.
+
+        Args:
+            script_name (str): Name of the SLURM script file.
+
+        Returns:
+            str: Path to the generated SLURM script.
+        """
+        slurm_folder = self.args['slurm_folder']
+        if not os.path.exists(slurm_folder):
+            os.makedirs(slurm_folder)
+        id11_code_path = get_ImageD11_code_path()
+        # Split dty values into `num_groups` parts
+        num_groups = np.min([int(len(self.dtys) / 15), 40])
+        dty_groups = np.array_split(self.dtys, num_groups)
+        if self.verbose >= 1:
+            logging.info('Got {} dty values'.format(len(self.dtys)))
+            logging.info("All dty positions will be divided into {} jobs and each job computes about {} dty values".format(num_groups, dty_groups[0].shape[0]))
+
+        bash_script_path = os.path.join(slurm_folder, script_name)
+        outfile_path = os.path.join(slurm_folder, "fp_slurm_%A_%a.out")
+        errfile_path = os.path.join(slurm_folder, "fp_slurm_%A_%a.err")
+        log_path = os.path.join(slurm_folder, "fp_slurm")
+
+        # Create a temporary file to store dty groups for safer parsing
+        dty_file_list = os.path.join(slurm_folder, "dty_groups.txt")
+        with open(dty_file_list, "w") as f:
+            for group in dty_groups:
+                f.write(" ".join(map(str, group)) + "\n")
+        
+        bash_script_string = """#!/bin/bash
+#SBATCH --job-name=fwd_projector
+#SBATCH --output={outfile_path}
+#SBATCH --error={errfile_path}
+#SBATCH --partition=nice
+#SBATCH --array=1-{num_groups}
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=300G
+#SBATCH --time=01:00:00
+
+date
+source /cvmfs/hpc.esrf.fr/software/packages/linux/x86_64/jupyter-slurm/latest/envs/jupyter-slurm/bin/activate
+log_path="{log_path}_${{SLURM_JOB_ID}}_${{SLURM_ARRAY_TASK_ID}}.log"
+dty_file="{dty_file_list}"
+dty_values=$(sed -n "${{SLURM_ARRAY_TASK_ID}}p" $dty_file)
+echo "OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 PYTHONPATH={id11_code_path}" >> $log_path 2>&1
+OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 PYTHONPATH={id11_code_path} \
+python3 -c "from ImageD11.forward_model import forward_projector; \
+fp = forward_projector.forward_projector(sample_filename='{sample_filename}', pars_filename='{pars_filename}', \
+phase_name='{phase_name}', output_folder='{output_folder}', gids_mask={gids_mask}, \
+verbose={verbose}, auto_set={auto_set}, detector_mask={detector_mask}, to_sparse={to_sparse}, \
+read_fwd_peaks_from_file={read_fwd_peaks_from_file}, **{args}); \
+fp.run_series_dty([float(v) for v in '$dty_values'.split()])" >> $log_path 2>&1
+date""".format(
+            outfile_path=outfile_path,
+            errfile_path=errfile_path,
+            num_groups=num_groups,
+            dty_file_list=dty_file_list,
+            log_path=log_path,
+            id11_code_path=id11_code_path,
+            sample_filename=self.sample_filename,
+            pars_filename=self.pars_filename,
+            phase_name=self.phase_name,
+            output_folder=self.output_folder,
+            gids_mask=self.gids_mask,
+            verbose=self.verbose,
+            auto_set=self.auto_set,
+            detector_mask=self.detector_mask,
+            to_sparse=self.to_sparse,
+            read_fwd_peaks_from_file=self.read_fwd_peaks_from_file,
+            args=self.args
+        )
+        with open(bash_script_path, "w") as f:
+            f.writelines(bash_script_string)
+
+        print("Done with writing bash script in", bash_script_path)
+        return bash_script_path
+
+    
+    def get_cf(self, dtys = None):
+        """
+        gather peaks from file for a given list of dty values and convert them to cf object using ImageD11.sinograms.dataset.colfile_from_dict
+        by default, gather all peaks from all the files existing in the self.output_folder
+        """
+        self.peaks_2d = []
+        self.peaks_3d = []
+        if dtys is None:
+            # gather all peaks
+            dtys = self.dtys
+        for dty in dtys:
+            # 2D peaks
+            fwd_peaks_file = os.path.join(self.output_folder, 'fpks_dty_' + str(round(dty, 2)).replace('.', 'p') + '.h5')
+            if os.path.exists(fwd_peaks_file):
+                self.peaks_2d.append( io.read_fwd_peaks(fwd_peaks_file, verbose=0) )
+            else:
+                if self.verbose >= 1:
+                    logging.info("{} not found ...".format(fwd_peaks_file))
+            # 3D peaks
+            fwd_peaks_3d_file = os.path.join(self.output_folder, 'fpks_3d_dty_' + str(round(dty, 2)).replace('.', 'p') + '.h5')
+            if os.path.exists(fwd_peaks_3d_file):
+                self.peaks_3d.append( io.read_fwd_peaks(fwd_peaks_3d_file, verbose=0) )
+            else:
+                if self.verbose >= 1:
+                    logging.info("{} not found ...".format(fwd_peaks_3d_file))
+
+        if len(self.peaks_2d) > 0:
+            self.peaks_2d = np.vstack(self.peaks_2d)
+            self.cf_2d = io.convert_fwd_peaks_to_cf(self.peaks_2d)
+            if self.verbose >= 1:
+                logging.info("Got cf_2d !")
+        else:
+            print("No peaks_2d is found")
+        if len(self.peaks_3d) > 0:
+            self.peaks_3d = np.vstack(self.peaks_3d)
+            self.cf_3d = io.convert_fwd_peaks_to_cf(self.peaks_3d)
+            if self.verbose >= 1:
+                logging.info("Got cf_3d !")
+        else:
+            print("No peaks_3d is found")
+            
+    def get_cf_4d(self):
+        """
+        merge 2D/3D peaks to 4D by merging dty
+        """
+        if not (hasattr(self, 'peaks_3d') and self.peaks_3d.size > 0):
+            self.read_cf()
+        # assemble to 4D peaks by merging dty for 3D peaks
+        self.peaks_4d, _ = merge_rows(self.peaks_3d, columns_to_cluster=[0, 8, 12, 13, 14],
+                                            epsilons=[0.1, 200*self.args['dty_step'], 0.1, 0.1, 0.1],
+                                            special_col_index=23, min_samples = 1, weighted_avg=True)
+        self.cf_4d = io.convert_fwd_peaks_to_cf(self.peaks_4d)
+        colfile_to_hdf(self.cf_4d, self.cf_4d_file)
+
+    def read_cf(self):
+        """
+        read peaks from h5 file, using ImageD11.columnfile.colfile_from_hdf
+        """
+        if os.path.exists(self.cf_2d_file):
+            self.cf_2d = colfile_from_hdf(self.cf_2d_file)
+            self.peaks_2d = io.convert_cf_to_fwd_peaks(self.cf_2d)
+            if self.verbose >= 1:
+                logging.info('loaded 2D peaks from {}'.format(self.cf_2d_file))
+            if os.path.exists(self.cf_2d_file):
+                self.cf_3d = colfile_from_hdf(self.cf_3d_file)
+                self.peaks_3d = io.convert_cf_to_fwd_peaks(self.cf_3d)
+                if self.verbose >= 1:
+                    logging.info('loaded 3D peaks from {}'.format(self.cf_3d_file))
+                if os.path.exists(self.cf_4d_file):
+                    self.cf_4d = colfile_from_hdf(self.cf_4d_file)
+                    self.peaks_4d = io.convert_cf_to_fwd_peaks(self.cf_4d)
+                    if self.verbose >= 1:
+                        logging.info('loaded 4D peaks from {}'.format(self.cf_4d_file))   
+        else:
+            self.get_cf()
+
+    def write_cf(self):
+        """
+        write 2D, 3D and 4D peaks to h5 file, using ImageD11.columnfile.colfile_to_hdf
+        """
+        if hasattr(self, 'cf_2d') and self.cf_2d.dty.size > 0:
+            if not os.path.exists(self.cf_2d_file):
+                colfile_to_hdf(self.cf_2d, self.cf_2d_file)
+                if self.verbose >= 1:
+                    logging.info("Done with writing cf_2d !")
+            else:
+                print('{} already exists; Not overwriting it.'.format(self.cf_2d_file))
+        if hasattr(self, 'cf_3d') and self.cf_3d.dty.size > 0:
+            if not os.path.exists(self.cf_3d_file):
+                colfile_to_hdf(self.cf_3d, self.cf_3d_file)
+                if self.verbose >= 1:
+                    logging.info("Done with writing cf_3d !")
+            else:
+                print('{} already exists; Not overwriting it.'.format(self.cf_3d_file))
+        if hasattr(self, 'cf_4d') and self.cf_4d.dty.size > 0:
+            if not os.path.exists(self.cf_4d_file):
+                colfile_to_hdf(self.cf_4d, self.cf_4d_file)
+                if self.verbose >= 1:
+                    logging.info("Done with writing cf_4d !")
+            else:
+                print('{} already exists; Not overwriting it.'.format(self.cf_4d_file))
+                
+    def plot_cf(self, cf_type = '2d', m=None):
+        """
+        plot the sinogram of cf peaks, i.e. dty vs omega colored by peak intensity
+        """
+        plt.figure(figsize=(10,8))
+        if cf_type == '2d':
+            if m is None:
+                m = (self.cf_2d.grainID > -1)
+            if self.verbose >= 1:
+                logging.info('Got {} / {} peaks to plot'.format(np.where(m==True)[0].shape[0], self.cf_2d.nrows))
+            plt.hist2d( self.cf_2d.omega[m], self.cf_2d.dty[m], weights= np.log(self.cf_2d.sum_intensity[m]),
+                   bins = (self.omega_angles.shape[0], self.dtys.shape[0]), norm='log')
+        if cf_type == '3d':
+            if m is None:
+                m = (self.cf_3d.grainID > -1)
+            if self.verbose >= 1:
+                logging.info('Got {} / {} peaks to plot'.format(np.where(m==True)[0].shape[0], self.cf_3d.nrows))
+            plt.hist2d( self.cf_3d.omega[m], self.cf_3d.dty[m], weights= np.log(self.cf_3d.sum_intensity[m]),
+                   bins = (self.omega_angles.shape[0], self.dtys.shape[0]), norm='log')
+        if cf_type == '4d':
+            if m is None:
+                m = (self.cf_4d.grainID > -1)
+            if self.verbose >= 1:
+                logging.info('Got {} / {} peaks to plot'.format(np.where(m==True)[0].shape[0], self.cf_4d.nrows))
+            plt.hist2d( self.cf_4d.omega[m], self.cf_4d.dty[m], weights= np.log(self.cf_4d.sum_intensity[m]),
+                   bins = (self.omega_angles.shape[0], self.dtys.shape[0]), norm='log')
+        plt.colorbar(label="Log Intensity")
+        plt.xlabel("Omega ($^{o}$)")
+        plt.ylabel("dty ($\mu$m)")
+        plt.show()
+
+
+def forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty=0.0,
+                         mask=None, ds_max=1.2, exp_time = 0.002, plot_peaks = False,
+                         verbose=1, use_cluster = False, **kwargs):
+    """
+    Forward calculating the expected peaks on the peaks for a given beam and sample
+    For a given dty and beam size, first computed the list of intersected sample voxels with the ray;
+    Then, computed the possible peaks on the detector for each voxel
+    Suitable for both s3DXRD and box-beam 3DXRD
+    
+    Benchmark shows that this parallelized version is 11.4 times faster than non-parallelized version:
+    360 projs -> 16 s, 24 s with new beam profile
+    720 projs -> 40 s, 60 s with new beam profile
+    3600 projs -> 180 s, 312 s with new beam profile
+    
+    Args:
+        beam (class): beam class defining the beam properties
+        sample (class): sample class defining the sample properties
+        omega_angles (array): rotation angles sorted from small to big [deg]
+        ucell (object): ImageD11.unitcell.unitcell object, e.g. ucell = ImageD11.unitcell.unitcell([4.04761405231186, 4.04761405231186, 4.04761405231186, 90.0, 90.0, 90.0], 225)
+        pars (objected): ImageD11.parameters object, e.g. pars = ImageD11.parameters.read_par_file('/data/visitor/ma6288/id11/20241119/PROCESSED_DATA/nscope_pars/pars.json')
+        dty (float): rotation axis position, dty [um]
+        mask (3D array): mask of sample effective voxels
+        ds_max (float):  maximum 1/d
+        exp_time (float): exposure time [s]
+        plot_peaks (logic): flag for plotting peaks
+        **kwargs:
+        y0_offset (float): offset value of the sample when dty = 0, [um]
+        weight (array): weights of considering fractional contribution of the voxel for scaled to the distance-to-ray-center, determined by the beam FWHM and profile
+        weight_pos (array): distances corresponding to the weights, scaled by beam FHWM
+        plot_flag (logic): plot or not for intersected voxels
+        detector (string): detector name, 'eiger' by default
+        
+    Returns:
+        results: forward peaks expected on the detector
+    """
+    beampol = beam.polarization[1]
+    DS = sample.DS
+    if mask is None:
+        mask = (DS['labels'] > -1) & (~np.isnan(DS['U'][:, :, :, 0, 0]))
+        mask = np.moveaxis(mask, 0, 2)
+    Lsam2det = pars.get_parameters()['distance'] / 1000.0
+    rot_step = omega_angles[1] - omega_angles[0]
+    if rot_step < 0:
+        rot_step = -rot_step
+
+    args = {
+        "dty": dty,
+        "y0_offset": kwargs.get("y0_offset", 0.0),
+        "voxel_size": [DS['voxel_size'][2], DS['voxel_size'][1], DS['voxel_size'][0]],  # change to follow x, y, z order
+        "ray_size": np.mean(beam.FWHM) * 1000, # [um]
+        "weight": beam.weight,
+        "weight_pos": beam.weight_pos,
+        "plot_flag": kwargs.get("plot_flag", False),
+        "detector": kwargs.get("detector", "eiger"),
+    }
+    
+    # "loky" uses process-based parallelism, requiring data pickling (which is failing).
+    # "threading" uses thread-based parallelism, avoiding memory-mapped files, but very SLOW !!!
+    t0 = time.time()
+    results = Parallel(n_jobs=-1, backend="loky")(delayed(process_omega)(
+        omega, mask, DS, beam, sample, pars, ucell, rot_step, ds_max, Lsam2det, args, verbose
+    ) for omega in tqdm(omega_angles, desc="Processing omega angles"))
+
+    fwd_peaks = [item for sublist in results for item in sublist]
+    fwd_peaks = np.array(fwd_peaks)
+    # # Regarding multiprocessing.Pool, tried chunk, shared memory etc, it does not help to improve the speed
+    # set_tmp_dir()
+    # with multiprocessing.Pool(processes=min(multiprocessing.cpu_count(), 24)) as pool:
+    #     results = list(tqdm(pool.starmap(process_omega, [
+    #         (omega, mask, DS, beam, sample, pars, ucell, rot_step, ds_max, Lsam2det, args, verbose)
+    #         for omega in omega_angles
+    #     ]), total=len(omega_angles), desc="Processing omega angles"))
+    
+    # Flatten the nested list of results
+    # 0-4 grainID, voxel_indices(ZYX), weight(contributing to fraction of voxel and fraction of source intensity)
+    # 5-7 pos
+    # 8-14 dty, rot, tth, eta, hkl
+    # 15-19 gx, gy, gz, dety_pixel(fc), detz_pixel(sc)
+    # 20-22 Lorentz, Polarization, transmission factors
+    # 23-24 intensity, ds, append to the last column
+    fwd_peaks = [item for sublist in results for item in sublist]
+    fwd_peaks = np.array(fwd_peaks)
+    t1 = time.time()
+    if verbose >= 1:
+        logging.info("Computing dty = {} took {} seconds ...".format(dty, t1-t0))
+    
+    # sum of intensity: scalable with an arbitrary factor
+    Ahkls = ucell.gethkls(ds_max)  # a list of structure_factor + hkl
+    ds_values = np.array(find_ds_for_multiple_targets(Ahkls, fwd_peaks[:, 12:15]), dtype='float') # 1 / d-spacing
+    # TODO: make a structure_factor calculation given atomic sites and sint, see structure_factor.m in DCT code
+    structure_factor = 1.0/ds_values # there is no function to calculate structure factor, so take it proportional to 1/d* first for the moment
+    
+    Vcell = cellvolume(ucell.lattice_parameters)    # unit cell volume [angstrom^3]
+    Vvoxel = DS['voxel_size'][0] * DS['voxel_size'][1] * DS['voxel_size'][2] # voxel volume [um^3]
+    K1 = K1_calc()                                  # square of Thomson scattering lenth r0^2 [mm^2]
+    K2 = (pars.parameters['wavelength']**3) * fwd_peaks[:, 4]*Vvoxel * 1e12 / (Vcell**2)  # K2, dimensionless [-]
+    
+    # K1 * K2 * I0 * Lorentz * Polarization * trans_factor * structure_factor * exp_time
+    intensity = K1 * K2 * beam.flux * fwd_peaks[:, 4] * fwd_peaks[:, 20] * fwd_peaks[:, 21] * fwd_peaks[:, 22] * structure_factor * exp_time # [-]
+    
+    fwd_peaks = np.hstack([fwd_peaks, intensity.reshape(-1, 1)]) # append the 'intensity' to the last column for fwd_peaks
+    fwd_peaks = np.hstack([fwd_peaks, ds_values.reshape(-1, 1)]) # append 'ds_values' to the last column for fwd_peaks
+
+    # shift sampos_y back, remember to account for dty + y0_offset shift for reproducing fwd_peaks calculation
+    fwd_peaks[:,6] = fwd_peaks[:,6] + (-args['dty'] - args['y0_offset'])/1000.0 # sampos_y [mm]
+    
+    if plot_peaks:
+        plot_fwd_peaks(fwd_peaks)
+        
+    return fwd_peaks
+
+
+def process_omega(omega, mask, DS, beam, sample, pars, ucell, rot_step, ds_max, Lsam2det, args, verbose):
+    """
+    sub-function for processing one omega angle for forward_peaks_voxels
+    """
+    
+    intersected_sampos, intersected_labpos, intersected_voxels = intersected_sample_pos(mask, omega = omega, **args)
+    fwd_peaks = []
+    
+    if intersected_voxels is not None:
+        rot_start = omega - rot_step / 2
+        rot_end = omega + rot_step
+        for i in range(intersected_sampos.shape[0]):
+            pos = intersected_sampos[i, :]  # [mm]
+            ind_voxel = [int(intersected_voxels[i, 2]), int(intersected_voxels[i, 1]), int(intersected_voxels[i, 0])]
+            U = DS['U'][ind_voxel[0], ind_voxel[1], ind_voxel[2], :, :]
+            B = DS['B'][ind_voxel[0], ind_voxel[1], ind_voxel[2], :, :]
+            fwd, Nr_simu = forward_model.forward_comp(pos, U, B, ucell, pars, ds_max=ds_max, rot_start=rot_start, rot_end=rot_end, rot_step=rot_step, verbose=0)
+
+            if Nr_simu > 0 and fwd[0][8]:
+                Gt = fwd[0][3]
+                eta_rad = np.arccos(np.dot(np.array([0, Gt[1], Gt[2]]) / np.linalg.norm([0, Gt[1], Gt[2]]), np.array([0, 0, 1])))
+                if Gt[1] > 0:
+                    eta_rad = 2 * np.pi - eta_rad
+                eta = np.rad2deg(eta_rad)
+                rho_rad = eta_rad + np.pi / 2
+
+                tth_rad = np.deg2rad(fwd[0][2])
+                Lorentz = 1 / np.sin(tth_rad)
+                Polarization = (1 + np.cos(tth_rad) ** 2 - beam.polarization[1] * np.cos(2 * rho_rad) * np.sin(tth_rad) ** 2) / 2
+
+                dety_mm = fwd[0][6]
+                detz_mm = fwd[0][7]
+                trans_factor, L_total = forward_model.beam_attenuation(intersected_labpos[i, :], Lsam2det, dety_mm, detz_mm,
+                                                                     Rsample=sample.Rsample, beam_name=beam.name, rou=sample.rou, mass_abs=sample.mass_abs)
+
+                fwd_peaks.append([
+                    DS['labels'][ind_voxel[0], ind_voxel[1], ind_voxel[2]], ind_voxel[0], ind_voxel[1], ind_voxel[2], intersected_voxels[i, 4],  # 0-4 grainID, voxel_indices(ZYX), weight
+                    intersected_sampos[i, 0], intersected_sampos[i, 1], intersected_sampos[i, 2],  # 5-7 pos
+                    args["dty"], fwd[0][0], fwd[0][2], eta, fwd[0][1][0], fwd[0][1][1], fwd[0][1][2],  # 8-14 dty, rot, tth, eta, hkl
+                    fwd[0][3][0], fwd[0][3][1], fwd[0][3][2], fwd[0][4], fwd[0][5],  # 15-19 gx, gy, gz, dety_pixel(fc), detz_pixel(sc)
+                    Lorentz, Polarization, trans_factor  # 20-22 Lorentz, Polarization, transmission factors
+                ])
+
+    return fwd_peaks
+
+
+def intersected_sample_pos(mask, dty = 0.0, y0_offset = 0.0, voxel_size = [1.0, 1.0, 1.0], omega = 0.0, ray_size = 1.0,
+                           weight = [1.0, 0.8, 0.5, 0.13], weight_pos = [0.5, 1.0, 1.5, 2.3], plot_flag = False, detector = 'eiger'):
+    """
+    Given a dty and a sample rotation angle omega, compute a list of voxels intersected with the X-ray beam and convert them to both sample and lab positions
+    In lab system, the sample rotates by omega, corresponding to rotating the incoming X-ray source by -omega without rotating the sample.
+    This has the benefit to keep the sample mask shape constant throughout the whole calculation
+    Note that all the calculations are based on the sample coordinate system and do conversions after
+    
+    Args:
+        mask (3D array): sample (or grain) mask Nx*Ny*Nz, note that sample axis normally follow Z, Y, X, so permute the axis may be required
+        dty (float): horizontal distance between rotation axis and X-ray beam [um]
+        y0_offset (float): offset of y0, if dty = 0 going through the sample center, then y0_offset = 0 [um]
+        voxel size (float): voxel size in x, y, z axis [um]
+        omega (float): sample rotation angle [deg]
+        ray_size (float): FWHM of the incoming X-ray beam [um]       
+        weight (array): weights of considering fractional contribution of the voxel for scaled to the distance-to-ray-center, determined by the beam FWHM and profile
+        weight_pos (array): distances corresponding to the weights, scaled by beam FHWM
+        plot_flag (logic): plotting flag
+        detector (string): name of the detector, eiger or frelon related to the flip story of the detector
+        
+    Returns:
+        intersected_sampos: intersected positions of the sample voxels in sample coordinate system after shifting by dty+y0_offset [x y z] [mm]
+        intersected_labpos: intersected positions of the sample voxels in lab coordinate system [x y z] [mm]
+        intersected_voxels: intersected voxels follow [x y z]
+    """
+    
+    if not isinstance(voxel_size, np.ndarray):
+        voxel_size = np.array(voxel_size, dtype='float')
+    Omega = forward_model.get_omega_matrix(np.deg2rad(-omega))
+    ray_direction = np.dot(Omega, [1.0, 0.0, 0.0])
+    grid_size = mask.shape
+    assert len(grid_size) == 3, "The input mask must be in 3D"
+    ray_origin = [0.0, -dty - y0_offset, 0.0]
+
+    intersected_voxels = intersected_voxels_3d(grid_size, ray_origin, ray_direction, voxel_size = voxel_size,
+                                               ray_size=ray_size, weight = weight, weight_pos = weight_pos, mask = mask, plot_flag = plot_flag)
+    
+    if intersected_voxels.size > 0:
+        intersected_sampos = np.zeros((intersected_voxels.shape[0], 3), dtype = 'float')
+        if detector in ['Eiger', 'eiger']:
+            for i in range(3):
+                intersected_sampos[:,i] = (intersected_voxels[:,i] - grid_size[i]/2 + 0.5) * voxel_size[i]
+        elif detector in ['Frelon', 'frelon']:
+            for i in range(3):
+                intersected_sampos[:,i] = (intersected_voxels[:,i] - grid_size[i]/2 + 0.5) * voxel_size[i] # to be tested
+
+        # convert to lab positions
+        intersected_sampos[:,1] = intersected_sampos[:,1] + dty + y0_offset
+        intersected_sampos /= 1000.0                                           # [mm]
+        Omega = forward_model.get_omega_matrix(np.deg2rad(omega))
+        intersected_labpos = np.einsum('ij,nj->ni', Omega, intersected_sampos) # [mm]
+    else:
+        intersected_sampos, intersected_labpos, intersected_voxels = None, None, None
+    
+    return intersected_sampos, intersected_labpos, intersected_voxels
+
+
+def intersected_voxels_3d(grid_size, ray_origin, ray_direction, voxel_size = [1.0, 1.0, 1.0], ray_size = 1.0,
+                          weight = [1.0, 0.8, 0.5, 0.13], weight_pos = [0.5, 1.0, 1.5, 2.3], mask = None, plot_flag = False):
+    """
+    Calculate and visualize the intersected voxels for a given ray in 3D.
+    
+    Args:
+        grid_size (tuple): Dimensions of the grid (Nx, Ny, Nz).
+        ray_origin (array): Origin of the ray [x, y, z].
+        ray_direction (array): Direction of the ray [dx, dy, dz].
+        voxel_size (array): voxel size of the grain map [um/pixel]
+        ray_size (float): FWHM of the ray [um]
+        weight (array): weights of considering fractional contribution of the voxel for scaled to the distance-to-ray-center, determined by the beam FWHM and profile
+        weight_pos (array): distances corresponding to the weights, scaled by beam FHWM
+        mask (array): 0 and 1 values, 1 corresponds to activated sample voxels
+        plot_flag (logic): to plot or not.
+    
+    Returns:
+        intersected (list): List of intersected voxel coordinates [x, y, z].
+    """
+    
+    if not isinstance(voxel_size, np.ndarray):
+        voxel_size = np.array(voxel_size, dtype='float')
+    ray_direction = ray_direction / np.linalg.norm(ray_direction)  # Normalize the direction
+    grid_extent = np.array(grid_size) * voxel_size
+    max_extent = np.linalg.norm(grid_extent)
+
+    t_values = np.linspace(-0.707 * max_extent + ray_origin[1], 0.707 * max_extent + ray_origin[1], int(max(grid_size)*1.414))
+    ray_shift = np.array([grid_size[1] / 2 + 0.5, grid_size[1] / 2 + 0.5, 0.0]) * voxel_size
+    ray_path = np.array(ray_origin) / voxel_size + ray_shift + np.outer(t_values, ray_direction)
+
+    tol_distances = np.array(weight_pos)*ray_size
+    weights       = np.array(weight)
+
+    if mask is None:
+        x, y, z = np.meshgrid(
+            np.arange(grid_size[0]),
+            np.arange(grid_size[1]),
+            np.arange(grid_size[2]),
+            indexing="ij",
+        )
+        voxel_indices = np.column_stack((x.ravel(), y.ravel(), z.ravel()))
+    else:
+        voxel_indices = np.argwhere(mask > 0)
+
+    chunk_size = np.min([t_values.shape[0], 100])  # Set an appropriate chunk size based on available memory
+    intersected = []
+
+    for start in range(0, voxel_indices.shape[0], chunk_size):
+        end = min(start + chunk_size, voxel_indices.shape[0])
+        chunk = voxel_indices[start:end]
+
+        intersected_chunk = compute_intersections_single_thread(ray_path, chunk, tol_distances, weights, voxel_size)
+        intersected.extend(intersected_chunk)
+
+    intersected = np.array(intersected)
+    
+    if intersected.size == 0:
+        plot_flag = False
+        
+    if plot_flag:
+        fig = plt.figure(figsize=(10, 8))
+        ax = fig.add_subplot(111, projection="3d")
+        if mask is not None:
+            indices = np.array(voxel_indices)
+            ax.scatter(indices[:, 0], indices[:, 1], indices[:, 2], c="blue", s=5, alpha=0.03, label="Masked Voxels")
+
+        ax.scatter(
+            intersected[:, 0],
+            intersected[:, 1],
+            intersected[:, 2],
+            c=intersected[:, 4] * 100,
+            cmap="viridis",
+            s=8,
+            alpha=0.9,
+            label="Intersected Voxels",
+        )
+
+        ax.plot(ray_path[:, 0]/voxel_size[0], ray_path[:, 1]/voxel_size[1], ray_path[:, 2]/voxel_size[2], "r-", label="Ray Path", linewidth=2)
+        ax.set_xlim(0, grid_size[0])
+        ax.set_ylim(0, grid_size[1])
+        ax.set_zlim(0, grid_size[2])
+        ax.set_xlabel("X")
+        ax.set_ylabel("Y")
+        ax.set_zlabel("Z")
+        ax.set_title("3D Ray-Voxel Intersection with Ray Size {:.2f}".format(ray_size))
+        ax.legend()
+        plt.show()
+        
+    return intersected
+
+
+@njit
+def compute_intersections_single_thread(ray_path, voxel_indices, tol_distances, weights, voxel_size):
+    """
+    sub-function for intersected_voxels_3d
+    """
+    intersected_chunk = []
+    
+    for i in range(voxel_indices.shape[0]):  # Process voxel indices sequentially
+        x, y, z = voxel_indices[i]
+        voxel_center = np.array([x + 0.5, y + 0.5, z + 0.5]) * voxel_size
+        distances = np.sqrt(np.sum((ray_path - voxel_center) ** 2, axis=1))
+        min_distance = np.min(distances)
+
+        # Assign weights based on distance thresholds
+        if min_distance <= tol_distances[-1]:
+            for j, tol_distance in enumerate(tol_distances):
+                if j == 0 and min_distance <= tol_distance:
+                    weight = weights[j]
+                elif j > 0:
+                    if min_distance <= tol_distance and min_distance > tol_distances[j-1]:
+                        weight = weights[j]
+                    else:
+                        continue
+            intersected_chunk.append((x, y, z, min_distance, weight))
+    
+    return intersected_chunk
+
+
+def make_projections_with_psf(fwd_peaks, omega_angles, image_size=(2162, 2068), detector='eiger', int_factors=(0.1065, 0.7807, 0.1065), sum_flag = False):
+    """
+    Make a series of projection images across different rotation angles for one rotation considering point spread function (psf).
+    
+    Args:
+        fwd_peaks (numpy array): Forward computed peaks N*24 array.
+        omega_angles (numpy array): List of rotation angles for projections. [deg]
+        image_size (tuple): Size of the output image (rows, cols).
+        detector (string): Detector name, "eiger" or "frelon".
+        int_factors (tuple): Intensity distribution factors for projection left, middle and right across rotation angles.
+    
+    Returns:
+        projs (array): a 3D array containing projection images [num_angles, rows, cols].
+        projs_sum: a 2D array summing up all the projections along rotation angle
+        
+    3620 projections takes about 91 seconds
+    """
+    
+    rot_step = omega_angles[1] - omega_angles[0]
+    
+    # Initialize 3D array for projections
+    projs = np.zeros((len(omega_angles), image_size[0], image_size[1]), dtype='float')
+    
+    # Iterate over rotation angles with tqdm for progress tracking
+    for i, rot_angle in enumerate(tqdm(omega_angles, desc="Generating projections over omega angles", unit="projection")):
+        mask = (fwd_peaks[:, 9] >= rot_angle - 3 * rot_step) & (fwd_peaks[:, 9] <= rot_angle + 3 * rot_step)
+        fwd_peaks_selected = fwd_peaks[mask]
+        if fwd_peaks_selected.size > 0:
+            projs[i, :, :] = make_one_projection_with_psf(
+                fwd_peaks=fwd_peaks_selected,
+                rot_angle=rot_angle,
+                rot_step=rot_step,
+                image_size=image_size,
+                detector=detector,
+                int_factors=int_factors
+            )
+    
+    if sum_flag:
+        projs_sum = np.sum(projs, axis = 0)
+    else:
+        projs_sum = None
+    return projs, projs_sum
+
+
+def make_one_projection_with_psf(fwd_peaks, rot_angle, rot_step = 0.05, image_size=(2162, 2068), detector = 'eiger', int_factors = (0.1065, 0.7807, 0.1065)):
+    """
+    Create one single projection image from position and intensity data with a point spread function (psf).
+    Instead of directly applying psf on 3D image, we decompose the psf to 2D-filters across the neiboring projections:
+    for psf_sigma = [1.0, 1.0, 0.5],
+    psf [omega -] = [[0.008, 0.0132, 0.008], [0.0132, 0.0217, 0.0132],[0.008, 0.0132, 0.008]]     intensity fraction: 0.1065
+    psf [omega]   = [[0.0591, 0.0975, 0.0591],[0.0975, 0.1607, 0.0975, 0.0591, 0.0975, 0.0591]]   intensity fraction: 0.7870
+    psf [omega +] = [[0.008, 0.0132, 0.008], [0.0132, 0.0217, 0.0132],[0.008, 0.0132, 0.008]]     intensity fraction: 0.1065
+    So, we directly distribute the sum_intensity over 3 frames across omega-, omega and omega+, corresponding to [0.1065, 0.7870, 0.1065] of the sum_intensity,
+    while the shape of the filter can be remained as the same, i.e. Gaussian filter with a sigma of 1
+    
+    
+
+    Args:
+        fwd_peaks (numpy array): forward computed peaks N*24 array
+        rot_angle (float): the ideal rotation angle corresponding to the projection no.
+        rot_step (float): step size of the omega rotation [deg]
+        image_size (tuple): size of the output image (rows, cols)
+        detector (string): detector name, "eiger" or "frelon"
+        int_factors (tuple): intensity distribution factors for projection left, middle and right across rotation angles
+        
+    Returns:
+        image: generated projection [x, y]
+        
+    One projection takes about 0.005 seconds
+    
+    TODO:
+    psf should also depend on the incident angle between the diffracted beam and the detector plane, i.e. more extended along radial direction
+    """
+    if 'eiger' in detector:
+        psf_values = np.array([0.0591, 0.0975, 0.0591,
+                               0.0975, 0.1607, 0.0975,
+                               0.0591, 0.0975, 0.0591], dtype=np.float64) # eiger detector, psf 3*3, sigma = 1
+        neigb_inds = np.array([[-1, -1], [0, -1], [1, -1],
+                               [-1, 0], [0, 0], [1, 0],
+                               [-1, 1], [0, 1], [1, 1]], dtype=np.int32)
+    else:
+        psf_values = np.array([0.0144, 0.0281, 0.0351, 0.0281, 0.0144,
+                               0.0281, 0.0547, 0.0683, 0.0547, 0.0281,
+                               0.0351, 0.0683, 0.0853, 0.0683, 0.0351,
+                               0.0281, 0.0547, 0.0683, 0.0547, 0.0281,
+                               0.0144, 0.0281, 0.0351, 0.0281, 0.0144], dtype=np.float64) # frelon detector, psf 5*5, sigma = 1.5
+        neigb_inds = np.array([[-2, -2], [-1, -2], [0, -2], [1, -2], [2, -2],
+                               [-2, -1], [-1, -1], [0, -1], [1, -1], [2, -1],
+                               [-2, 0], [-1, 0], [0, 0], [1, 0], [2, 0],
+                               [-2, 1], [-1, 1], [0, 1], [1, 1], [2, 1],
+                               [-2, 2], [-1, 2], [0, 2], [1, 2], [2, 2]], dtype=np.int32)
+    
+    # Extract data
+    ind_left = np.where((fwd_peaks[:, 9] >= rot_angle - rot_step*1.5) & (fwd_peaks[:, 9] < rot_angle - rot_step*0.5))[0]
+    ind_middle = np.where((fwd_peaks[:, 9] >= rot_angle - rot_step*0.5) & (fwd_peaks[:, 9] < rot_angle + rot_step*0.5))[0]
+    ind_right = np.where((fwd_peaks[:, 9] >= rot_angle + rot_step*0.5) & (fwd_peaks[:, 9] < rot_angle + rot_step*1.5))[0]
+    
+    positions = np.vstack([  np.vstack([fwd_peaks[ind_left, 18:20], fwd_peaks[ind_middle, 18:20]]), fwd_peaks[ind_right, 18:20]  ])
+    intensities = np.hstack([  np.hstack([fwd_peaks[ind_left, 23]*int_factors[0], fwd_peaks[ind_middle, 23]*int_factors[1]]), fwd_peaks[ind_right, 23]*int_factors[2]  ])
+
+#     # make it compatible with numba, but turned out to be slower --------------- to be investigated
+#     positions = np.zeros((np.sum(ind_left) + np.sum(ind_middle) + np.sum(ind_right), 2), dtype=np.float64)
+#     intensities = np.zeros(np.sum(ind_left) + np.sum(ind_middle) + np.sum(ind_right), dtype=np.float64)
+
+#     # Fill positions and intensities
+#     count = 0
+#     for i in range(fwd_peaks.shape[0]):
+#         if ind_left[i]:
+#             positions[count] = fwd_peaks[i, 18:20]
+#             intensities[count] = fwd_peaks[i, 23] * int_factors[0]
+#             count += 1
+#         elif ind_middle[i]:
+#             positions[count] = fwd_peaks[i, 18:20]
+#             intensities[count] = fwd_peaks[i, 23] * int_factors[1]
+#             count += 1
+#         elif ind_right[i]:
+#             positions[count] = fwd_peaks[i, 18:20]
+#             intensities[count] = fwd_peaks[i, 23] * int_factors[2]
+#             count += 1
+
+#     image = np.zeros(image_size, dtype = 'float')
+#     # Accumulate intensities in the image, for clarity and compatibility
+#     for i in range(positions.shape[0]):
+#         x = int(positions[i, 0])
+#         y = int(positions[i, 1])
+#         intensity = intensities[i]
+#         if 0 <= x < image_size[1] and 0 <= y < image_size[0]:
+#             # distribute the intensity over neighboring pixels, equivalent to gaussian convolution but much faster
+#             for j in range(len(neigb_inds)):
+#                 x_neigh = x + neigb_inds[j, 0]
+#                 y_neigh = y + neigb_inds[j, 1]
+#                 if 0 <= x_neigh < image_size[1] and 0 <= y_neigh < image_size[0]:
+#                     image[y_neigh, x_neigh] += intensity * psf_values[j]
+            
+    # Initialize the image
+    image = np.zeros(image_size, dtype = 'float')
+    
+    # Map positions to pixel indices
+    x_indices = (positions[:, 0]).astype(int)
+    y_indices = (positions[:, 1]).astype(int)
+    
+    # Accumulate intensities in the image    
+    for x, y, intensity in zip(x_indices, y_indices, intensities):
+        if 0 <= x < image_size[1] and 0 <= y < image_size[0]:
+            # distribute the intensity over neighboring pixels, equivalent to gaussian convolution but much faster
+            for (neigb_ind, psf_value) in zip(neigb_inds, psf_values):
+                pos_list = [x + neigb_ind[0], y + neigb_ind[1]]
+                if 0 <= pos_list[0] < image_size[1] and 0 <= pos_list[1] < image_size[0]:
+                    image[pos_list[1], pos_list[0]] += intensity * psf_value
+
+    # Apply Gaussian filter for PSF, this is 17 times slower
+    # image = gaussian_filter(image, sigma=psf_sigma)
+
+    return image
+
+
+def cellvolume(latticepar):
+    """
+    calculate unit cell volume [angstrom^3]
+    """
+    a = latticepar[0]
+    b = latticepar[1]
+    c = latticepar[2]
+    calp = np.cos(np.deg2rad(latticepar[3]))
+    cbet = np.cos(np.deg2rad(latticepar[4]))
+    cgam = np.cos(np.deg2rad(latticepar[5]))
+    
+    angular = np.sqrt(1 - calp**2 - cbet**2 - cgam**2 + 2*calp*cbet*cgam)
+    
+    Vcell = a*b*c*angular
+    
+    return Vcell
+
+
+def K1_calc():
+    """
+    calculate square of Thomson scattering lenth r0^2, [mm^2]
+    K1 = 7.940788332083948e-24 [mm^2]
+    """
+    emass = 9.1093826e-31
+    echarge = 1.60217653e-19
+    pi4eps0 = 1.11265e-10
+    c = 299792458
+    K1 = (echarge**2/(pi4eps0 * emass * c * c) *1000)**2  # [mm^2]
+    return K1
+
+    
+def find_ds_for_multiple_targets(Ahkls, target_hkls):
+    """
+    Find the ds for a list of target hkls in the list Ahkls.
+
+    Args:
+        Ahkls (list): A list of [structure_factor, hkl], e.g. Ahkls = ucell.gethkls(ds_max)
+        target_hkls (list): a list of target hkl to search for, e.g. [[0, -2, 2], [0, 2, -2]]
+
+    Returns:
+        list: A list of ds values for each target hkl (or 0 if not found).
+    """
+    # Ensure target_hkls is a 2D list
+    target_hkls = ensure_2d_array(target_hkls)
+
+    # Convert Ahkls to a dictionary for fast lookups
+    Ahkls_dict = {tuple(hkl): ds for ds, hkl in Ahkls}
+
+    return [Ahkls_dict.get(tuple(target_hkl), 0.0) for target_hkl in target_hkls]
+
+
+def ensure_2d_array(target_hkls):
+    """
+    Ensures the input target_hkls is a 2D array.
+
+    Args:
+        target_hkls (list or array): A single 1D array or a list of N x 3 arrays.
+
+    Returns:
+        list: A 2D list of N x 3 arrays.
+    """
+    if isinstance(target_hkls[0], (int, float)):
+        return [target_hkls]
+    return target_hkls
+
+
+def plot_fwd_peaks(fwd_peaks):
+    assert fwd_peaks.shape[1] == 25, "fwd_peaks shapes are not qualified"
+    f, ax = plt.subplots(1, 2, figsize=(15, 9))
+
+    sc = ax[0].scatter(fwd_peaks[:, 18], fwd_peaks[:, 19], c=fwd_peaks[:, 23], cmap='viridis', s=8)
+    ax[0].set_aspect('equal', 'box')
+    cb = f.colorbar(sc, ax=ax[0])
+    # cb.set_label('Intensity', fontsize = 20)
+    cb.ax.tick_params(labelsize=14)
+    ax[0].set_xlabel('fc (pixel)', fontsize = 20)
+    ax[0].set_ylabel('sc (pixel)', fontsize = 20)
+    ax[0].set_title('(a) Forward peaks on detector', fontsize = 20)
+    ax[0].tick_params(width=1.5, length=6, labelsize=14)
+    ax[0].invert_yaxis()
+
+    sc = ax[1].scatter(fwd_peaks[:, 5], fwd_peaks[:, 6], c=fwd_peaks[:, 23], cmap='viridis', s=8)
+    ax[1].set_aspect('equal', 'box')
+    cb = f.colorbar(sc, ax=ax[1])
+    cb.set_label('Intensity', fontsize = 20)
+    cb.ax.tick_params(labelsize=14)
+    ax[1].set_xlabel('X (mm)', fontsize = 20)
+    ax[1].set_ylabel('Y (mm)', fontsize = 20)
+    ax[1].set_title('(b) Forward peaks from the sample', fontsize = 20)
+    ax[1].tick_params(width=1.5, length=6, labelsize=14) 
+
+    f.tight_layout()
+    plt.show()
+    
+    
+def make_intensity_map(x_positions, y_positions, intensities, x_range = None, y_range = None, pixel_size=1e-3, plot_flag=True, cmap="viridis"):
+    """
+    Generate and plot an intensity map based on input x, y positions and the associated intensities.
+    
+    Args:
+        x_positions (array): x positions
+        y_positions (array): y positions
+        intensities (array): intensities
+        x_range (float): min and max x range values
+        y_range (float): min and max y range values
+        pixel_size (float): pixel size for generating the image
+        plot_flag (logic): for making a plot
+        cmap (str): color map for plotting
+    
+    Returns:
+        intensity_map
+    """
+    assert (x_positions.size == y_positions.size) and (x_positions.size == intensities.size), "The sizes of x, y, intensities must be the same"
+
+    # Compute the bounds of the grid
+    if x_range is None:
+        x_min, x_max = np.min(x_positions), np.max(x_positions)
+    else:
+        x_min = x_range[0]
+        x_max = x_range[1]
+    if y_range is None:
+        y_min, y_max = np.min(y_positions), np.max(y_positions)
+    else:
+        y_min = y_range[0]
+        y_max = y_range[1]
+
+    # Determine the grid size
+    x_bins = int(np.ceil((x_max - x_min) / pixel_size))
+    y_bins = int(np.ceil((y_max - y_min) / pixel_size))
+
+    intensity_map = np.zeros((y_bins, x_bins))
+
+    # Map positions to pixel indices
+    x_indices = np.floor((x_positions - x_min) / pixel_size).astype(int)
+    y_indices = np.floor((y_positions - y_min) / pixel_size).astype(int)
+
+    # Accumulate intensities
+    for x_idx, y_idx, intensity in zip(x_indices, y_indices, intensities):
+        intensity_map[y_idx, x_idx] += intensity
+
+    if plot_flag:
+        plt.figure(figsize=(10, 8))
+        plt.imshow(intensity_map, origin='lower', extent=[x_min, x_max, y_min, y_max], cmap=cmap,
+                  norm=LogNorm(vmin=max(10, intensity_map.min()), vmax=intensity_map.max()), interpolation="nearest")
+        # plt.imshow(intensity_map, origin='lower', extent=[x_min, x_max, y_min, y_max], cmap=cmap)
+        plt.colorbar(label="Intensity")
+        plt.xlabel("X position")
+        plt.ylabel("Y position")
+        plt.title("Intensity Map, pixel size = {}".format(pixel_size))
+        plt.show()
+    
+    return intensity_map
+
+
+"""
+The following functions are related to segment the peaks from the projections, which are all adapted from ImageD11.sinograms.lima_segmenter
+"""
+
+def get_opts_seg(mask = None, bg = None, cut = 1, pixels_in_spot = 1):
+    """
+    set segmentation parameters
+    Args:
+        mask (2D array): mask for the detector
+        bg (2D array):   background for the detector
+        cut (float):     keep values abuve cut in first look at image
+        pixels_in_spot:  minimum number of pixels in a single spot
+    """
+    thresholds = tuple([cut * pow(2, i) for i in range(6)])
+    opts_seg = {"mask": mask,
+        "bg": bg,
+        "cut": cut,           # keep values abuve cut in first look at image
+        "overwrite": False,   # overwrite existing sparse h5 file
+        "howmany": 100000,    # max pixels per frame to keep
+        "thresholds": thresholds,
+        "pixels_in_spot": pixels_in_spot}
+    return opts_seg
+
+
+def make_projs_and_sparse_file(fwd_peaks, destname, omega_angles, opts_seg, detector = 'eiger', detector_mask = None, image_size=(2162, 2068), int_factors=(0.1065, 0.7807, 0.1065)): 
+    """
+    Make projection image and do segmentation on it to generate sparse peaks h5 file
+    Combine make_one_projection_with_psf and adaptation of "segment_lima" in ImageD11.sinograms.lima_segmenter
+    The advantage with this is processing frame by frame, instead of producing a series of frames and then doing sementation (slower and more memory consuming) 
+    Args:
+        fwd_peaks (numpy array): Forward computed peaks N*24 array.
+        dsetname (str):  output filename
+        omega_angles (numpy array): List of rotation angles for projections. [deg]
+        opts_seg (dict): segmenting options, e.g.:
+        opts_seg = {"mask": None,
+            "bg": None,
+            "cut": 1,           # keep values abuve cut in first look at image
+            "overwrite": False,
+            "howmany": 100000,  # max pixels per frame to keep
+            "thresholds": 55,
+            "pixels_in_spot": 1}
+        detector (str):  detector name, e.g. "eiger" or "frelon3"
+        detector_mask (2D array):  detector mask image, 1-active, 0-non-active
+        image_size (int array): dimensions of the 2D projection image
+        int_factors (tuple): Intensity distribution factors for projection left, middle and right across rotation angles.
+    Returns:
+        dsetname (str):  output filename with saved sparse peaks
+    """
+    
+    dataset = "/entry_0000/ESRF-ID11/" + detector + "/data"
+    # saving compression style:
+    opts = {
+        "chunks": (10000,),
+        "maxshape": (None,),
+        "compression": "lzf",
+        "shuffle": True,
+    }
+    assert fwd_peaks.size > 0, "fwd_peaks must not be empty"
+    if detector_mask is None:
+        detector_mask = np.ones(image_size, dtype = 'float')
+    opts_seg["mask"] = detector_mask
+    
+    if os.path.exists(destname) and opts_seg['overwrite']:
+        os.remove(destname)
+    elif os.path.exists(destname):
+        print('{} exists already; skipping ...'.format(destname))
+        return destname
+    
+    rot_step = omega_angles[1] - omega_angles[0]
+    dty_values = d = np.full((omega_angles.shape[0],), fwd_peaks[0, 8])   # save dty as the same shape as omega_angles
+    start = time.time()
+    with h5py.File(destname, "w") as hout:
+        print("# ", fwd_peaks.shape, destname)
+        print("# time now", time.ctime(), "\n#", end=" ")
+        g = hout.require_group(dataset)
+        g.create_dataset("rot", data = omega_angles, dtype='float')
+        g.create_dataset("rot_center", data = omega_angles, dtype='float')
+        g.create_dataset("dty", data = dty_values, dtype='float')
+        row = g.create_dataset("row", (0,), dtype=np.uint16, **opts)
+        col = g.create_dataset("col", (0,), dtype=np.uint16, **opts)
+        sig = g.create_dataset("intensity", (0,), dtype=np.float64, **opts)
+             
+        nframes = omega_angles.shape[0]
+        nnz = g.create_dataset("nnz", (nframes,), dtype=np.uint32)
+        g.attrs["itype"] = np.dtype(np.uint16).name
+        g.attrs["nframes"] = nframes
+        g.attrs["shape0"] = image_size[0]
+        g.attrs["shape1"] = image_size[1]
+        
+        npx = 0
+        # Iterate over rotation angles with tqdm for progress tracking
+        for i, rot_angle in enumerate(tqdm(omega_angles, desc="Making projection and segmenting sparse peaks over omega angles", unit="projection")):
+            peaks_mask = (fwd_peaks[:, 9] >= rot_angle - 3 * rot_step) & (fwd_peaks[:, 9] <= rot_angle + 3 * rot_step)
+            fwd_peaks_selected = fwd_peaks[peaks_mask]
+            if fwd_peaks_selected.size > 0:
+                frm = make_one_projection_with_psf(
+                    fwd_peaks=fwd_peaks_selected,
+                    rot_angle=rot_angle,
+                    rot_step=rot_step,
+                    image_size=image_size,
+                    detector=detector,
+                    int_factors=int_factors
+                )
+                fun = lima_segmenter.frmtosparse(detector_mask, frm.dtype)
+                if opts_seg['bg'] is not None:
+                    frm = frm.astype(np.float32) - opts_seg['bg']
+                frm_npx, frm_row, frm_col, frm_val = fun(frm, opts_seg['cut'])
+                spf = clean_frms(frm_npx, frm_row, frm_col, frm_val, opts_seg)
+                if spf is None or spf.nnz == 0:
+                    nnz[i] = 0
+                    continue
+                if spf.nnz + npx > len(row):
+                    row.resize(spf.nnz + npx, axis=0)
+                    col.resize(spf.nnz + npx, axis=0)
+                    sig.resize(spf.nnz + npx, axis=0)
+            
+                row[npx:] = spf.row[:]
+                col[npx:] = spf.col[:]
+                sig[npx:] = spf.pixels["intensity"]
+                nnz[i] = spf.nnz
+                npx += spf.nnz
+        g.attrs["npx"] = npx
+        
+    end = time.time()
+    print("\n# Done", nframes, "frames", npx, "pixels  fps", nframes / (end - start))
+    return destname
+
+
+def segment_frms(frms, destname, opts_seg, detector = 'eiger'):
+    """
+    Adapted from "segment_lima" in ImageD11.sinograms.lima_segmenter
+    Does segmentation on a series of frames, e.g. generated from fwd_peaks
+    Modified based on the function segment_lima in ImageD11/sinograms/lima_segmenter.py
+    Args:
+        frms (3D array): projections generated from fwd_peaks using forward_projector.make_projections_with_psf
+        dsetname (str):  output filename
+        detector (str):  detector name, e.g. "eiger" or "frelon3"
+        opts_seg (dict): segmenting options, e.g.:
+        opts_seg = {"mask": None,
+            "bg": None,
+            "cut": 1,           # keep values abuve cut in first look at image
+            "overwrite": False,
+            "howmany": 100000,  # max pixels per frame to keep
+            "thresholds": 55,
+            "pixels_in_spot": 1}
+    Returns:
+        dsetname (str):  output filename
+    """
+    dataset = "/entry_0000/ESRF-ID11/" + detector + "/data"
+    # saving compression style:
+    opts = {
+        "chunks": (10000,),
+        "maxshape": (None,),
+        "compression": "lzf",
+        "shuffle": True,
+    }
+    assert len(frms.shape) == 3, "frms must have 3D shape"
+    if opts_seg["mask"] is None:
+        opts_seg["mask"] = np.ones((frms.shape[1], frms.shape[2]), dtype = "float")
+    detector_mask = opts_seg['mask']
+    
+    if os.path.exists(destname) and opts_seg['overwrite']:
+        os.remove(destname)
+    elif os.path.exists(destname):
+        print('{} exists already; skipping ...'.format(destname))
+        return destname
+    start = time.time()
+    with h5py.File(destname, "a") as hout:
+        print("# ", frms.shape, destname)
+        print("# time now", time.ctime(), "\n#", end=" ")
+        g = hout.require_group(dataset)
+        row = g.create_dataset("row", (0,), dtype=np.uint16, **opts)
+        col = g.create_dataset("col", (0,), dtype=np.uint16, **opts)
+        # can go over 65535 frames in a scan
+        # num = g.create_dataset("frame", (1,), dtype=np.uint32, **opts)
+        sig = g.create_dataset("intensity", (0,), dtype=frms.dtype, **opts)
+        nnz = g.create_dataset("nnz", (frms.shape[0],), dtype=np.uint32)
+        g.attrs["itype"] = np.dtype(np.uint16).name
+        g.attrs["nframes"] = frms.shape[0]
+        g.attrs["shape0"] = frms.shape[1]
+        g.attrs["shape1"] = frms.shape[2]
+        npx = 0
+        nframes = frms.shape[0]
+        for i, spf in enumerate(reader_frms(frms, detector_mask, opts_seg)):
+            if i % 100 == 0:
+                if spf is None:
+                    print("%4d 0" % (i), end=",")
+                else:
+                    print("%4d %d" % (i, spf.nnz), end=",")
+                sys.stdout.flush()
+            if spf is None:
+                nnz[i] = 0
+                continue
+            if spf.nnz + npx > len(row):
+                row.resize(spf.nnz + npx, axis=0)
+                col.resize(spf.nnz + npx, axis=0)
+                sig.resize(spf.nnz + npx, axis=0)
+            row[npx:] = spf.row[:]
+            col[npx:] = spf.col[:]
+            sig[npx:] = spf.pixels["intensity"]
+            # num[npx:] = i
+            nnz[i] = spf.nnz
+            npx += spf.nnz
+        g.attrs["npx"] = npx
+    end = time.time()
+    print("\n# Done", nframes, "frames", npx, "pixels  fps", nframes / (end - start))
+    return destname
+
+    # the output file should be flushed and closed when this returns
+    
+    
+def reader_frms(frms, mask, opts_seg, start=0):
+    """
+    Adapted from "reader" in ImageD11.sinograms.lima_segmenter
+    iterator to read frames and segment them
+    returns sparseframes
+    
+    Args:
+        frms (3D array): projections to be segmented
+        mask (2D array): mask image for the detector
+        opts_seg (dict): segmenting options, e.g.:
+        opts_seg = {"mask": None,
+            "bg": None,
+            "cut": 1,           # keep values abuve cut in first look at image
+            "overwrite": False,
+            "howmany": 100000,  # max pixels per frame to keep
+            "thresholds": 55,
+            "pixels_in_spot": 1}
+        start (int): first indice for projections to be segmented
+    Returns:
+        dsetname (str):  output filename
+    """
+    
+    assert start < len(frms)
+
+    fun = lima_segmenter.frmtosparse(mask, frms.dtype)
+    for i in range(start, frms.shape[0]):
+        frm = frms[i]
+        if opts_seg['bg'] is not None:
+            frm = frm.astype(np.float32) - opts_seg['bg']
+        npx, row, col, val = fun(frm, opts_seg['cut'])
+        spf = clean_frms(npx, row, col, val, opts_seg)
+        yield spf
+
+
+def clean_frms(nnz, row, col, val, opts_seg):
+    """
+    Adapted from "clean" in ImageD11.sinograms.lima_segmenter
+    """
+    if nnz == 0:
+        return None
+    if nnz > opts_seg['howmany']:
+        nnz = lima_segmenter.top_pixels(nnz, row, col, val, opts_seg['howmany'], opts_seg['thresholds'])
+        # Now get rid of the single pixel 'peaks'
+        #   (for the mallocs, data is copied here)
+        s = lima_segmenter.sparseframe.sparse_frame(
+            row[:nnz].copy(), col[:nnz].copy(), opts_seg['mask'].shape
+        )
+        s.set_pixels("intensity", val[:nnz].copy())
+    else:
+        s = lima_segmenter.sparseframe.sparse_frame(row, col, opts_seg['mask'].shape)
+        s.set_pixels("intensity", val)
+    if opts_seg['pixels_in_spot'] <= 1:
+        return s
+    # label them according to the connected objects
+    s.set_pixels("f32", s.pixels["intensity"].astype(np.float32))
+    npk = lima_segmenter.sparseframe.sparse_connected_pixels(
+        s, threshold=0, data_name="f32", label_name="cp"
+    )
+    # only keep spots with more than 3 pixels ...
+    #    mom = sparseframe.sparse_moments( s,
+    #                                     intensity_name="f32",
+    #                                     labels_name="cp" )
+    #    npx = mom[:, cImageD11.s2D_1]
+    npx = np.bincount(s.pixels["cp"], minlength=npk)
+    pxcounts = npx[s.pixels["cp"]]
+    pxmsk = pxcounts >= opts_seg['pixels_in_spot']
+    if pxmsk.sum() == 0:
+        return None
+    sf = s.mask(pxmsk)
+    return sf
+
+
+def assemble_sparsefiles(sparsefiles_folder, dtys, outname_sparse = "fwd_sparse.h5", image_size=(2162, 2068)):
+    """
+    assemble sparsefiles from each dty position to a single sparse file
+    adapted from "harvest_masterfile" in ImageD11.sinograms.assemble_label
+
+    Args:
+        sparsefiles_folder (str): folder holds individual dty sparse files
+        dtys (array):  a list of dty positions [um]
+        outname_sparse (str): sparse file to write
+        image_size (int array): dimensions of the 2D projection image
+    Returns:
+        outname_sparse (str): sparse file to write
+    """
+    if os.path.exists(outname_sparse):
+        print('{} already exists; exit ...'.format(outname_sparse))
+        return outname_sparse
+    scanmotors = ['dty', 'rot', 'rot_center']
+    headermotors = ['dty', 'rot']
+    with h5py.File(outname_sparse, "a") as hout:
+        for i, dty in enumerate(dtys):
+            scan = str(i+1) + '.1'
+            sparsefile = os.path.join(sparsefiles_folder, 'fsparse_dty_' + str(round(dty, 2)).replace('.', 'p') + '.h5')
+            if not os.path.exists(sparsefile):
+                print('{} not found ...'.format(sparsefile))
+                continue
+            else:
+                fsparse_pks = io.read_fsparse(sparsefile)
+                # write basic motor info
+                g = hout.require_group(scan)
+                gm = g.require_group("measurement")
+                for m in scanmotors:
+                    if m in fsparse_pks.keys():
+                        data = fsparse_pks[m][:]
+                        ds = gm.require_dataset(m, shape=data.shape, dtype=data.dtype)
+                        ds[()] = data
+                gip = g.require_group("instrument/positioners")
+                for m in headermotors:
+                    if m in fsparse_pks.keys():
+                        data = fsparse_pks[m][:]
+                        ds = gip.require_dataset(m, shape=data.shape, dtype=data.dtype)
+                        ds[()] = data
+                g.attrs["itype"] = fsparse_pks['intensity'].dtype.name
+                g.attrs["nframes"] = fsparse_pks['nnz'].shape
+                g.attrs["shape0"] = image_size[0]
+                g.attrs["shape1"] = image_size[1]
+
+                # write peaks info
+                g.create_dataset("row", data = fsparse_pks['row'], dtype=np.uint16)
+                g.create_dataset("col", data = fsparse_pks['col'], dtype=np.uint16)
+                g.create_dataset("nnz", data = fsparse_pks['nnz'], dtype=np.uint32)
+                g.create_dataset("intensity", data = fsparse_pks['intensity'], dtype=g.attrs["itype"])
+            print(scan, end=", ")
+        print()
+    return outname_sparse
+
+
+def merge_rows(data, columns_to_cluster=[0, 9, 12, 13, 14], epsilons=[0.1, 2, 0.1, 0.1, 0.1],
+               special_col_index=23, weighted_avg=True, min_samples=1):
+    """
+    Merge rows based on proximity of specific columns with column-specific epsilon values.
+    The default values are suitable for fwd_peaks, where columns_to_cluster=[0, 9, 12, 13, 14, 18, 19] correspond to
+    grainID, rot, hkl, dety_pixel(fc), detz_pixel(sc)
+
+    Args:
+        data (ndarray): Input array with shape (n_rows, n_cols).
+        columns_to_cluster (list): Indices of columns to check for closeness.
+        epsilons (list): List of epsilon values for each column in columns_to_cluster.
+        special_col_index (int): Index of the special column to sum instead of averaging.
+        weighted_avg (bool): Whether to use weighted averaging (weights from a specific column).
+        min_samples (int): Minimum samples to form a cluster.
+
+    Returns:
+        ndarray: Array with merged rows.
+        clusters: cluster ID
+    """
+    # Input validation
+    if not isinstance(data, np.ndarray) or data.ndim != 2:
+        raise ValueError("Input data must be a 2D numpy array.")
+    if special_col_index >= data.shape[1]:
+        raise ValueError("special_col_index is out of bounds.")
+    if not all(0 <= col < data.shape[1] for col in columns_to_cluster):
+        raise ValueError("Invalid column indices in columns_to_cluster.")
+    if len(columns_to_cluster) != len(epsilons):
+        raise ValueError("columns_to_cluster and epsilons must have the same length.")
+
+    # Normalize the columns to cluster by their respective epsilon
+    subset = data[:, columns_to_cluster]
+    normalized_subset = subset / np.array(epsilons)
+
+    # Perform clustering using DBSCAN
+    dbscan = DBSCAN(eps=1.0, min_samples=min_samples, metric='euclidean')  # `eps=1.0` because of normalization
+    clusters = dbscan.fit_predict(normalized_subset)
+
+    # Merge rows based on clusters
+    merged_data = []
+    for cluster_id in np.unique(clusters):
+        if cluster_id == -1:  # Noise points (optional: handle them separately)
+            continue
+        cluster_rows = data[clusters == cluster_id]
+
+        if not weighted_avg:
+            # Average all columns except the special column
+            averaged = np.mean(cluster_rows[:, :], axis=0)
+        else:
+            # Use weighted average (weights from the special column)
+            weights = cluster_rows[:, special_col_index]
+            averaged1 = np.average(cluster_rows[:, 0:special_col_index], axis=0, weights=weights)
+            averaged2 = np.average(cluster_rows[:, special_col_index+1:], axis=0, weights=weights)
+
+        # Sum the special column
+        special_col_sum = np.sum(cluster_rows[:, special_col_index], axis=0)
+
+        # Combine averaged and summed columns
+        merged_row = np.append(averaged1, special_col_sum)
+        merged_row = np.append(merged_row, averaged2)
+        merged_data.append(merged_row)
+
+    # Convert merged data to a numpy array
+    merged_data = np.array(merged_data)
+
+    print("Original shape:", data.shape)
+    print("Merged shape:", merged_data.shape)
+    return merged_data, clusters
+
+
+def get_ImageD11_code_path():
+    """
+    get the code path of ImageD11
+    """
+    return os.path.split(os.path.split(os.path.split(inspect.getfile(forward_projector))[0])[0])[0]
+
+
+def set_tmp_dir(tmp_dir = "/tmp_14_days/slurm/log"):
+    """
+    set a temporary directory for multiprocessing to a writable location
+    """
+    tempdir = tempfile.mkdtemp(dir=tmp_dir)
+    multiprocessing.set_start_method("fork", force=True)  # Use 'fork' for better HPC support
+    os.environ["TMPDIR"] = tempdir  # Ensure workers use the correct temp dir

--- a/ImageD11/forward_model/grainmaps.py
+++ b/ImageD11/forward_model/grainmaps.py
@@ -716,17 +716,23 @@ def pairing_grains(grains1, grains2, crystal_system='cubic', tol_misori=3, tol_d
         # Check tolerances
         if the_angle < tol_rad and dis < tol_dis:
             if tol_int == [0.0, 0.0]:
+                # return [i, j, grains1[i].Rod[0], grains1[i].Rod[1], grains1[i].Rod[2],
+                #         grains2[j].Rod[0], grains2[j].Rod[1], grains2[j].Rod[2],
+                #         intensity1, intensity2, np.rad2deg(the_angle), dis,
+                #         *pos1, *pos2]
                 return [i, j, grains1[i].Rod[0], grains1[i].Rod[1], grains1[i].Rod[2],
                         grains2[j].Rod[0], grains2[j].Rod[1], grains2[j].Rod[2],
-                        intensity1, intensity2, np.rad2deg(the_angle), dis,
-                        *pos1, *pos2]
+                        intensity1, intensity2, np.rad2deg(the_angle), dis] + list(pos1) + list(pos2)
             else:
                 intensity_diff = abs(intensity1 - intensity2) / intensity1
                 if tol_int[0] <= intensity_diff <= tol_int[1]:
+                    # return [i, j, grains1[i].Rod[0], grains1[i].Rod[1], grains1[i].Rod[2],
+                    #         grains2[j].Rod[0], grains2[j].Rod[1], grains2[j].Rod[2],
+                    #         intensity1, intensity2, np.rad2deg(the_angle), dis,
+                    #         *pos1, *pos2]
                     return [i, j, grains1[i].Rod[0], grains1[i].Rod[1], grains1[i].Rod[2],
-                            grains2[j].Rod[0], grains2[j].Rod[1], grains2[j].Rod[2],
-                            intensity1, intensity2, np.rad2deg(the_angle), dis,
-                            *pos1, *pos2]
+                        grains2[j].Rod[0], grains2[j].Rod[1], grains2[j].Rod[2],
+                        intensity1, intensity2, np.rad2deg(the_angle), dis] + list(pos1) + list(pos2)
         return None
     
     total_pairs = len(grains1) * len(grains2)

--- a/ImageD11/forward_model/grainmaps.py
+++ b/ImageD11/forward_model/grainmaps.py
@@ -1,0 +1,1450 @@
+# grainmaps.py
+# Main functions are as follows:
+# 1) grainmap class
+#    - read the tensor_map from tomo or pbp reconstructed results
+#    - build a DS-type grain map from the ImageD11 results
+#    - merge regions to have grain IDs, i.e. 'labels', if there is no effective 'labels' in the tensor_map
+#    - extract grain boundaries and compute grain boundary character from the DS-type grain map
+#    - TODO: operations on the grain map, including cropping, rotating, re-scaling, comparing with another grain map and overlaying on tomographic slice etc
+# 2) indexing_iterative: iterative indexing with left peaks
+# 3) merge_grains: identify grains by merging voxels with similar UBIs, 'similar' is defined with a user defined tolerance in misorientation and/or unit cells
+# 4) pairing_grains: track the same grains between two different grains object, useful for tracking grains across different datasets
+# 5) Crystal, symmetry related functions, e.g. calculate misorientations considering the crystal symmetry, compute mean Rodrigues vector etc.
+# Haixing Fang, haixing.fang@esrf.fr
+# Dec 9, 2024
+# updated on January 30, 2025
+
+import os
+import enum
+import functools
+from math import sin, cos, sqrt, gcd
+import numpy as np
+from numpy import pi, dot, transpose, radians
+import matplotlib
+from matplotlib import pyplot as plt
+
+from joblib import Parallel, delayed
+import time
+from tqdm import tqdm
+import re
+from sklearn.cluster import KMeans
+import warnings
+from scipy.ndimage import distance_transform_edt
+
+import h5py
+import ImageD11.nbGui.nb_utils as utils
+import ImageD11.grain
+import ImageD11.indexing
+import ImageD11.columnfile
+from ImageD11.unitcell import Phases
+from ImageD11.unitcell import unitcell
+from ImageD11.peakselect import select_ring_peaks_by_intensity
+
+from ImageD11.forward_model import forward_model
+from ImageD11.forward_model import io
+from ImageD11.forward_model import ori_converter
+
+
+class grainmap:
+    '''
+    grain map class to create and do operations on a grain map, akin fwd-DCT DS
+    example:
+    filename = ds.grains_file
+    gm = grainmap(filename)
+    gm.merge_and_identify_grains(FirstGrainID = 0, dis_tol = np.sqrt(2))
+    DS = gm.DS
+    '''
+    def __init__(self, filename = None, outname = None, min_misori = 3, crystal_system = 'cubic', remove_small_grains = True, min_vol = 2):
+        self.filename = filename
+        self.outname = outname
+        if self.outname is None and self.filename is not None:
+            self.outname = os.path.join(os.path.split(self.filename)[0], 'DS.h5')
+        if filename is not None:
+            self.DS, self.tensor_map = self.convert2DS()
+        else:
+            self.DS = None
+            self.tensor_map = None
+        self.min_misori = min_misori
+        self.crystal_system = crystal_system
+        self.remove_small_grains = remove_small_grains
+        self.min_vol = min_vol
+        print('****************************************** Parameters for operating the grain map: ')
+        print('Output file name: {}'.format(self.outname))
+        print('min_misori = {}'.format(min_misori))
+        print('crystal_system: {}'.format(crystal_system))
+        print('remove_small_grains = {}'.format(remove_small_grains))
+        print('min_vol = {} voxels'.format(min_vol))
+        
+    
+    def read_tensor_map(self):
+        if os.path.exists(self.filename):
+            tensor_map = io.read_h5_file(self.filename)
+            if isinstance(tensor_map, dict):
+                io.print_all_keys(tensor_map)
+            else:
+                print("The file did not produce a dictionary.")
+            return tensor_map
+        else:
+            print('{} is not found'.format(self.filename))
+            return None
+    
+    
+    def convert2DS(self):
+        """
+        convert tensor_map to a dictionary like DS, which is similar to fwd-DCT struct, easier for subsequent operation
+        """
+        tensor_map = self.read_tensor_map()
+        
+        for key in tensor_map.keys():
+            if 'TensorMap' in key:
+                print('Got the key name {}'.format(key))
+                keyname = key
+        
+        print('********************* Converting to DS format *****************************')
+        keys_list = ['B', 'U', 'UB', 'UBI', 'eps_sample', 'euler', 'ipf_x', 'ipf_y', 'ipf_z', 'mt', 'nuniq', 'phase_ids', 'unitcell', 'intensity', 'labels']
+        DS = {}
+        for k in keys_list:
+            if k in tensor_map[keyname]['maps'].keys():
+                print('Loading {} with a shape of {} to DS ...'.format(k, tensor_map[keyname]['maps'][k].shape))
+                DS[k] = tensor_map[keyname]['maps'][k]
+        if 'step' in tensor_map[keyname].keys():
+            DS['voxel_size'] = tensor_map[keyname]['step'] # [um/pixel]
+        
+        
+        DS['Rod'] = np.empty((DS['UBI'].shape[0], DS['UBI'].shape[1], DS['UBI'].shape[2], 3))
+        DS['Rod'].fill(np.nan)
+                
+        # assign labels ID without any merging, i.e. grain ID
+        if 'labels' not in DS.keys():
+            DS['labels'] = np.zeros_like(DS['phase_ids']) - 1
+            indices = np.argwhere(DS['phase_ids'] > -1)
+
+            for label, (i, j, k) in enumerate(indices):
+                DS['labels'][i, j, k] = label  # label starts from 0
+            
+            print('Found a map (dimensions {}) with {} voxels to be labeled with grain ID'.format(DS['labels'].shape, np.max(DS['labels'])))
+            print('Please note: current labels are only randomized without any region merging !!!')
+
+        # get U from UBI if no 'U' existed
+        if 'U' not in DS.keys() and 'UBI' in DS.keys():
+            try:
+                latticepar = np.array(tensor_map[keyname]['phases']['0'].decode('utf-8').split(), dtype = float)
+                ucell = unitcell(latticepar[0:6], int(latticepar[-1]))
+                B = ucell.B
+                print('Got lattice parameters: {} for calculating B matrix to decompose UBI and derive U matrix'.format(latticepar))
+                
+                DS['U'] = np.empty((DS['UBI'].shape[0], DS['UBI'].shape[1], DS['UBI'].shape[2], 3, 3))
+                DS['U'].fill(np.nan)
+                
+                indices = np.argwhere(~np.isnan(DS['UBI'][:, :, :, 0, 0]))
+                for (i, j, k) in indices:
+                    DS['U'][i, j, k, :, :] = np.dot(B, DS['UBI'][i, j, k, :, :]).T
+                print('Done with deriving U matrix !')
+            except KeyError as e:
+                print("Key error: {}".format(e))
+            except Exception as e:
+                print("An unexpected error occurred: {}".format(e))
+        
+        # assign Rodrigues vector
+        try:
+            for i in range(DS['U'].shape[0]):
+                for j in range(DS['U'].shape[1]):
+                    for k in range(DS['U'].shape[2]):
+                        if not np.isnan(DS['U'][i, j, k, 0, 0]):
+                            DS['Rod'][i, j, k] = ori_converter.quat2rod(ori_converter.u2quat(DS['U'][i, j, k, :, :]))
+            print('Got Rodrigues vector for each voxel !')
+        except KeyError as e:
+            print("Key error: {}".format(e))
+        except Exception as e:
+            print("An unexpected error occurred: {}".format(e))
+
+        return DS, tensor_map
+    
+    
+    def merge_and_identify_grains(self, FirstGrainID = 0, dis_tol = np.sqrt(2), count_max = 100):
+        """
+        merge regions and identify grains to update grain IDs, i.e. 'labels' in DS
+        default option to also remove small grains, e.g. remove grain IDs with size no bigger than 2 voxels
+        """
+        self.DS = DS_merge_and_identify_grains(self.DS, FirstGrainID = FirstGrainID, min_misori = self.min_misori, dis_tol = dis_tol, crystal_system = self.crystal_system, count_max = count_max)
+        if self.remove_small_grains:
+            self.DS = DS_remove_small_grains(self.DS, self.min_vol)
+        
+    
+    def write_DS(self):
+        """
+        write DS to an h5 file with filename defined as self.outname'
+        """
+        if not self.outname.endswith(('.h5', '.hdf5')):
+            self.outname = self.outname + '.h5'
+        
+        with h5py.File(self.outname, 'w') as hout:
+            for key, value in self.DS.items():
+                hout.create_dataset(key, data = value)
+        print('Done with saving DS to {}'.format(self.outname))
+        
+        
+    def write_labels2tmfile(self):
+        """
+        write labels as new dataset to the original tensor map file'
+        """
+        with h5py.File(self.filename, 'a') as hout:
+            if 'labels' in self.DS.keys():
+                hout.create_dataset('labels', data = self.DS['labels'])
+                print('Done with appending labels to {}'.format(self.filename))
+            else:
+                print('No labels in DS keys; Do merge_and_identify_grains first ...')
+    
+    
+    'TODO'
+    """
+    method to create grain boundaries and compute boundary misorientations    
+    method for cropping
+    method for rotating
+    method for rescaling
+    method for plotting
+    method for comparing with another DS
+    
+    """
+
+
+def DS_merge_and_identify_grains(DS, FirstGrainID = 0, min_misori = 3.0, dis_tol = np.sqrt(2), crystal_system = 'cubic', count_max = 100):
+
+    """
+    Merge regions within which the voxel misorientation is smaller than a pre-defined values
+    New grain ID will be assigned to DS dictionary 'labels' key
+    Optional to keep the first grain IDs static by defining FirstGrainID (by default = 0 means no first grains to be static)
+
+    Arguments:
+    DS                -- grain map dictionary, gm = grainmap(tensor_map_file); DS = gm.DS
+    FirstGrainID      -- First grain ID to be considered for merging, by default = 0
+    min_misori        -- misorientation for merging regions
+    dis_tol           -- maximum distance around the target voxel for identifying its neigboring grains, np.sqrt(2) corresponds to the diagonal voxel
+    crystal_system    -- crystal system name one of ['cubic', 'hexagonal', 'orthorhombic', 'tetragonal', 'trigonal', 'monoclinic', 'triclinic']
+    count_max         -- maximum iterations for merging regions
+
+    Returns:
+    DS_new          -- DS grain map dictionary with updated grain IDs
+    """
+    
+    stop_merge = False
+    count = 0
+    start_time = time.time()
+    while not stop_merge:
+        DS_new = DS_merge_and_identify_grains_sub(DS, FirstGrainID = FirstGrainID, min_misori = min_misori, dis_tol = dis_tol, crystal_system = crystal_system)
+
+        N_old = np.max(DS['labels'])
+        N_new = np.max(DS_new['labels'])
+
+        count = count+1
+        print('*************************** Done iterative No. {} for merging ***************************'.format(count))
+
+        if N_new == N_old or count >= count_max:
+            stop_merge = True
+        else:
+            DS = DS_new.copy()
+
+    end_time = time.time()
+    print("The whole merging took {:.4f} seconds".format(end_time - start_time))
+
+    return DS_new
+
+
+def DS_remove_small_grains(DS, min_vol = 2):
+    """
+    Remove small grains defined by no bigger than min_vol voxels
+    
+    Arguments:
+    DS                -- grain map dictionary, gm = grainmap(tensor_map_file); DS = gm.DS
+    min_vol           -- minimum number of voxels to be kept in DS [voxel]
+
+    Returns:
+    DS_out            -- DS grain map dictionary with updated grain IDs
+    """
+    
+    assert 'labels' in DS.keys(), "labels must be in DS keys"
+    DS_out = DS.copy()
+    count1 = 0
+    count2 = 0
+    for j in range(np.max(DS['labels'])+1):
+        ind = np.array(np.where(DS['labels'] == j)).T
+        Vregion = ind.shape[0] # number of voxels for each grain
+        if Vregion <= min_vol:
+            count1 += 1
+            DS_out['labels'][ind[:,0], ind[:,1], ind[:,2]] = -1
+        elif Vregion > min_vol:
+            count2 += 1
+    print('Found and removed {} small grains with size <= {} voxels; {} grains left now.'.format(count1, min_vol, count2))
+    return DS_out
+
+
+def DS_merge_and_identify_grains_sub(DS, FirstGrainID = 0, min_misori = 3.0, dis_tol = np.sqrt(2), crystal_system = 'cubic'):
+    
+    """
+    sub function:
+    Merge regions within which the voxel misorientation is smaller than a pre-defined values
+    New grain ID will be assigned to DS dictionary 'labels' key
+    Optional to keep the first grain IDs static by defining FirstGrainID (by default = 0 means no first grains to be static)
+
+    Arguments:
+    DS                -- grain map dictionary, gm = grainmap(tensor_map_file); DS = gm.DS
+    FirstGrainID      -- First grain ID to be considered for merging, by default = 0
+    min_misori        -- misorientation for merging regions
+    dis_tol           -- maximum distance around the target voxel for identifying its neigboring grains, np.sqrt(2) corresponds to distance to the diagonal voxel in 2D
+    crystal_system    -- crystal system name one of ['cubic', 'hexagonal', 'orthorhombic', 'tetragonal', 'trigonal', 'monoclinic', 'triclinic']
+
+    Returns:
+    DS_merge          -- DS grain map dictionary with updated grain IDs
+    """
+    
+    if crystal_system in ['cubic', 'hexagonal', 'orthorhombic', 'tetragonal', 'trigonal', 'monoclinic', 'triclinic']:
+        print('{} is OK'.format(crystal_system))
+        crystal_structure = Symmetry[crystal_system]
+    else:
+        raise ValueError('{} is not supported.'.format(crystal_system))
+    
+    DS_merge = DS.copy()
+    DS_merge['labels'] = np.zeros_like(DS['labels']) - 1
+
+    id = np.unique(DS['labels'].ravel())
+    id = id[id >= FirstGrainID]  # Filter IDs greater than or equal to FirstGrainID
+    id = np.sort(id)
+    id0 = len(id)
+    print('Initial number of grain IDs is {}'.format(id0))
+
+    # Initialize Vregion array to store the number of voxels for each region
+    Vregion=np.zeros((np.max(DS['labels'])+1, 1), dtype = 'int64')
+    print('Get the number of voxels for each of the {} regions ...'.format(len(id)) )       
+    for j in range(np.max(DS['labels'])+1):
+        Vregion[j] = np.array(np.where(DS['labels'] == j)).T.shape[0] # number of voxels for each region
+        if j % 20000 == 0 or j == np.max(DS['labels'])-1:
+            print('Done for {} regions ...'.format(j))
+            
+    # Retrieve GrainIDs for the unchanged ones
+    if FirstGrainID > 0:
+        print('Retrieve the first {} grain IDs, which are supposed to stay static ...'.format(FirstGrainID - 1))
+        for i in range(FirstGrainID):
+            ind = np.array(np.where(DS['labels'] == i)).T
+            if ind.size > 0:
+                DS_merge['labels'][ind[:, 0], ind[:, 1], ind[:, 2]] = i
+
+    # merging loop
+    ct = 0
+    stop_merge = False
+    i = -1
+    cutbox = np.zeros((3, 2), dtype=int)
+    print('{} regions to be merged ...'.format(id0))
+    start_time = time.time()
+    while not stop_merge:
+        i += 1
+        id_vol = DS['labels'] == id[0]
+        id_bbox = np.array(np.where(id_vol > 0)).T
+
+        cutbox[:, 0] = np.maximum(np.min(id_bbox, axis=0) - 2, 0)
+        cutbox[:, 1] = np.minimum(np.max(id_bbox, axis=0) + 2, np.array(DS['labels'].shape) - 1)
+
+        slices = tuple(slice(cutbox[ii, 0], cutbox[ii, 1] + 1) for ii in range(3))
+        id_vol_cut = id_vol[slices]
+        vol_cut = DS['labels'][slices]
+
+        # Compute distance map and neighbors
+        id_dismap = distance_transform_edt(~id_vol_cut)  # Equivalent to bwdist in MATLAB
+        id_neigb = (id_dismap > 0) & (id_dismap < dis_tol)
+        id_neigb = np.unique(vol_cut[id_neigb])
+        id_neigb = id_neigb[id_neigb > -1]  # Filter out -1 values
+
+        id_indices = np.array(np.where(id_vol)).T
+
+        if len(id_indices) > 1:
+            # Multiple indices case
+            id_indices_ind = np.ravel_multi_index(
+                (id_indices[:, 0], id_indices[:, 1], id_indices[:, 2]), id_vol.shape
+            )
+            r0 = get_mean_rod(DS['Rod'][id_indices[:, 0], id_indices[:, 1], id_indices[:, 2], :])
+        else:
+            r0 = np.ravel(DS['Rod'][id_indices[:, 0], id_indices[:, 1], id_indices[:, 2]])
+
+        # get the information for the target region
+        U0 = ori_converter.quat2u(ori_converter.rod2quat(r0))
+        euler_angles0 = ori_converter.u2euler(U0)
+        V0 = Vregion[ id[0] ]
+        mergeInd = id_indices    # indices for merging regions    
+
+        # find the potential neighboring region to be merged by checking the misorientation
+        indices_neigb_tomerge = []    
+        if id_neigb.size > 0:
+            r1_list = []
+            ang_list = []
+            indices_neigb_tomerge = []
+            V1_list = []
+
+            for id_neigb_j in id_neigb:
+                neigb_vol = DS['labels'] == id_neigb_j
+                indices_neigb = np.array(np.where(neigb_vol)).T
+
+                r1 = get_mean_rod(DS['Rod'][indices_neigb[:, 0], indices_neigb[:, 1], indices_neigb[:, 2], :].T)
+                U1 = ori_converter.quat2u(ori_converter.rod2quat(r1))
+                the_angle, _, _ = disorientation(U0, U1, crystal_structure=crystal_structure)
+
+                ang_list.append(np.rad2deg(the_angle))
+                V1_list.append(Vregion[id_neigb_j])
+                r1_list.append(r1)
+
+                if np.rad2deg(the_angle) <= min_misori:
+                    indices_neigb_tomerge.append(indices_neigb)
+
+            # Batch computation for neighbors
+            ang = np.array(ang_list)
+            V1 = np.array(V1_list)
+            r1 = np.array(r1_list)
+
+            ID_for_merge_indices = np.where(ang <= min_misori)[0]
+            ID_for_merge = id_neigb[ID_for_merge_indices]
+
+            newGrainID = i + FirstGrainID
+
+            if ID_for_merge.size != 0:
+                # Inherit_region_nr = np.hstack([id[0], ID_for_merge])
+                weights = np.vstack([V0, V1[ID_for_merge_indices]])/np.sum( np.vstack([V0, V1[ID_for_merge_indices]]) ) # weights for updating the orientation and completeness
+
+                r_new = np.dot(np.vstack([r0, r1[ID_for_merge_indices,:].reshape(len(ID_for_merge_indices), 3)]).T, weights).T # new Rodrigues vector
+                U_new = ori_converter.quat2u(ori_converter.rod2quat(np.ravel(r_new)))
+                EulerZXZ_new = ori_converter.u2euler(U_new)
+                
+                indices_neigb_tomerge = np.vstack(indices_neigb_tomerge)
+                mergeInd = np.vstack([mergeInd, indices_neigb_tomerge])  # all indices to be merged together
+                if np.min(ID_for_merge) < FirstGrainID:
+                    # print('Detect smaller grain ID:')
+                    # print(newGrainID, ID_for_merge)
+                    newGrainID = np.min(ID_for_merge)
+                    ct += 1
+                    # print(ct)
+            else:
+                # Inherit_region_nr = id[0]
+                EulerZXZ_new = euler_angles0
+                r_new = r0
+
+            # update DS_merge
+            DS_merge['labels'][mergeInd[:,0], mergeInd[:,1], mergeInd[:,2]] = newGrainID
+
+            # remove the id which have been processed
+            id = np.setdiff1d(id, np.hstack([id[0], np.ravel(ID_for_merge)]))
+        else:
+            Inherit_region_nr = id[0]
+            U_new = U0
+            DS_merge['labels'][mergeInd[:,0], mergeInd[:,1], mergeInd[:,2]] = i + FirstGrainID
+            id = np.setdiff1d(id, id[0])
+
+        # Display progress
+        if i > 1 and i % 10000 == 0:
+            print('{} grains identified. {} regions have been merged and {} regions waiting for merging ...'.format(i+1, id0 - len(id), len(id)))
+
+        stop_merge = id.size == 0
+
+    end_time = time.time()
+    print("The whole merging took {:.4f} seconds".format(end_time - start_time))
+    print('{} grains identified out of {} regions.'.format(i+1, id0))
+    
+    return DS_merge
+    
+
+def indexing_iterative(cf_strong, grains, ds, ucell, pars, ds_max = 1.6, tol_angle = 0.25, tol_pixel =3, peak_assign_tol = 0.25, tol_misori = 3, crystal_system='cubic', **kwargs):
+    """
+    Using the rest of peaks that are not matched with already-indexed grains to index additional grains
+    Then, try to merge the grains by removing duplicate grains (if misori < tol_misori) and return grains_new
+    
+    Arguments:
+    cf_strong         -- ImageD11 colume file object file containing strong peaks
+    grains            -- ImageD11 grains object, already-indexed grains
+    ds                -- dataset object,   e.g. ds = ImageD11.sinograms.dataset.load(dset_file)
+    ucell             -- ImageD11.unitcell object, e.g. ucell = ds.phases.unitcells[phase_str]
+    pars              -- ImageD1.parameters object, e.g. pars = ImageD11.parameters.read_par_file(ds.parfile)
+    Optional arguments:
+    ds_max    -- maximum 1/d
+    tol_angle -- tolerance of angles for matching peaks
+    tol_piexl -- tolerance of pixels for matching peaks
+    peak_assign_tol -- tolerance for assigning peaks to grains
+    tol_misori -- minimal misorientation to distinguish grains
+    crystal_system -- string name of the crystal system, 'cubic', 'hexagonal', 'orthorhombic', 'tetragonal', 'trigonal', 'monoclinic', 'triclinic'
+    
+    Returns:
+    grains_new -- ImageD11 grains object, with update grain ids starting from 0
+    """
+    if crystal_system in ['cubic', 'hexagonal', 'orthorhombic', 'tetragonal', 'trigonal', 'monoclinic', 'triclinic']:
+        print('{} is OK'.format(crystal_system))
+    else:
+        raise ValueError('{} is not supported.'.format(crystal_system))
+    
+    cosine_tol = np.cos(np.radians(90 - ds.ostep))
+    args = {
+        "cf": cf_strong,
+        "unitcell": ucell,
+        "dstol": kwargs.get("indexer_ds_tol", 0.008),
+        "forgen": kwargs.get("rings_for_gen", [0, 3, 5]),
+        "foridx": kwargs.get("rings_for_scoring", [0, 1, 3, 4, 5]),
+        "hkl_tols": kwargs.get("hkl_tols_seq", [0.01, 0.02, 0.03, 0.04, 0.05]),
+        "fracs": kwargs.get("fracs", [0.9, 0.7]),
+        "cosine_tol": kwargs.get("cosine_tol", cosine_tol),
+        "max_grains": kwargs.get("max_grains", 1000),
+        }
+    print('I got indexing parameters as follows:')
+    print(args)
+    
+    # find all the peaks that have matched with already-indexed grains
+    print('****************** step 1: find all the peaks that are matched wwith already-indexed grains using forward model ***************************')
+    cf_matched_all, Comp_all = forward_model.forward_match_peaks(cf_strong, grains, ds, ucell, pars, ds_max = ds_max, tol_angle = tol_angle, tol_pixel=tol_pixel, thres_int=None)
+    
+    # find all the peaks that left unmatched
+    print('****************** step 2: find all the peaks that are left unindexed ***************************')
+    cf_clean = forward_model.cf_remove_unmatched_peaks(cf_strong, cf_matched_all)
+    cf_strong_rest, cf_clean_diff = forward_model.cf_set_difference(cf_strong, cf_clean, tol = 0.001)
+    
+    print('Sinograme of all matched peaks')
+    forward_model.cf_plot_sino(cf_clean)
+    print('Sinograme of the rest peaks')
+    forward_model.cf_plot_sino(cf_strong_rest)
+    print('{} / {} = {} matched peaks'.format(cf_clean.nrows, cf_strong.nrows, cf_clean.nrows/cf_strong.nrows))
+    print('{} / {} = {} peaks left unindexed'.format(cf_strong_rest.nrows, cf_strong.nrows, cf_strong_rest.nrows/cf_strong.nrows))
+    
+    # specify our ImageD11 indexer with these peaks
+    print('****************** step 3: index additional grains with all the left peaks ***************************')
+    indexer_rest = ImageD11.indexing.indexer_from_colfile(cf_strong_rest)
+    print("Indexing {} peaks".format(cf_strong_rest.nrows))
+    
+    # USER: set a tolerance in d-space (for assigning peaks to powder rings)
+    indexer_rest.ds_tol = args['dstol']
+
+    # change the log level so we can see what the ring assigments look like
+    ImageD11.indexing.loglevel = 1
+
+    # assign peaks to powder rings
+    indexer_rest.assigntorings()
+
+    # change log level back again
+    ImageD11.indexing.loglevel = 3
+    
+    # let's plot the assigned peaks
+    fig, ax = plt.subplots(layout='constrained', figsize=(10,5))
+
+    # indexer.ra is the ring assignments
+    ax.scatter(cf_strong_rest.ds, cf_strong_rest.eta, c=indexer_rest.ra, cmap='tab20', s=1)
+    ax.plot( ucell.ringds, [0,]*len(ucell.ringds), '|', ms=90, c="red")
+    ax.set_xlim(cf_strong_rest.ds.min()-0.05, cf_strong_rest.ds.max()+0.05)
+    ax.set_xlabel("d-star")
+    ax.set_ylabel("eta")
+
+    plt.show()
+    
+    grains_rest, indexer_rest = utils.do_index(**args)
+    print('Found {} grains!'.format(len(grains_rest)))
+
+    # add temporary grain IDs to the grains
+    for ginc, g in enumerate(grains_rest):
+        g.gid = ginc + len(grains)
+    
+    # plotting unit cell lenth
+    mean_unit_cell_lengths_rest = [np.cbrt(np.linalg.det(g.ubi)) for g in grains_rest]
+    fig, ax = plt.subplots()
+    ax.plot(mean_unit_cell_lengths_rest)
+    ax.set_xlabel("Grain ID")
+    ax.set_ylabel("Unit cell length")
+    plt.show()
+    a0_rest = np.median(mean_unit_cell_lengths_rest)
+    print('Average lattice parameter of newly indexed additional grains: {} angstrom'.format(a0_rest))
+          
+    # assign peaks to grains
+    utils.assign_peaks_to_grains(grains_rest, cf_strong_rest, tol=peak_assign_tol)
+    utils.plot_index_results(indexer_rest, cf_strong_rest, 'First attempt')
+    
+    # merge duplicated grains
+    print('****************** step 4: merge grains by removing duplicated grains based on their misorientations ***************************')
+    grains_new = merge_grains(grains, grains_rest, crystal_system = crystal_system, tol_misori = tol_misori)
+    print(len(grains), len(grains_rest), len(grains_new))
+          
+    # update grain IDs to the grains
+    for ginc, g in enumerate(grains_new):
+        g.gid = ginc
+
+    # plotting unit cell lenth for grains_new
+    mean_unit_cell_lengths_new = [np.cbrt(np.linalg.det(g.ubi)) for g in grains_new]
+    fig, ax = plt.subplots()
+    ax.plot(mean_unit_cell_lengths_new)
+    ax.set_xlabel("Grain ID")
+    ax.set_ylabel("Unit cell length")
+    plt.show()
+
+    a0_new = np.median(mean_unit_cell_lengths_new)
+
+    print('Average lattice parameter of all grains: {} angstrom'.format(a0_new))
+    print('Done !')
+    # if you want to assign peaks to grains_new, do this
+    # utils.assign_peaks_to_grains(grains_new, cf_strong, tol=peak_assign_tol)
+    # utils.plot_grain_sinograms(grains_new, cf_strong, min(len(grains_new), 25))
+    return grains_new
+
+
+def remove_gid_from_grains(grains, gid_to_remove = None):
+    """
+    Remove specific grains from the existing grains
+    
+    Arguments:
+    gid_to_remove -- a list of grain IDs to be removed
+    
+    Returns:
+    grains_new -- ImageD11 grains object, with update grain ids starting from 0
+    """
+    if gid_to_remove is not None:
+        grains_new = []
+        print('The following grain IDs will be removed and new grains object will be produced (note that thhe grain ID may be altered):')
+        print(gid_to_remove)
+        for g in grains:
+            if g.gid in gid_to_remove:
+                continue
+            else:
+                grains_new.append(g)
+        
+        # update grain IDs to the grains
+        for ginc, g in enumerate(grains_new):
+            g.gid = ginc
+    else:
+        print('Nothing needs to be done')
+        grains_new = grains
+    return grains_new
+
+
+def merge_grains(grains, grains_rest, crystal_system = 'cubic', tol_misori=3):
+    """
+    Identify duplicate grains and then make a new grains_new object
+    
+    Arguments:
+    grains         -- ImageD11 grains object, assuming from the first indexing
+    grains_rest    -- ImageD11 grains object, assuming from the second indexing
+    crystal_structure -- symmetry class with crystal symmetry operators
+    tol_ang            -- tolerance for misorientation to distinguish grains [deg]
+
+    Returns:
+    grains_new -- ImageD11 grains object, with update grain ids starting from 0
+    """
+    
+    if crystal_system in ['cubic', 'hexagonal', 'orthorhombic', 'tetragonal', 'trigonal', 'monoclinic', 'triclinic']:
+        crystal_structure = Symmetry[crystal_system]
+    else:
+        raise ValueError('{} is not supported.'.format(crystal_system))
+    
+    grains_new = []
+    oris_duplicate = set()  # Use a set for faster lookups
+    tol_rad = np.deg2rad(tol_misori)  # Convert tolerance to radians once
+    print('tol_misori = {} or {} rad'.format(tol_misori, tol_rad))
+    
+    # Precompute inverses for grains and grains_rest
+    inv_grains = {g.gid: np.linalg.inv(g.U) for g in grains}
+    inv_grains_rest = {g_rest.gid: np.linalg.inv(g_rest.U) for g_rest in grains_rest}
+    
+    # Check for duplicates and merge
+    for g in grains:
+        ori1 = inv_grains[g.gid]
+        for g_rest in grains_rest:
+            if g_rest.gid not in oris_duplicate:
+                ori2 = inv_grains_rest[g_rest.gid]
+                the_angle, the_axis, the_axis_xyz = disorientation(ori1, ori2, crystal_structure=crystal_structure)
+                if the_angle < tol_rad:  # Compare directly in radians
+                    print("Angle: {}, Axis: {}, Axis XYZ: {}".format(np.rad2deg(the_angle), the_axis, the_axis_xyz))
+                    oris_duplicate.add(g_rest.gid)
+                    print('grain no. {} from grains matches with grain no. {} from grains_rest'.format(g.gid, g_rest.gid))
+        grains_new.append(g)
+    
+    # get unique grains from grains_rest
+    grains_new.extend(g for g in grains_rest if g.gid not in oris_duplicate)
+    
+    # update grain IDs to the grains
+    for ginc, g in enumerate(grains_new):
+        g.gid = ginc
+        
+    return grains_new
+
+
+def pairing_grains(grains1, grains2, crystal_system='cubic', tol_misori=3, tol_dis=50, tol_int=[0.0, 0.0]):
+    """
+    pairing grains from two different grains objects, useful for tracking the same grain across different datasets
+    about 3 times faster with parallel, it may be speed up further
+    
+    Arguments:
+    grains1         -- ImageD11 grains object
+    grains2         -- ImageD11 grains object assuming from the second indexing
+    crystal_structure -- symmetry class with crystal symmetry operators
+    tol_ang            -- tolerance for misorientation to distinguish grains [deg]
+    tol_dis            -- tolerance for distance-to-volume-center to distinguish grains [um]
+    tol_int            -- tolerance for intensity (relative difference in mean intensity) to distinguish grains [-]
+
+    Returns:
+    PairIndex -- numpy array with a shape of N*18, column means [i, j, rod_i, rod_j, int_sum1, int_sum2, mis_ori, dis, COM_i, COM_j]
+    """   
+
+    if crystal_system in ['cubic', 'hexagonal', 'orthorhombic', 'tetragonal', 'trigonal', 'monoclinic', 'triclinic']:
+        crystal_structure = Symmetry[crystal_system]
+    else:
+        raise ValueError('{} is not supported.'.format(crystal_system))
+
+    print('Got {} grains from grain1 and {} grains from grains2'.format(len(grains1), len(grains2)))
+    print('I will use the following tolerances for pairing grains:')
+    print('tol_misori = {} deg'.format(tol_misori))
+    print('tol_dis = {} um'.format(tol_dis))
+    if not tol_int == [0.0, 0.0]:
+        print('tol_int = {}'.format(tol_int))
+    
+    tol_rad = np.deg2rad(tol_misori)
+    inv_grains1 = np.array([np.linalg.inv(g.U) for g in grains1])
+    inv_grains2 = np.array([np.linalg.inv(g.U) for g in grains2])
+    
+    translations1 = np.array([g.translation if g.translation is not None else [0.0, 0.0, 0.0] for g in grains1])
+    translations2 = np.array([g.translation if g.translation is not None else [0.0, 0.0, 0.0] for g in grains2])
+    
+    intensities1 = [read_intensity_info(g.intensity_info)['sum_of_all'] for g in grains1]
+    intensities2 = [read_intensity_info(g.intensity_info)['sum_of_all'] for g in grains2]
+
+    def process_pair(i, j):
+        ori1, ori2 = inv_grains1[i], inv_grains2[j]
+        pos1, pos2 = translations1[i], translations2[j]
+        intensity1, intensity2 = intensities1[i], intensities2[j]
+
+        # Calculate misorientation
+        the_angle, _, _ = disorientation(ori1, ori2, crystal_structure=crystal_structure)
+
+        # Calculate distance
+        dis = np.linalg.norm(pos1 - pos2)
+
+        # Check tolerances
+        if the_angle < tol_rad and dis < tol_dis:
+            if tol_int == [0.0, 0.0]:
+                return [i, j, grains1[i].Rod[0], grains1[i].Rod[1], grains1[i].Rod[2],
+                        grains2[j].Rod[0], grains2[j].Rod[1], grains2[j].Rod[2],
+                        intensity1, intensity2, np.rad2deg(the_angle), dis,
+                        *pos1, *pos2]
+            else:
+                intensity_diff = abs(intensity1 - intensity2) / intensity1
+                if tol_int[0] <= intensity_diff <= tol_int[1]:
+                    return [i, j, grains1[i].Rod[0], grains1[i].Rod[1], grains1[i].Rod[2],
+                            grains2[j].Rod[0], grains2[j].Rod[1], grains2[j].Rod[2],
+                            intensity1, intensity2, np.rad2deg(the_angle), dis,
+                            *pos1, *pos2]
+        return None
+    
+    total_pairs = len(grains1) * len(grains2)
+    print('{} comparisons will be performed.'.format(total_pairs))
+    
+    start_time = time.time()
+    pairs = Parallel(n_jobs=-1, backend='loky')(
+        delayed(process_pair)(i, j) for i, j in tqdm([(i, j) for i in range(len(grains1)) for j in range(len(grains2))], total=total_pairs)
+    )
+    elapsed_time = end_time = time.time() - start_time
+    print("Time taken: {} seconds".format(elapsed_time))
+    print('PairIndex column info: [i, j, rod_i, rod_j, int_sum1, int_sum2, mis_ori, dis, COM_i, COM_j]')
+    
+    # Filter and convert to NumPy array
+    PairIndex = np.array([pair for pair in pairs if pair is not None])
+    print('{} pairs found.'.format(len(PairIndex)))
+
+    return PairIndex
+
+
+def read_intensity_info(text):
+    # Input string example
+    # text = 'sum_of_all = 4989843.970096 , middle 343 from 0.000000 to 180.000000 in tth: median = 5725.219460 , min = 133.669141 , max = 90410.322693 , mean = 14010.814810 , std = 19810.559831 , n = 343\n'
+
+    # Regular expression to match key-value pairs
+    pattern = r'(\w+(?:_\w+)?) = ([\d\.]+)'
+
+    # Extract matches into a dictionary
+    data = {key: float(value) for key, value in re.findall(pattern, text)}
+
+    return data
+
+
+def get_mean_rod(rod, kmeans_flag=False):
+    """
+    Compute the mean Rodrigues vector with optional k-means clustering.
+    
+    Parameters:
+    - rod: numpy array of shape (n, 3) or (3, n) representing Rodrigues vectors
+    - kmeans_flag: boolean, whether to perform k-means clustering
+
+    Returns:
+    - rod_mean: numpy array of shape (3,) representing the mean Rodrigues vector
+    """
+    rod = np.array(rod)
+    
+    # Ensure rod has shape (n, 3)
+    if rod.shape[1] != 3 and rod.shape[0] == 3:
+        rod = rod.T
+    
+    if kmeans_flag and len(rod) > 1:
+        # Perform k-means clustering
+        kmeans = KMeans(n_clusters=2, random_state=0).fit(rod)
+        C = kmeans.cluster_centers_  # Centroids
+        idx = kmeans.labels_         # Cluster indices
+        
+        # Compute the distance between the two cluster centroids
+        C_diff = np.linalg.norm(C[0] - C[1])
+        
+        if C_diff > 0.5:
+            # Separate into two clusters
+            rod1 = rod[idx == 0]
+            rod2 = rod[idx == 1]
+            
+            # Choose the larger cluster
+            if len(rod1) > len(rod2):
+                larger_cluster = rod1
+            else:
+                larger_cluster = rod2
+            
+            # Compute the median for each coordinate
+            mid_ind = len(larger_cluster) // 2
+            rod_mean = np.zeros(3)
+            for i in range(3):
+                rod_temp = np.sort(larger_cluster[:, i])
+                rod_mean[i] = rod_temp[mid_ind]
+        else:
+            # If centroids are close, use the first centroid
+            rod_mean = C[0]
+    else:
+        # Compute the median for the entire set
+        mid_ind = len(rod) // 2
+        rod_mean = np.zeros(3)
+        for i in range(3):
+            rod_temp = np.sort(rod[:, i])
+            rod_mean[i] = rod_temp[mid_ind]
+    
+    return rod_mean
+
+
+# this class comes from pymicro/crystal/lattice.py
+class Symmetry(enum.Enum):
+    """
+    Class to describe crystal symmetry defined by its Laue class symbol.
+    """
+    cubic = 'm3m'
+    hexagonal = '6/mmm'
+    orthorhombic = 'mmm'
+    tetragonal = '4/mmm'
+    trigonal = 'bar3m'
+    monoclinic = '2/m'
+    triclinic = 'bar1'
+
+    @staticmethod
+    def from_string(s):
+        if s == 'cubic':
+            return Symmetry.cubic
+        elif s == 'hexagonal':
+            return Symmetry.hexagonal
+        elif s == 'orthorhombic':
+            return Symmetry.orthorhombic
+        elif s == 'tetragonal':
+            return Symmetry.tetragonal
+        elif s == 'trigonal':
+            return Symmetry.trigonal
+        elif s == 'monoclinic':
+            return Symmetry.monoclinic
+        elif s == 'triclinic':
+            return Symmetry.triclinic
+        else:
+            return None
+
+    def to_string(self):
+        if self is Symmetry.cubic:
+            return 'cubic'
+        elif self is Symmetry.hexagonal:
+            return 'hexagonal'
+        elif self is Symmetry.orthorhombic:
+            return 'orthorhombic'
+        elif self is Symmetry.tetragonal:
+            return 'tetragonal'
+        elif self is Symmetry.trigonal:
+            return 'trigonal'
+        elif self is Symmetry.monoclinic:
+            return 'monoclinic'
+        elif self is Symmetry.triclinic:
+            return 'triclinic'
+        else:
+            return None
+
+    @staticmethod
+    def from_dream3d(n):
+        if n in [1, 3]:
+            return Symmetry.cubic
+        elif n in[0, 2]:
+            return Symmetry.hexagonal
+        elif n == 6:
+            return Symmetry.orthorhombic
+        elif n in [7, 8]:
+            return Symmetry.tetragonal
+        elif n in [9, 10]:
+            return Symmetry.trigonal
+        elif n == 5:
+            return Symmetry.monoclinic
+        elif n == 4:
+            return Symmetry.triclinic
+        else:
+            return None
+
+    @staticmethod
+    def from_space_group(space_group_number):
+        """Create an instance of the `Symmetry` class from a TSL symmetry
+        number.
+
+        :raise ValueError: if the space_group_number is not between 1 and 230.
+        :param int space_group_number: the number asociated with the
+        space group (between 1 and 230).
+        :return: an instance of the `Symmetry` class
+        """
+        if space_group_number < 1 or space_group_number > 230:
+          raise ValueError('space_group_number must be between 1 and 230')
+          return None
+        if space_group_number <= 2:
+            return Symmetry.triclinic
+        elif space_group_number <= 15:
+            return Symmetry.monoclinic
+        elif space_group_number <= 74:
+            return Symmetry.orthorhombic
+        elif space_group_number <= 142:
+            return Symmetry.tetragonal
+        elif space_group_number <= 167:
+            return Symmetry.trigonal
+        elif space_group_number <= 194:
+            return Symmetry.hexagonal
+        else:
+            return Symmetry.cubic
+
+    @staticmethod
+    def from_tsl(tsl_number):
+        """Create an instance of the `Symmetry` class from a TSL symmetry
+        number.
+
+        :return: an instance of the `Symmetry` class
+        """
+        if tsl_number == 43:
+            return Symmetry.cubic
+        elif tsl_number == 62:
+            return Symmetry.hexagonal
+        elif tsl_number == 22:
+            return Symmetry.orthorhombic
+        elif tsl_number == 42:
+            return Symmetry.tetragonal
+        elif tsl_number == 32:
+            return Symmetry.trigonal
+        elif tsl_number == 2:
+            return Symmetry.monoclinic
+        elif tsl_number == 1:
+            return Symmetry.triclinic
+        else:
+            return None
+
+    @staticmethod
+    def to_tsl(symmetry):
+        """Convert a type of crystal `Symmetry` in the corresponding TSL number.
+
+        :return: the TSL number for this symmetry.
+        """
+        if symmetry is Symmetry.cubic:
+            return 43
+        elif symmetry is Symmetry.hexagonal:
+            return 62
+        elif symmetry is Symmetry.orthorhombic:
+            return 22
+        elif symmetry is Symmetry.tetragonal:
+            return 42
+        elif symmetry is Symmetry.trigonal:
+            return 32
+        elif symmetry is Symmetry.monoclinic:
+            return 2
+        elif symmetry is Symmetry.triclinic:
+            return 1
+        else:
+            return None
+
+    def symmetry_operators(self, use_miller_bravais=False):
+        """Define the equivalent crystal symmetries.
+
+        Those come from Randle & Engler, 2000. For instance in the cubic
+        crystal struture, for instance there are 24 equivalent cube orientations.
+
+        :return array: A numpy array of shape (n, 3, 3) where n is the \
+        number of symmetries of the given crystal structure.
+        """
+        if self is Symmetry.cubic:
+            sym = np.zeros((24, 3, 3), dtype=float)
+            sym[0] = np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+            sym[1] = np.array([[0., 0., -1.], [0., -1., 0.], [-1., 0., 0.]])
+            sym[2] = np.array([[0., 0., -1.], [0., 1., 0.], [1., 0., 0.]])
+            sym[3] = np.array([[-1., 0., 0.], [0., 1., 0.], [0., 0., -1.]])
+            sym[4] = np.array([[0., 0., 1.], [0., 1., 0.], [-1., 0., 0.]])
+            sym[5] = np.array([[1., 0., 0.], [0., 0., -1.], [0., 1., 0.]])
+            sym[6] = np.array([[1., 0., 0.], [0., -1., 0.], [0., 0., -1.]])
+            sym[7] = np.array([[1., 0., 0.], [0., 0., 1.], [0., -1., 0.]])
+            sym[8] = np.array([[0., -1., 0.], [1., 0., 0.], [0., 0., 1.]])
+            sym[9] = np.array([[-1., 0., 0.], [0., -1., 0.], [0., 0., 1.]])
+            sym[10] = np.array([[0., 1., 0.], [-1., 0., 0.], [0., 0., 1.]])
+            sym[11] = np.array([[0., 0., 1.], [1., 0., 0.], [0., 1., 0.]])
+            sym[12] = np.array([[0., 1., 0.], [0., 0., 1.], [1., 0., 0.]])
+            sym[13] = np.array([[0., 0., -1.], [-1., 0., 0.], [0., 1., 0.]])
+            sym[14] = np.array([[0., -1., 0.], [0., 0., 1.], [-1., 0., 0.]])
+            sym[15] = np.array([[0., 1., 0.], [0., 0., -1.], [-1., 0., 0.]])
+            sym[16] = np.array([[0., 0., -1.], [1., 0., 0.], [0., -1., 0.]])
+            sym[17] = np.array([[0., 0., 1.], [-1., 0., 0.], [0., -1., 0.]])
+            sym[18] = np.array([[0., -1., 0.], [0., 0., -1.], [1., 0., 0.]])
+            sym[19] = np.array([[0., 1., 0.], [1., 0., 0.], [0., 0., -1.]])
+            sym[20] = np.array([[-1., 0., 0.], [0., 0., 1.], [0., 1., 0.]])
+            sym[21] = np.array([[0., 0., 1.], [0., -1., 0.], [1., 0., 0.]])
+            sym[22] = np.array([[0., -1., 0.], [-1., 0., 0.], [0., 0., -1.]])
+            sym[23] = np.array([[-1., 0., 0.], [0., 0., -1.], [0., -1., 0.]])
+        elif self is Symmetry.hexagonal:
+            if use_miller_bravais:
+              # using the Miller-Bravais representation here
+              sym = np.zeros((12, 4, 4), dtype=float)
+              sym[0] = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+              sym[1] = np.array([[0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+              sym[2] = np.array([[0, 1, 0, 0], [0, 0, 1, 0], [1, 0, 0, 0], [0, 0, 0, 1]])
+              sym[3] = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]])
+              sym[4] = np.array([[0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, -1]])
+              sym[5] = np.array([[0, 1, 0, 0], [0, 0, 1, 0], [1, 0, 0, 0], [0, 0, 0, -1]])
+              sym[6] = np.array([[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
+              sym[7] = np.array([[0, 0, -1, 0], [-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]])
+              sym[8] = np.array([[0, -1, 0, 0], [0, 0, -1, 0], [-1, 0, 0, 0], [0, 0, 0, 1]])
+              sym[9] = np.array([[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]])
+              sym[10] = np.array([[0, 0, -1, 0], [-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, -1]])
+              sym[11] = np.array([[0, -1, 0, 0], [0, 0, -1, 0], [-1, 0, 0, 0], [0, 0, 0, -1]])
+            else:
+              sym = np.zeros((12, 3, 3), dtype=float)
+              s60 = np.sin(60 * np.pi / 180)
+              sym[0] = np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+              sym[1] = np.array([[0.5, s60, 0.], [-s60, 0.5, 0.], [0., 0., 1.]])
+              sym[2] = np.array([[-0.5, s60, 0.], [-s60, -0.5, 0.], [0., 0., 1.]])
+              sym[3] = np.array([[-1., 0., 0.], [0., -1., 0.], [0., 0., 1.]])
+              sym[4] = np.array([[-0.5, -s60, 0.], [s60, -0.5, 0.], [0., 0., 1.]])
+              sym[5] = np.array([[0.5, -s60, 0.], [s60, 0.5, 0.], [0., 0., 1.]])
+              sym[6] = np.array([[1., 0., 0.], [0., -1., 0.], [0., 0., -1.]])
+              sym[7] = np.array([[0.5, s60, 0.], [s60, -0.5, 0.], [0., 0., -1.]])
+              sym[8] = np.array([[-0.5, s60, 0.], [s60, 0.5, 0.], [0., 0., -1.]])
+              sym[9] = np.array([[-1., 0., 0.], [0., 1., 0.], [0., 0., -1.]])
+              sym[10] = np.array([[-0.5, -s60, 0.], [-s60, 0.5, 0.], [0., 0., -1.]])
+              sym[11] = np.array([[0.5, -s60, 0.], [-s60, -0.5, 0.], [0., 0., -1.]])
+        elif self is Symmetry.orthorhombic:
+            sym = np.zeros((4, 3, 3), dtype=float)
+            sym[0] = np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+            sym[1] = np.array([[1., 0., 0.], [0., -1., 0.], [0., 0., -1.]])
+            sym[2] = np.array([[-1., 0., -1.], [0., 1., 0.], [0., 0., -1.]])
+            sym[3] = np.array([[-1., 0., 0.], [0., -1., 0.], [0., 0., 1.]])
+        elif self is Symmetry.tetragonal:
+            sym = np.zeros((8, 3, 3), dtype=float)
+            sym[0] = np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+            sym[1] = np.array([[0., -1., 0.], [1., 0., 0.], [0., 0., 1.]])
+            sym[2] = np.array([[-1., 0., 0.], [0., -1., 0.], [0., 0., 1.]])
+            sym[3] = np.array([[0., 1., 0.], [-1., 0., 0.], [0., 0., 1.]])
+            sym[4] = np.array([[1., 0., 0.], [0., -1., 0.], [0., 0., -1.]])
+            sym[5] = np.array([[-1., 0., 0.], [0., 1., 0.], [0., 0., -1.]])
+            sym[6] = np.array([[0., 1., 0.], [1., 0., 0.], [0., 0., -1.]])
+            sym[7] = np.array([[0., -1., 0.], [-1., 0., 0.], [0., 0., -1.]])
+        elif self is Symmetry.triclinic:
+            sym = np.zeros((1, 3, 3), dtype=float)
+            sym[0] = np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+        else:
+            raise ValueError('warning, symmetry not supported: %s' % self)
+        return sym
+
+    def move_vector_to_FZ(self, v):
+        """
+        Move the vector to the Fundamental Zone of a given `Symmetry` instance.
+
+        :param v: a 3 components vector.
+        :return: a new 3 components vector in the fundamental zone.
+        """
+        omegas = []  # list to store all the rotation angles
+        syms = self.symmetry_operators()
+        for sym in syms:
+            # apply symmetry to the vector and compute the corresponding angle
+            v_sym = np.dot(sym, v)
+            omega = 2 * np.arctan(np.linalg.norm(v_sym)) * 180 / np.pi
+            omegas.append(omega)
+        # the fundamental zone corresponds to the minimum angle
+        index = np.argmin(omegas)
+        return np.dot(syms[index], v)
+
+    def move_rotation_to_FZ(self, g, verbose=False):
+        """Compute the rotation matrix in the Fundamental Zone of a given
+        `Symmetry` instance.
+
+        The principle is to apply all symmetry operators to the rotation matrix
+        and identify which one yield the smallest rotation angle. The
+        corresponding rotation is then returned. This computation is vectorized
+        to save time.
+
+        :param g: a 3x3 matrix representing the rotation.
+        :param bool verbose: flag for verbose mode.
+        :return: a new 3x3 matrix for the rotation in the fundamental zone.
+        """
+        syms = self.symmetry_operators()
+        g_syms = np.dot(syms, g)
+        traces = np.trace(g_syms, axis1=1, axis2=2)
+        omegas = np.arccos(0.5 * (traces - 1))
+        index = np.argmin(omegas)
+        if verbose:
+            print(traces)
+            print(omegas)
+            print('moving to FZ, index = %d' % index)
+        return g_syms[index]
+
+    def lattice_parameters_number(self):
+        """Return the number of parameter associated with a lattice of this
+        symmetry.
+
+        :return: the number of parameters.
+        """
+        if self is Symmetry.cubic:
+            return 1
+        elif self in [Symmetry.hexagonal, Symmetry.trigonal, Symmetry.tetragonal]:
+            return 2
+        elif self is Symmetry.orthorhombic:
+            return 3
+        elif self is Symmetry.monoclinic:
+            return 4
+        else:  # triclinic case
+            return 6
+
+    def elastic_constants_number(self):
+        """Return the number of independent elastic constants for this symmetry.
+
+        :return: the number of elastic constants.
+        """
+        if self is Symmetry.cubic:
+            return 3
+        elif self is Symmetry.hexagonal:
+            return 5
+        elif self is Symmetry.tetragonal:
+            return 6
+        elif self is Symmetry.orthorhombic:
+            return 9
+        elif self is Symmetry.monoclinic:
+            return 13
+        else:  # triclinic case
+            return 21
+
+    def stiffness_matrix(self, elastic_constants):
+        """Build the stiffness matrix for this symmetry using Voigt convention.
+
+        The Voigt notation contracts 2 tensor indices into a single index:
+        11 -> 1, 22 -> 2, 33 -> 3, 23 -> 4, 31 -> 5, 12 -> 6
+
+        :param list elastic_constants: the elastic constants (the number must
+            correspond to the type of symmetry, eg 3 for cubic).
+        :return ndarray: a numpy array of shape (6, 6) representing
+            the stiffness matrix.
+        """
+        if self is Symmetry.cubic:
+            if len(elastic_constants) != 3:
+                raise ValueError('Error: need 3 elastic constants for cubic '
+                                 'symmetry, got %d' % len(elastic_constants))
+            C11, C12, C44 = elastic_constants
+            C = np.array([[C11, C12, C12,   0,   0,   0],
+                          [C12, C11, C12,   0,   0,   0],
+                          [C12, C12, C11,   0,   0,   0],
+                          [  0,   0,   0, C44,   0,   0],
+                          [  0,   0,   0,   0, C44,   0],
+                          [  0,   0,   0,   0,   0, C44]])
+            return C
+        elif self is Symmetry.hexagonal:
+            if len(elastic_constants) != 5:
+                raise ValueError('Error: need 5 elastic constants for hexagonal '
+                                 'symmetry, got %d' % len(elastic_constants))
+            C11, C12, C13, C33, C44 = elastic_constants
+            C66 = (C11 - C12) / 2
+            C = np.array([[C11, C12, C13,   0,   0,   0],
+                          [C12, C11, C13,   0,   0,   0],
+                          [C13, C13, C33,   0,   0,   0],
+                          [  0,   0,   0, C44,   0,   0],
+                          [  0,   0,   0,   0, C44,   0],
+                          [  0,   0,   0,   0,   0, C66]])
+            return C
+        elif self is Symmetry.tetragonal:
+            if len(elastic_constants) != 6:
+                raise ValueError('Error: need 6 elastic constants for tetragonal '
+                                 'symmetry, got %d' % len(elastic_constants))
+            C11, C12, C13, C33, C44, C66 = elastic_constants
+            C = np.array([[C11, C12, C13,   0,   0,   0],
+                          [C12, C11, C13,   0,   0,   0],
+                          [C13, C13, C33,   0,   0,   0],
+                          [  0,   0,   0, C44,   0,   0],
+                          [  0,   0,   0,   0, C44,   0],
+                          [  0,   0,   0,   0,   0, C66]])
+            return C
+        elif self is Symmetry.orthorhombic:
+            if len(elastic_constants) != 9:
+                raise ValueError('Error: need 9 elastic constants for tetragonal '
+                                 'symmetry, got %d' % len(elastic_constants))
+            C11, C12, C13, C22, C23, C33, C44, C55, C66 = elastic_constants
+            C = np.array([[C11, C12, C13,   0,   0,   0],
+                          [C12, C22, C23,   0,   0,   0],
+                          [C13, C23, C33,   0,   0,   0],
+                          [  0,   0,   0, C44,   0,   0],
+                          [  0,   0,   0,   0, C55,   0],
+                          [  0,   0,   0,   0,   0, C66]])
+            return C
+        elif self is Symmetry.monoclinic:
+            if len(elastic_constants) != 13:
+                raise ValueError('Error: need 13 elastic constants for monoclinic '
+                                 'symmetry, got %d' % len(elastic_constants))
+            C11, C12, C13, C16, C22, C23, C26, C33, C36, C44, C45, \
+            C55, C66 = elastic_constants
+            C = np.array([[C11, C12, C13,   0,   0, C16],
+                          [C12, C22, C23,   0,   0, C26],
+                          [C13, C23, C33,   0,   0, C36],
+                          [  0,   0,   0, C44, C45,   0],
+                          [  0,   0,   0, C45, C55,   0],
+                          [C16, C26, C36,   0,   0, C66]])
+            return C
+        elif self is Symmetry.triclinic:
+            if len(elastic_constants) != 21:
+                raise ValueError('Error: need 21 elastic constants for triclinic '
+                                 'symmetry, got %d' % len(elastic_constants))
+            C11, C12, C13, C14, C15, C16, C22, C23, C24, C25, C26, C33, \
+            C34, C35, C36, C44, C45, C46, C55, C56, C66 = elastic_constants
+            C = np.array([[C11, C12, C13, C14, C15, C16],
+                          [C12, C22, C23, C24, C25, C26],
+                          [C13, C23, C33, C34, C35, C36],
+                          [C14, C24, C34, C44, C45, C46],
+                          [C15, C25, C35, C45, C55, C56],
+                          [C16, C26, C36, C46, C56, C66]])
+            return C
+        else:
+            raise ValueError('warning, symmetry not supported: %s' % self)
+
+    @staticmethod
+    def orthotropic_constants_from_stiffness(C):
+        """Return orthotropic elastic constants from stiffness matrix.
+
+        :param ndarray C: a numpy array of shape (6, 6) representing
+            the stiffness matrix.
+        :return dict ortho_elas: a dictionary of orthotropic elastic constants
+            corresponding to the input stiffness matrix. Keys are
+            'E1','E2','E3','nu12','nu13','nu23','G12','G13','G23'
+        """
+        # compute the compliance matrix
+        S = np.linalg.inv(C)
+        # compute the orthotropic elastic constants
+        ortho_elas = dict()
+        ortho_elas['E1'] = 1 / S[0, 0]
+        ortho_elas['E2'] = 1 / S[1, 1]
+        ortho_elas['E3'] = 1 / S[2, 2]
+        ortho_elas['Nu12'] = -ortho_elas['E1'] * S[1, 0]
+        ortho_elas['Nu13'] = -ortho_elas['E1'] * S[2, 0]
+        ortho_elas['Nu23'] = -ortho_elas['E2'] * S[2, 1]
+        ortho_elas['G12'] = 1 / S[5, 5]
+        ortho_elas['G13'] = 1 / S[4, 4]
+        ortho_elas['G23'] = 1 / S[3, 3]
+        # return a dictionary populated with the relevant values
+        return ortho_elas
+
+
+# these functions are adapted from pymicro/crystal/microstructure.py
+def disorientation_list(ori1_list, ori2_list, crystal_structure=Symmetry.triclinic):
+    """
+    Compute the misorientation for lists of crystal orientations.
+    
+    Arguments:
+    ori1_list: A list or array of 3x3 rotation matrices (shape: [N, 3, 3])
+        describing the first set of orientations.
+    ori2_list: A list or array of 3x3 rotation matrices (shape: [N, 3, 3])
+        describing the second set of orientations.
+    crystal_structure: An instance of the `Symmetry` class describing the crystal symmetry.
+    
+    Returns:
+    A list of numpy arrays:
+    - angles: Misorientation angles in radians (shape: [N]).
+    - axes: Misorientation axes in crystal coordinates (shape: [N, 3]).
+    - axes_xyz: Misorientation axes in sample coordinates (shape: [N, 3]).
+    """
+    # Ensure inputs are numpy arrays
+    ori1_list = np.asarray(ori1_list)
+    ori2_list = np.asarray(ori2_list)
+    assert len(ori1_list) == len(ori2_list), "ori1_list must be the same length as ori2_list"
+    symmetries = crystal_structure.symmetry_operators()  # Shape: [num_sym_ops, 3, 3]
+    if len(ori1_list.shape) == 2:
+        num_orientations = 1
+    elif len(ori1_list.shape) == 3:
+        num_orientations = len(ori1_list)
+    else:
+        print('Only supports 2 or 3 dimensional inputs.')
+
+    # Initialize outputs
+    angles = []
+    axes = []
+    axes_xyz = []
+
+    # Iterate through all orientations
+    if num_orientations > 1:
+        for idx in range(num_orientations):
+            ori1 = ori1_list[idx]
+            ori2 = ori2_list[idx]
+            print(ori1)
+
+            the_angle, the_axis, the_axis_xyz = disorientation(ori1, ori2, crystal_structure=crystal_structure)
+            angles.append(the_angle)
+            axes.append(the_axis)
+            axes_xyz.append(the_axis_xyz)
+    else:
+        the_angle, the_axis, the_axis_xyz = disorientation(ori1_list, ori2_list, crystal_structure=crystal_structure)
+        angles.append(the_angle)
+        axes.append(the_axis)
+        axes_xyz.append(the_axis_xyz)
+
+    return angles, axes, axes_xyz
+
+
+def disorientation(ori1, ori2, crystal_structure=Symmetry.triclinic):
+    """
+    Compute the disorientation between two orientations using vectorized symmetry operations.
+
+    Arguments:
+    ori1: A 3x3 rotation matrix representing the first orientation.
+    ori2: A 3x3 rotation matrix representing the second orientation.
+    crystal_structure: A `Symmetry` class instance describing the crystal symmetry.
+    
+    Returns: Tuple (misorientation angle in radians, misorientation axis in crystal coordinates,
+              misorientation axis in sample coordinates).
+                  
+    Replace the function disorientation_deprecated, speed up by 10x faster
+    """
+    if (ori1 == ori2).all():
+        the_angle = 0.0
+        the_axis = np.array([0.0, 0.0, 1.0])
+        the_axis_xyz = np.array([0.0, 0.0, 1.0])
+    else:
+        the_angle = np.pi
+        the_axis = np.array([0., 0., 1.])
+        the_axis_xyz = np.array([0., 0., 1.])
+
+        # Get symmetry operators as an array of shape (N, 3, 3)
+        symmetries = crystal_structure.symmetry_operators()  # Shape: [N, 3, 3]
+        num_sym_ops = symmetries.shape[0]
+
+        # Apply symmetries to ori1 and ori2
+        oj_list = np.einsum('nij,jk->nik', symmetries, ori1)
+        oi_list = np.einsum('nij,jk->nik', symmetries, ori2)
+
+        # Compute all combinations of symmetrized ori1 and ori2
+        oj_list_T = np.transpose(oj_list, axes=(0, 2, 1))
+        delta_list = np.einsum('bij,bjk->bik', oi_list, oj_list_T)
+
+        # Calculate misorientation angles for all delta matrices
+        mis_angles = np.array([misorientation_angle_from_delta(delta) for delta in delta_list])
+
+        # Find the minimum non-zero misorientation angle
+        nonzero_mask = mis_angles > 0
+        try:
+            if np.any(nonzero_mask):
+                min_idx = np.argmin(mis_angles[nonzero_mask])
+                min_idx = np.where(nonzero_mask)[0][min_idx]
+        except ValueError:
+            min_idx = 0
+            print("No non-zero misorientation angles found.")
+        except Exception as e:
+            min_idx = 0
+            print("An unexpected error occurred: {}".format(e))            
+
+        the_angle = mis_angles[min_idx]
+
+        # Compute misorientation axis for the minimum angle
+        delta_min = delta_list[min_idx]
+        the_axis = misorientation_axis_from_delta(delta_min)
+
+        # Calculate the axis in sample coordinates
+        oi_min = oi_list[min_idx // num_sym_ops]
+        the_axis_xyz = np.dot(oi_min.T, the_axis)
+
+    return the_angle, the_axis, the_axis_xyz
+
+
+def disorientation_deprecated(ori1, ori2, crystal_structure=Symmetry.triclinic):
+    """This function is deprecated. Use `new_function` instead."""
+    
+    """Compute the disorientation another crystal orientation.
+
+    Considering all the possible crystal symmetries, the disorientation
+    is defined as the combination of the minimum misorientation angle
+    and the misorientation axis lying in the fundamental zone, which
+    can be used to bring the two lattices into coincidence.
+
+    .. note::
+
+     Both orientations are supposed to have the same symmetry. This is not
+     necessarily the case in multi-phase materials.
+
+    :param orientation: an instance of
+        :py:class:`~pymicro.crystal.microstructure.Orientation` class
+        describing the other crystal orientation from which to compute the
+        angle.
+    :param crystal_structure: an instance of the `Symmetry` class
+        describing the crystal symmetry, triclinic (no symmetry) by
+        default.
+    :returns tuple: the misorientation angle in radians, the axis as a
+        numpy vector (crystal coordinates), the axis as a numpy vector
+        (sample coordinates).
+    """
+    the_angle = np.pi
+    the_axis = np.array([0., 0., 1.])
+    the_axis_xyz = np.array([0., 0., 1.])
+    symmetries = crystal_structure.symmetry_operators()
+    (gA, gB) = (ori1, ori2)  # nicknames
+    for (g1, g2) in [(gA, gB), (gB, gA)]:
+        for j in range(symmetries.shape[0]):
+            sym_j = symmetries[j]
+            oj = np.dot(sym_j, g1)  # the crystal symmetry operator is left applied
+            for i in range(symmetries.shape[0]):
+                sym_i = symmetries[i]
+                oi = np.dot(sym_i, g2)
+                delta = np.dot(oi, oj.T)
+                mis_angle = misorientation_angle_from_delta(delta)
+                if mis_angle < the_angle:
+                    # now compute the misorientation axis, should check if it lies in the fundamental zone
+                    mis_axis = misorientation_axis_from_delta(delta)
+                    # here we have np.dot(oi.T, mis_axis) = np.dot(oj.T, mis_axis)
+                    # print(mis_axis, mis_angle*180/np.pi, np.dot(oj.T, mis_axis))
+                    the_angle = mis_angle
+                    the_axis = mis_axis
+                    the_axis_xyz = np.dot(oi.T, the_axis)
+    return the_angle, the_axis, the_axis_xyz
+
+
+def misorientation_angle_from_delta(delta):
+    """Compute the misorientation angle from the misorientation matrix.
+
+    Compute the angle associated with this misorientation matrix :math:`\\Delta g`.
+    It is defined as :math:`\\omega = \\arccos(\\text{trace}(\\Delta g)/2-1)`.
+    To avoid float rounding point error, the value of :math:`\\cos\\omega`
+    is clipped to [-1.0, 1.0].
+
+    .. note::
+
+      This does not account for the crystal symmetries. If you want to
+      find the disorientation between two orientations, use the
+      :py:meth:`~pymicro.crystal.microstructure.Orientation.disorientation`
+      method.
+
+    :param delta: The 3x3 misorientation matrix.
+    :returns float: the misorientation angle in radians.
+    """
+    cw = np.clip(0.5 * (delta.trace() - 1), -1., 1.)
+    omega = np.arccos(cw)
+    return omega
+
+
+def misorientation_axis_from_delta(delta):
+    """Compute the misorientation axis from the misorientation matrix.
+
+    :param delta: The 3x3 misorientation matrix.
+    :returns: the misorientation axis (normalised vector).
+    """
+    n = np.array([delta[1, 2] - delta[2, 1], delta[2, 0] -
+                  delta[0, 2], delta[0, 1] - delta[1, 0]])
+    n /= np.sqrt((delta[1, 2] - delta[2, 1]) ** 2 +
+                 (delta[2, 0] - delta[0, 2]) ** 2 +
+                 (delta[0, 1] - delta[1, 0]) ** 2)
+    return n

--- a/ImageD11/forward_model/io.py
+++ b/ImageD11/forward_model/io.py
@@ -438,7 +438,7 @@ def print_all_keys(d, prefix=""):
         raise TypeError("Expected a dictionary, but got {} instead.".format(type(d)))
     print('Got the following keys:')
     for key, value in d.items():
-        full_key = f"{prefix}.{key}" if prefix else key
+        full_key = "{}.{}".format(prefix, key) if prefix else key
         print(full_key)
         if isinstance(value, dict):  # If the value is a dictionary, recurse
             print_all_keys(value, prefix=full_key)
@@ -619,7 +619,7 @@ def read_fsparse(h5_file, group_name = "/entry_0000/ESRF-ID11/eiger/data"):
     with h5py.File(h5_file, 'r') as hin:
         g = hin.get(group_name)
         if g is None:
-            raise ValueError("Group '{}' not found in file '{}'".format(group_name, h5name))
+            raise ValueError("Group {} not found in file {}".format(group_name, h5_file))
         for name in names:
             if name in g.keys():
                 fsparse_pks[name] = g[name][()]

--- a/ImageD11/forward_model/io.py
+++ b/ImageD11/forward_model/io.py
@@ -3,12 +3,15 @@
 # edf images
 # tif images
 # xml (to be added)
+# fwd_peaks
+# bridge with cf
 # write to dream3d and xdmf files
 # read motor positions
 # Haixing Fang, haixing.fang@esrf.fr
 # March 20, 2024
+# updated on January 30, 2025
 
-import os
+import os, shutil
 import glob
 
 import numpy as np
@@ -19,11 +22,18 @@ import matplotlib
 import ImageD11.columnfile
 import ImageD11.unitcell
 import ImageD11.transformer
+from ImageD11.sinograms.dataset import colfile_from_dict
+
 import xml.etree.ElementTree as ET
 import scipy.io
 from scipy import ndimage
 import tifffile as tiff
 from PIL import Image
+
+from tqdm import tqdm
+import logging
+
+logging.basicConfig(level=logging.INFO, force=True)
 
 
 def read_images_from_h5(h5name, scan = '1.1', detector = None, StartIndex = None, EndIndex = None):
@@ -107,19 +117,32 @@ def read_motor_posisitions_from_h5(h5name, scan = '1.1'):
     return MotorPos
 
 
-def convert_h52_tif(h5name, save_path, prefix_name = 'proj', save_stack = False, ctrl_name = '1.1/measurement/marana3', data_format = 'uint16'):
+def convert_h52_tif(h5name, save_path, prefix_name = 'proj', save_stack = False, ctrl_name = '1.1/measurement/marana3', data_format = 'uint16', clip_range = None):
+    '''
+    Read images from an h5/hdf5 file and convert to a specified data format (uint16 or uint8) and save to tif images
+    Suitable for convert e.g. nabu_recon hdf5 to tif images
+    '''
+    print('Loading data from {}'.format(h5name))
     with h5py.File(h5name, 'r') as hin:
         dataset = hin[ctrl_name][:]
         print("Dataset shape:", dataset.shape)
-        if data_format == 'uint16':
-            print('Converting to uint16 format ...')
-            normalized_data = (65535 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint16)
-        elif data_format == 'uint8':
-            print('Converting to uint8 format ...')
-            normalized_data = (255 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint8)
-        else:
-            print('Converting to uint16 format ...')
-            normalized_data = (65535 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint16)
+        
+    if clip_range is None:
+        dataset_mean = np.mean(dataset)
+        dataset_std  = np.std(dataset)
+        clip_range = [dataset_mean - 3*dataset_std, dataset_mean + 3*dataset_std]
+    print("clip_range = {}".format(clip_range))
+    dataset = np.clip(dataset, clip_range[0], clip_range[1])  # Clip values to the given range
+
+    if data_format == 'uint16':
+        print('Converting to uint16 format ...')
+        normalized_data = (65535 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint16)
+    elif data_format == 'uint8':
+        print('Converting to uint8 format ...')
+        normalized_data = (255 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint8)
+    else:
+        print('Converting to uint16 format ...')
+        normalized_data = (65535 * (dataset - np.min(dataset)) / (np.max(dataset) - np.min(dataset))).astype(np.uint16)
     
     if not os.path.exists(save_path):
         os.mkdir(save_path)
@@ -137,19 +160,7 @@ def convert_h52_tif(h5name, save_path, prefix_name = 'proj', save_stack = False,
             filename = os.path.join(save_path, "{}{:04d}.tif".format(prefix_name, i))
             image.save(filename)
     print('Done')
-    
-    
-    print("Writing TIFF images to {}".format(save_path))
-    if save_stack:
-        # Save the entire 3D dataset as a single multi-page TIFF image
-        filename = os.path.join(save_path, prefix_name + "_stack.tif")
-        tiff.imwrite(filename, normalized_data, photometric='minisblack')
-    else:
-        # Save each slice of the 3D dataset as an individual TIFF image
-        for i in range(normalized_data.shape[0]):
-            filename = os.path.join(save_path, "{}{:04d}.tif".format(prefix_name, i))
-            tiff.imwrite(filename, normalized_data[i], photometric='minisblack')
-
+    return normalized_data
 
 
 def convert_to_list(input_data):
@@ -236,6 +247,9 @@ def is_mat_v7p3(file_path):
 
         
 def read_h5_file(file_path):
+    '''
+    Read all data inside an h5/hdf5 file and return the output as a dictionary
+    '''
     data_dict = {}
 
     def visit_group(name, obj):
@@ -380,7 +394,7 @@ def write_xdmf(h5name, xdmf_filename = None, ctrl = 'recon_mlem', attributes = [
 
     
 def camera_names_ID11():
-    return ['marana3', 'marana1', 'marana2', 'marana', 'frelon3', 'frelon6', 'eiger', 'basler_eh32']
+    return ['marana3', 'marana1', 'marana2', 'marana', 'frelon1', 'frelon3', 'frelon6', 'eiger', 'basler_eh32', 'frelon16']
 
 
 def guess_camera_name(h5name, scan = '1.1'):
@@ -410,3 +424,260 @@ def delete_group_from_h5(h5name, group_name):
             return True
         else:
             return False
+        
+        
+def print_all_keys(d, prefix=""):
+    """
+    Recursively prints all keys in a dictionary, including sub-keys.
+
+    Parameters:
+    d (dict): The dictionary to explore.
+    prefix (str): The prefix for nested keys (used internally for recursion).
+    """
+    if not isinstance(d, dict):
+        raise TypeError("Expected a dictionary, but got {} instead.".format(type(d)))
+    print('Got the following keys:')
+    for key, value in d.items():
+        full_key = f"{prefix}.{key}" if prefix else key
+        print(full_key)
+        if isinstance(value, dict):  # If the value is a dictionary, recurse
+            print_all_keys(value, prefix=full_key)
+
+
+def write_fwd_peaks(fwd_peaks, output_folder = None, fname_prefix = None, verbose = 1):
+    """
+    Write fwd_peaks to an h5 file with each column as a separate dataset, see how to compute fwd_peaks in forward_projector.py.
+
+    Args:
+        fwd_peaks (array): an N*25 array containing forward computed peaks
+        output_folder (string): output folder
+        fname_prefix (string): filename prefix, "fpks_" by default
+        verbose: logging level, 0, 1 or 2
+        
+    Returns:
+        None
+    """
+    assert fwd_peaks.shape[1] == 25, "fwd_peaks must have 25 columns"
+    if output_folder is None:
+        output_folder = os.getcwd()
+    if fname_prefix is None:
+        fname_prefix = 'fpks'
+        
+    dty = fwd_peaks[0, 8]
+    outname = os.path.join(output_folder, fname_prefix + '_dty_' + str(round(dty, 2)).replace('.', 'p') + '.h5')  # e.g. dty = 0.1, outname = 'fpks_dty_0p10.h5'
+    
+    col_names = ['grainID', 'voxel_zyx', 'weight', 'pos_xyz', 'dty', 'omega', 'tth', 'eta', 'hkl',
+                 'g_xyz', 'det_pixel_yz', 'lorentz', 'polarization', 'transmission', 'sum_intensity', 'ds']
+    
+    with h5py.File(outname, 'w') as hout:
+        hout.create_dataset(col_names[0], data = fwd_peaks[:, 0], dtype='int32')
+        hout.create_dataset(col_names[1], data = fwd_peaks[:, [1, 2, 3]], dtype='int32')
+        hout.create_dataset(col_names[2], data = fwd_peaks[:, 4], dtype='float')
+        hout.create_dataset(col_names[3], data = fwd_peaks[:, [5, 6, 7]], dtype='float')
+        hout.create_dataset(col_names[4], data = fwd_peaks[:, 8], dtype='float')
+        hout.create_dataset(col_names[5], data = fwd_peaks[:, 9], dtype='float')
+        hout.create_dataset(col_names[6], data = fwd_peaks[:, 10], dtype='float')
+        hout.create_dataset(col_names[7], data = fwd_peaks[:, 11], dtype='float')
+        hout.create_dataset(col_names[8], data = fwd_peaks[:, [12, 13, 14]], dtype='int32')
+        hout.create_dataset(col_names[9], data = fwd_peaks[:, [15, 16, 17]], dtype='float')
+        hout.create_dataset(col_names[10], data = fwd_peaks[:, [18, 19]], dtype='float')
+        hout.create_dataset(col_names[11], data = fwd_peaks[:, 20], dtype='float')
+        hout.create_dataset(col_names[12], data = fwd_peaks[:, 21], dtype='float')
+        hout.create_dataset(col_names[13], data = fwd_peaks[:, 22], dtype='float')
+        hout.create_dataset(col_names[14], data = fwd_peaks[:, 23], dtype='float')
+        hout.create_dataset(col_names[15], data = fwd_peaks[:, 24], dtype='float')
+    if verbose >= 1:
+        logging.info('fwd_peaks written to {}'.format(outname))
+
+    return None
+
+
+def read_fwd_peaks(h5_file, verbose=1):
+    """
+    Read fwd_peaks data from an h5 file and reconstruct it as an N*24 array.
+    
+    Args:
+        h5_file (string): path to the HDF5 file containing fwd_peaks data
+        verbose: logging level, 0, 1 or 2
+        
+    Returns:
+        fwd_peaks: an N*25 array containing forward computed peaks
+    """
+    
+    col_names = ['grainID', 'voxel_zyx', 'weight', 'pos_xyz', 'dty', 'omega', 'tth', 'eta', 'hkl',
+                 'g_xyz', 'det_pixel_yz', 'lorentz', 'polarization', 'transmission', 'sum_intensity', 'ds']
+    if not os.path.exists(h5_file):
+        return None
+    try:
+        with h5py.File(h5_file, 'r') as hin:
+            num_rows = hin[col_names[0]].shape[0]  # Determine the number of rows
+            fwd_peaks = np.zeros((num_rows, 25), dtype=np.float64)
+
+            # Read each dataset and fill the corresponding columns in fwd_peaks
+            fwd_peaks[:, 0] = hin[col_names[0]][:]    # grainID
+            fwd_peaks[:, 1:4] = hin[col_names[1]][:]  # voxel_zyx indices
+            fwd_peaks[:, 4] = hin[col_names[2]][:]    # weight
+            fwd_peaks[:, 5:8] = hin[col_names[3]][:]  # pos_xyz [mm]
+            fwd_peaks[:, 8] = hin[col_names[4]][:]    # dty [um]
+            fwd_peaks[:, 9] = hin[col_names[5]][:]    # omega [deg]
+            fwd_peaks[:, 10] = hin[col_names[6]][:]   # tth [deg]
+            fwd_peaks[:, 11] = hin[col_names[7]][:]   # eta [deg]
+            fwd_peaks[:, 12:15] = hin[col_names[8]][:]  # hkl
+            fwd_peaks[:, 15:18] = hin[col_names[9]][:]  # g_xyz
+            fwd_peaks[:, 18:20] = hin[col_names[10]][:] # det_pixel_yz [pixel]
+            fwd_peaks[:, 20] = hin[col_names[11]][:]  # Lorentz
+            fwd_peaks[:, 21] = hin[col_names[12]][:]  # Polarization
+            fwd_peaks[:, 22] = hin[col_names[13]][:]  # transmission
+            fwd_peaks[:, 23] = hin[col_names[14]][:]  # sum_intensity
+            fwd_peaks[:, 24] = hin[col_names[15]][:]  # ds
+        if verbose >= 1:
+            logging.info('fwd_peaks read from {}'.format(h5_file))
+        return fwd_peaks
+    except Exception as e:
+        print("An unexpected error occurred: {}".format(e))
+        return None
+
+
+def convert_fwd_peaks_to_cf(fwd_peaks):
+    """
+    convert fwd_peaks to ImageD11 column file object.
+    
+    Args:
+        fwd_peaks: an N*25 array containing forward computed peaks        
+    Returns:
+        cf: an ImageD11 cf object, see ImageD11.sinograms.dataset.colfile_from_dict
+    """
+    col_names = ['grainID', 'voxel_z', 'voxel_y', 'voxel_x', 'weight', 'pos_x', 'pos_y', 'pos_z', 'dty', 'omega', 'tth', 'eta', 'h', 'k', 'l',
+             'gx', 'gy', 'gz', 'det_pixel_y', 'det_pixel_z', 'lorentz', 'polarization', 'transmission', 'sum_intensity', 'ds']
+    if isinstance(fwd_peaks, dict):
+        raise TypeError("Expected a numpy array, but got a dict")
+    if not isinstance(fwd_peaks, np.ndarray):
+        fwd_peaks = np.vstack(fwd_peaks)
+    assert fwd_peaks.shape[1] == 25, "fwd_peaks must have 25 columns"
+    fwd_peaks_dict = {}
+    for i, col_name in enumerate(col_names):
+        fwd_peaks_dict[col_name] = fwd_peaks[:,i]
+        
+    cf = colfile_from_dict(fwd_peaks_dict)  # convert to a cf object
+    return cf
+
+
+def convert_cf_to_fwd_peaks(cf):
+    """
+    convert cf (generated by forward_projector) to fwd_peaks numpy array.
+    
+    Args:
+        cf: ImageD11 column file object (generated by forward_projector), e.g. fp.cf_2d or fp.cf_3d
+    Returns:
+        fwd_peaks: an N*25 array containing forward computed peaks
+    """
+    num_rows = cf.nrows  # Determine the number of rows
+    fwd_peaks = np.zeros((num_rows, 25), dtype=np.float64)
+
+    # Read each dataset and fill the corresponding columns in fwd_peaks
+    fwd_peaks[:, 0] = cf.grainID  # grainID
+    fwd_peaks[:, 1] = cf.voxel_z  # voxel_zyx indices
+    fwd_peaks[:, 2] = cf.voxel_y  # voxel_zyx indices
+    fwd_peaks[:, 3] = cf.voxel_x  # voxel_zyx indices
+    fwd_peaks[:, 4] = cf.weight   # weight
+    fwd_peaks[:, 5] = cf.pos_x    # pos_xyz [mm]
+    fwd_peaks[:, 6] = cf.pos_y    # pos_xyz [mm]
+    fwd_peaks[:, 7] = cf.pos_z    # pos_xyz [mm]
+    fwd_peaks[:, 8] = cf.dty      # dty [um]
+    fwd_peaks[:, 9] = cf.omega    # omega [deg]
+    fwd_peaks[:, 10] = cf.tth     # tth [deg]
+    fwd_peaks[:, 11] = cf.eta     # eta [deg]
+    fwd_peaks[:, 12] = cf.h       # hkl
+    fwd_peaks[:, 13] = cf.k       # hkl
+    fwd_peaks[:, 14] = cf.l       # hkl
+    fwd_peaks[:, 15] = cf.gx      # g_xyz
+    fwd_peaks[:, 16] = cf.gy      # g_xyz
+    fwd_peaks[:, 17] = cf.gz      # g_xyz
+    fwd_peaks[:, 18] = cf.det_pixel_y  # det_pixel_yz [pixel]
+    fwd_peaks[:, 19] = cf.det_pixel_z  # det_pixel_yz [pixel]
+    fwd_peaks[:, 20] = cf.lorentz      # Lorentz
+    fwd_peaks[:, 21] = cf.polarization # Polarization
+    fwd_peaks[:, 22] = cf.transmission # transmission
+    fwd_peaks[:, 23] = cf.sum_intensity# sum_intensity
+    fwd_peaks[:, 24] = cf.ds           # ds
+    return fwd_peaks
+
+
+def read_fsparse(h5_file, group_name = "/entry_0000/ESRF-ID11/eiger/data"):
+    """
+    Read fsparse_pks from a sparse h5 peaks file.
+    
+    Args:
+        h5_file (string): path to the HDF5 file containing the sparse peaks generated from forward_projector.make_projs_and_sparse_file
+        group_name: group name
+        
+    Returns:
+        fsparse_pks: a dictionary containing 'col', 'row', 'nnz', 'intensity', 'dty', 'rot'
+    """
+    names = ['col', 'row', 'nnz', 'intensity', 'dty', 'rot']
+    fsparse_pks = {}
+    with h5py.File(h5_file, 'r') as hin:
+        g = hin.get(group_name)
+        if g is None:
+            raise ValueError("Group '{}' not found in file '{}'".format(group_name, h5name))
+        for name in names:
+            if name in g.keys():
+                fsparse_pks[name] = g[name][()]
+    return fsparse_pks
+
+
+def copytree_with_progress(src, dst, skip_keys=None, create_subfolder = True, overwrite = False):
+    """
+    Copies a folder with all subfolders and files, displaying progress. 
+    Skips subfolders containing specified keys.
+
+    Main usage is to backup files from the server to local computer by skipping filefolders containing keywords specified by the input "skip_keys"
+    e.g. skip_keys = ['0_rawdata', '2_difblob', '2_difspot', '6_rendering', '7_fed', '8_analysis', 'OAR_log', 'RAW_DATA']
+    
+    Args:
+        src (str): Source directory path.
+        dst (str): Destination directory path.
+        skip_keys (list): List of strings; skip folders containing these keys in their path.
+        create_subfolder (logic): using the last name of the source directory to create a new sub directory under the destination direction
+        overwrite (logic): flag for overwriting any existing files in the destination directory, False for skipping
+    """
+    if not os.path.exists(src):
+        raise ValueError("Source folder {} does not exist.".format(src))
+
+    if create_subfolder:
+        dst = os.path.join(dst, os.path.split(src)[1])
+        
+    print("Source directory: {}".format(src))
+    print("Destination directory: {}".format(dst))
+    print("Skipping {}".format(skip_keys))
+
+    if skip_keys is None:
+        skip_keys = []
+    
+    # Get all files and directories in the source folder
+    files_to_copy = []
+    for root, dirs, files in os.walk(src):
+        # Skip subfolders containing any of the keys
+        if any(key in root for key in skip_keys):
+            continue
+        for file in files:
+            src_file = os.path.join(root, file)
+            dst_file = os.path.join(dst, os.path.relpath(src_file, src))
+            # Add file only if it doesn't already exist or the source is newer
+            if overwrite:
+                files_to_copy.append((src_file, dst_file))
+            else:
+                if not os.path.exists(dst_file) or os.path.getmtime(src_file) > os.path.getmtime(dst_file):
+                    files_to_copy.append((src_file, dst_file))
+                    
+    # Create destination directory if it does not exist
+    os.makedirs(dst, exist_ok=True)
+    
+    # Use tqdm for progress visualization
+    with tqdm(total=len(files_to_copy), desc="Copying files", unit="file") as pbar:
+        for src_file, dst_file in files_to_copy:
+            os.makedirs(os.path.dirname(dst_file), exist_ok=True)
+            shutil.copy2(src_file, dst_file)
+            pbar.update(1)    
+    print("Folder '{}' has been successfully copied to '{}', skipping subfolders containing {}.".format(src, dst, skip_keys))
+    return None

--- a/ImageD11/forward_model/test_forward_model_matching_peaks.ipynb
+++ b/ImageD11/forward_model/test_forward_model_matching_peaks.ipynb
@@ -1,0 +1,431 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "02d94170-ad20-4e6d-b01b-d5321dbe719a",
+   "metadata": {},
+   "source": [
+    "# Test forward_model.py\n",
+    "### Mainly to test forward matching peaks and use the cleaned peaks for tomographic grain reconstruction\n",
+    "### Normally it is used as an extra step for the example notebook tomo_2_map.ipynb or tomo_2_map_minor_phase.ipynb\n",
+    "### Jan 2025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c08bf8af-09db-42d3-9b75-d9cf4e48c5ec",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exec(open('/data/id11/nanoscope/install_ImageD11_from_git.py').read())\n",
+    "PYTHONPATH = setup_ImageD11_from_git( ) # ( os.path.join( os.environ['HOME'],'Code'), 'ImageD11_git' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc2f010e-0b5a-4c64-9d90-0fb30306b99d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import functions we need\n",
+    "\n",
+    "import concurrent.futures\n",
+    "\n",
+    "# %matplotlib ipympl\n",
+    "\n",
+    "import h5py\n",
+    "from tqdm.notebook import tqdm\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from skimage.filters import threshold_otsu\n",
+    "from skimage.morphology import convex_hull_image\n",
+    "\n",
+    "import ImageD11.columnfile\n",
+    "from ImageD11.grain import grain\n",
+    "from ImageD11.peakselect import select_ring_peaks_by_intensity\n",
+    "from ImageD11.sinograms.sinogram import GrainSinogram, build_slice_arrays, write_slice_recon, read_h5, write_h5, get_2d_peaks_from_4d_peaks\n",
+    "from ImageD11.sinograms.roi_iradon import run_iradon\n",
+    "from ImageD11.sinograms.tensor_map import TensorMap\n",
+    "import ImageD11.sinograms.dataset\n",
+    "import ImageD11.nbGui.nb_utils as utils\n",
+    "\n",
+    "import ipywidgets as widgets\n",
+    "from ipywidgets import interact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c63dc3d7-d61b-46da-b97c-2f3fe172d455",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ImageD11.forward_model import forward_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99be8b16-34ae-4e41-b33d-773de2594733",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: Pass path to dataset file\n",
+    "\n",
+    "dset_file = '/data/visitor/es1505/id11/20240926/PROCESSED_DATA/LGM_15/LGM_15_s3DXRD_inclusion1/LGM_15_s3DXRD_inclusion1_dataset.h5'\n",
+    "\n",
+    "ds = ImageD11.sinograms.dataset.load(dset_file)\n",
+    "\n",
+    "ds.parfile = '/data/visitor/es1505/id11/20240926/SCRIPTS/HF/LGM_15_s3DXRD_inclusion1/pars.json' # specify the pars.json path\n",
+    "\n",
+    "sample = ds.sample\n",
+    "dataset = ds.dsname\n",
+    "rawdata_path = ds.dataroot\n",
+    "processed_data_root_dir = ds.analysisroot\n",
+    "\n",
+    "print(ds)\n",
+    "print(ds.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "461ec3a8-59ca-475e-a2f7-a3871d047348",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load phases from parameter file\n",
+    "\n",
+    "ds.phases = ds.get_phases_from_disk()\n",
+    "ds.phases.unitcells"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7489704-a563-4f76-a1ae-12721db22346",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# pick a phase\n",
+    "phase_str = 'Pyrrhotite_hex2'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a14d4b6-0dd7-4db5-8a18-1bbc694b4d5e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# If the sinograms are only half-sinograms (we scanned dty across half the sample rather than the full sample), set the below to true:\n",
+    "is_half_scan = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2fa6ff0-2fe9-42e7-a3a9-edddc1b212df",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if is_half_scan:\n",
+    "    ds.correct_bins_for_half_scan()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dd647d6-897e-45c2-90b1-2535249ccfc7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Import 4D peaks\n",
+    "\n",
+    "cf_4d = ds.get_cf_4d_from_disk()\n",
+    "\n",
+    "ds.update_colfile_pars(cf_4d, phase_name=phase_str)\n",
+    "\n",
+    "print(f\"Read {cf_4d.nrows} 4D peaks\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ea21e87-7e88-4851-b30c-ed19a1e460fa",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# plot sino for cf_4d\n",
+    "forward_model.cf_plot_sino(cf_4d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f8d828e-9de0-4722-8994-d7378b18da9a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# here we are filtering our peaks (cf_4d) to select only the strongest ones\n",
+    "# this time as opposed to indexing, our frac is slightly weaker but we are NOT filtering in dstar!!!!!\n",
+    "# this means many more peaks per grain = stronger sinograms\n",
+    "\n",
+    "# USER: modify the \"frac\" parameter below and re-run the cell until the orange dot sits nicely on the \"elbow\" of the blue line\n",
+    "# this indicates the fractional intensity cutoff we will select\n",
+    "# if the blue line does not look elbow-shaped in the logscale plot, try changing the \"doplot\" parameter (the y scale of the logscale plot) until it does\n",
+    "\n",
+    "cf_strong_frac = 0.999\n",
+    "cf_strong_dstol = 0.005\n",
+    "\n",
+    "cf_strong = select_ring_peaks_by_intensity(cf_4d, frac=cf_strong_frac, dstol=cf_strong_dstol, dsmax=cf_4d.ds.max(), doplot=0.9)\n",
+    "print(cf_4d.nrows)\n",
+    "cf_strong.nrows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae03c287-c11d-4fa7-8901-c8ba7c1f8e4e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# plot sino for cf_strong\n",
+    "forward_model.cf_plot_sino(cf_strong)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ba39d4c-36c2-4c5a-b2e9-e791663a234d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import the grains from disk\n",
+    "\n",
+    "grains = ds.get_grains_from_disk(phase_str)\n",
+    "print(f\"{len(grains)} grains imported\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3f109c5-44d8-4c8c-bd59-00a1f319856b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# assign peaks to the grains\n",
+    "\n",
+    "peak_assign_tol = 0.25\n",
+    "utils.assign_peaks_to_grains(grains, cf_strong, peak_assign_tol)\n",
+    "\n",
+    "for grain_label, g in enumerate(grains):\n",
+    "    g.npks_4d = np.sum(cf_strong.grain_id == grain_label)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "535b8b10-ef39-4cf7-8915-08bc229798e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# let's make a GrainSinogram object for each grain\n",
+    "\n",
+    "grainsinos = [GrainSinogram(g, ds) for g in grains]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a78cc9e7-f906-4146-8aa4-3e72e4968ff0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Now let's determine the positions of each grain from the 4D peaks\n",
+    "\n",
+    "for grain_label, gs in enumerate(grainsinos):\n",
+    "    gs.update_lab_position_from_peaks(cf_strong, grain_label)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "253cbda7-d74b-48d0-bb67-3725d3edcb0d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# get peaks for each grain, only to be able to see the peaks for individual grains\n",
+    "cf_grains = []\n",
+    "for i in range(len(grains)):\n",
+    "    cf_grains.append(forward_model.cf_filter_for_grain(cf_strong, grain_id = i))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3279f09-3a12-423a-af68-7d4e9eed5407",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "forward_model.cf_plot_sino(cf_grains)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a3438e9-7bb9-4d4f-b277-6fc212438c8a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ucell = ds.phases.unitcells[phase_str]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1167c80c-0ec6-4f78-8bbb-3ee63ac5bce9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pars = ImageD11.parameters.read_par_file(ds.parfile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8cedfc6-41f9-41e3-af48-985437cc9a0a",
+   "metadata": {},
+   "source": [
+    "# Testing the forward calculation and forward matching"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0117c8a8-8a29-4722-b6bf-397c2b8609cd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cf_matched_all, Comp_all = forward_model.forward_match_peaks(cf_strong, grains, ds, ucell, pars, ds_max=1.2, tol_angle=3, tol_pixel=5, thres_int=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "316bec48-921e-4bd8-b26a-fb840abe057f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot all the matched peaks\n",
+    "# in this example, the scan was performed on a region-of-interest, so the number of 'useful' peaks have been filtered significantly from all peaks\n",
+    "forward_model.cf_plot_sino(cf_matched_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "850d25bc-d454-4b95-95dd-291d21023ea3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create cf_clean that is supposed to be matched with the indexed grains\n",
+    "cf_clean = forward_model.cf_remove_unmatched_peaks(cf_strong, cf_matched_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb76f13a-fd00-4862-84e4-2b70a4455a85",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# plot sino for cf_strong (before cleaning) and cf_clean (after cleaning)\n",
+    "forward_model.cf_plot_sino([cf_strong, cf_clean])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ee9e2cb-40e7-4055-8d25-13216b2b6d63",
+   "metadata": {},
+   "source": [
+    "# Once cf_clean is obtained, one can continue with grain reconstruction with cf_clean instead of cf_strong\n",
+    "# See the rest of processing in the example notebook tomo_2_map.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ae69f2f-35c3-4225-91bb-ef5aa10d933f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ImageD11/forward_model/test_forward_projector_principle.ipynb
+++ b/ImageD11/forward_model/test_forward_projector_principle.ipynb
@@ -1,0 +1,1429 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e2c9f82e-6d9b-42a5-8eb6-dc0150436527",
+   "metadata": {},
+   "source": [
+    "# Test forward_projector.py\n",
+    "## Test the principle of forward_projector: to find intersected voxels with point-focused beam and the computation of fwd_peaks and making projections\n",
+    "## Haixing Fang\n",
+    "## Jan 2025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65590db3-8b87-4380-a139-8ff8b886df2f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['OMP_NUM_THREADS'] = '1'\n",
+    "os.environ['OPENBLAS_NUM_THREADS'] = '1'\n",
+    "os.environ['MKL_NUM_THREADS'] = '1'\n",
+    "\n",
+    "exec(open('/data/id11/nanoscope/install_ImageD11_from_git.py').read())\n",
+    "PYTHONPATH = setup_ImageD11_from_git( ) # ( os.path.join( os.environ['HOME'],'Code'), 'ImageD11_git' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54f1da48-bbf4-4484-b278-b2a0906b8c42",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import functions we need\n",
+    "\n",
+    "import shutil\n",
+    "import concurrent.futures\n",
+    "\n",
+    "# %matplotlib ipympl\n",
+    "\n",
+    "import h5py\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49be9eaf-ae36-47b6-b464-e0c3e6ed6756",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import ImageD11.parameters\n",
+    "import ImageD11.unitcell\n",
+    "import time\n",
+    "from joblib import Parallel, delayed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3333f34-4272-4197-ada9-f7dce91b5f33",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ImageD11.forward_model import forward_projector\n",
+    "from ImageD11.forward_model import io\n",
+    "from ImageD11.forward_model import forward_model\n",
+    "from ImageD11.forward_model import pars_conversion\n",
+    "from ImageD11.forward_model import grainmaps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "784176f7-6960-4ff0-a5d6-8c33c3173832",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "871d90f9-639f-46eb-8c20-003873e87e1e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "beam = forward_projector.beam(energy = 43.56, FWHM = [1e-3, 1e-3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05586666-0b1e-4565-b2d7-759e6eb47463",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "beam.set_beam_shape(plot_flag=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "013cd14c-bd1c-4073-8c24-d1611b296747",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# sample_filename = '../../A2050_DN_W340_nscope/A2050_DN_W340_nscope_full_slice/A2050_DN_W340_nscope_full_slice_grains.h5'\n",
+    "# sample_filename = 'pbp_tensormap_refined.h5'\n",
+    "sample_filename = '/data/visitor/ma6288/id11/20241119/PROCESSED_DATA/A2050_DN_W340_nscope_5pct_strained/A2050_DN_W340_nscope_5pct_strained_full_slice/DS.h5'\n",
+    "pars_filename = '/data/visitor/ma6288/id11/20241119/PROCESSED_DATA/nscope_pars/pars.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68105e95-f764-4ceb-bea2-7ac475680327",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "output_folder = 'output_test'\n",
+    "# Check if the folder exists, then delete it\n",
+    "if os.path.exists(output_folder) and os.path.isdir(output_folder):\n",
+    "    shutil.rmtree(output_folder)\n",
+    "    print(f\"Deleted folder: {output_folder}\")\n",
+    "else:\n",
+    "    os.mkdir(output_folder)\n",
+    "    print(f\"{output_folder} did not exist and has been created now.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "715f9574-d7e7-4736-a791-890c379cc230",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sample = forward_projector.sample(filename=os.path.join(os.getcwd(), sample_filename))\n",
+    "sample.set_rou()\n",
+    "sample.set_mass_abs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06058a35-2211-456d-9ff2-c1ec8f78a277",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.imshow(sample.DS['labels'][0,:,:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7f13464-3f3d-45ed-a7dd-dd5b1a32f473",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pars = ImageD11.parameters.read_par_file(pars_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f0751bb-99ac-4193-a32e-5ff70de1ac14",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ucell = ImageD11.unitcell.unitcell([4.04761405231186, 4.04761405231186, 4.04761405231186, 90.0, 90.0, 90.0], 225)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "526b57e0-7bf6-448e-b4bc-65b4b2181caf",
+   "metadata": {},
+   "source": [
+    "# Check intersected voxels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9f235c9-9aba-4f2b-9bc7-f9797bf7f497",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dty = 100.0\n",
+    "y0_offset = 0.0\n",
+    "voxel_size = sample.DS['voxel_size']\n",
+    "ray_size = np.mean(beam.FWHM) * 1000\n",
+    "omega = 45.0\n",
+    "\n",
+    "mask = (sample.DS['labels'] > -1) & (~np.isnan(sample.DS['U'][:, :, :, 0, 0]))\n",
+    "mask = np.moveaxis(mask, 0, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6647670d-b8f8-463e-a75d-d9329a373ce1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "intersected_sampos, intersected_labpos, intersected_voxels = forward_projector.intersected_sample_pos(mask, dty=dty, y0_offset=y0_offset, voxel_size=voxel_size,\n",
+    "                                                                 omega=omega, ray_size=ray_size, weight = beam.weight, weight_pos = beam.weight_pos,\n",
+    "                                                                 plot_flag=True,detector='eiger')\n",
+    "print(intersected_voxels.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25ecdca1-4954-4d9d-97c2-b03c7d98e473",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.hist(intersected_voxels[:,3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2143fc7c-b157-40cc-a1ee-59749bde3017",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f, a = plt.subplots(1, 2, figsize=(12, 6))\n",
+    "a[0].scatter(intersected_sampos[:,0], intersected_sampos[:,1], s = 3)\n",
+    "a[0].set_title(\"intersected_sampos\")\n",
+    "\n",
+    "a[1].scatter(intersected_labpos[:,0], intersected_labpos[:,1], s = 3)\n",
+    "a[1].set_title(\"intersected_labpos\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "515c6263-98e0-4c05-9465-2b6726b0db16",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# compute intersected voxels at different omega angles\n",
+    "dty = 120\n",
+    "omegas = [0, 30, 60, 90, 120, 150]\n",
+    "intersected_voxels_all = []\n",
+    "for omega in omegas:\n",
+    "    intersected_sampos, intersected_labpos, intersected_voxels = forward_projector.intersected_sample_pos(mask, dty=dty, y0_offset=y0_offset, voxel_size=voxel_size,\n",
+    "                                                                 omega=omega, ray_size=ray_size, weight = [1.0, 0.8, 0.5, 0.13], weight_pos = [0.5, 1.0, 1.5, 2.3], plot_flag=False,detector='eiger')\n",
+    "    intersected_voxels_all.append(intersected_voxels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29b67218-5e08-48b0-b48b-b651ac18eae1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# plot intersected voxels at different omega angles\n",
+    "fig = plt.figure(figsize=(10, 8))\n",
+    "ax = fig.add_subplot(111, projection=\"3d\")\n",
+    "\n",
+    "grid_size = mask.shape\n",
+    "voxel_indices = np.argwhere(mask > 0)\n",
+    "indices = np.array(voxel_indices)\n",
+    "ax.scatter(indices[:, 0], indices[:, 1], indices[:, 2], c=\"blue\", s=1, alpha=0.03, label=\"Masked Voxels\")\n",
+    "\n",
+    "colors = plt.cm.tab20(np.linspace(0, 1, len(intersected_voxels_all)))  # Use a colormap for variety\n",
+    "\n",
+    "for i, (intersected, omega) in enumerate(zip(intersected_voxels_all, omegas)):\n",
+    "    ax.scatter(\n",
+    "        intersected[:, 0],\n",
+    "        intersected[:, 1],\n",
+    "        intersected[:, 2],\n",
+    "        c=colors[i],  # Assign a unique color to each intersected group\n",
+    "        s=8,\n",
+    "        alpha=0.9,\n",
+    "        label=\"Intersected voxels @\" + str(omega) + \" deg\",\n",
+    "    )\n",
+    "    \n",
+    "# ax.plot(ray_path[:, 0], ray_path[:, 1], ray_path[:, 2], \"r-\", label=\"Ray Path\", linewidth=2)\n",
+    "ax.set_xlim(0, grid_size[0])\n",
+    "ax.set_ylim(0, grid_size[1])\n",
+    "ax.set_zlim(0, grid_size[2])\n",
+    "ax.set_xlabel(\"X\")\n",
+    "ax.set_ylabel(\"Y\")\n",
+    "ax.set_zlabel(\"Z\")\n",
+    "ax.set_title(\"3D Ray-Voxel Intersection with Ray Size {:.2f} and dty = {:.2f}\".format(ray_size, dty))\n",
+    "ax.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40198a83-1fa9-4256-8070-648fa79262ed",
+   "metadata": {},
+   "source": [
+    "# Compute forward peaks for one dty position"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8deadd0-997e-4bf9-8064-63783b53d570",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds_max = 1.2\n",
+    "mask = None\n",
+    "\n",
+    "rot_start = -89.975\n",
+    "rot_end = 90.9668\n",
+    "rot_step = 0.5\n",
+    "omega_angles = np.arange(rot_start, rot_end+rot_step/2, rot_step)\n",
+    "print(\"{} rotation angles in one dty position\".format(omega_angles.shape[0]))\n",
+    "\n",
+    "dty = 0.0\n",
+    "fwd_peaks_test = forward_projector.forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty = dty, mask = None, ds_max = 1.2, plot_peaks=True, verbose = 1)\n",
+    "print(fwd_peaks_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52155f6c-577f-4bd5-9456-d4b2869c74be",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "io.write_fwd_peaks(fwd_peaks_test, output_folder = output_folder, fname_prefix='fpks_test')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb8988a3-4027-4892-aa05-5917252121ca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "intensity_map = forward_projector.make_intensity_map(fwd_peaks_test[:, 5], fwd_peaks_test[:, 6], fwd_peaks_test[:, 23],\n",
+    "                                     x_range=[-0.18, 0.18], y_range=[-0.18, 0.18], pixel_size=1e-3)\n",
+    "print(intensity_map.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b75998a9-251f-4430-bd28-ce6eeb26c59b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "intensity_map = forward_projector.make_intensity_map(fwd_peaks_test[:, 18], fwd_peaks_test[:, 19], fwd_peaks_test[:, 23],\n",
+    "                                     x_range = [0, 2162], y_range = [0, 2068], pixel_size=1,)\n",
+    "print(intensity_map.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63208f56-a603-4d2b-aafb-5c426b92c133",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "projs, projs_sum = forward_projector.make_projections_with_psf(\n",
+    "    fwd_peaks_test,\n",
+    "    omega_angles,\n",
+    "    image_size=(2162, 2068),\n",
+    "    detector='eiger',\n",
+    "    int_factors=(0.1065, 0.7807, 0.1065),\n",
+    "    sum_flag=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64a16a79-1a3c-4918-936e-4d9294ffee8a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f, a = plt.subplots(1,2, sharex=True, sharey=True, figsize=(16, 8))\n",
+    "\n",
+    "a[0].imshow(intensity_map, origin=\"lower\", norm=LogNorm(vmin=10, vmax=1e4), interpolation=\"nearest\")\n",
+    "a[0].set_title('(a) Sum of intensities without psf')\n",
+    "\n",
+    "a[1].imshow(projs_sum, origin=\"lower\", norm=LogNorm(vmin=10, vmax=1e4), interpolation=\"nearest\")\n",
+    "a[1].set_title('(b) Sum of projections with psf')\n",
+    "\n",
+    "a[1].set_xlim([200, 600])\n",
+    "a[1].set_ylim([200, 600])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14166022-0519-4cf1-80ef-decbe374d8ea",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dty = 120.0\n",
+    "fwd_peaks_test = forward_projector.forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty = dty, mask = None, ds_max = 1.2, plot_peaks=True, verbose = 1)\n",
+    "print(fwd_peaks_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "951a92fe-cd4c-4a47-9a7d-85ccfe7b8d9f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "intensity_map = forward_projector.make_intensity_map(fwd_peaks_test[:, 5], fwd_peaks_test[:, 6], fwd_peaks_test[:, 23],\n",
+    "                                     x_range=[-0.18, 0.18], y_range=[-0.18, 0.18], pixel_size=1e-3)\n",
+    "print(intensity_map.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4a98501-44b7-4577-99f3-0156c2a50b95",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "io.write_fwd_peaks(fwd_peaks_test, output_folder = output_folder, fname_prefix='fpks_test')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34e4fb7a-045f-42cb-896c-c893557fc76e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fwd_peaks = io.read_fwd_peaks(os.path.join(output_folder, 'fpks_test_dty_120p0.h5'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dfd3673-e25d-4e33-b158-d460835225a2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f, ax = plt.subplots(1, 2, figsize=(15, 9))\n",
+    "\n",
+    "sc = ax[0].scatter(fwd_peaks[:, 18], fwd_peaks[:, 19], c=fwd_peaks[:, 23], cmap='viridis', s=8)\n",
+    "ax[0].set_aspect('equal', 'box')\n",
+    "cb = f.colorbar(sc, ax=ax[0])\n",
+    "# cb.set_label('Intensity', fontsize = 20)\n",
+    "cb.ax.tick_params(labelsize=14)\n",
+    "ax[0].set_xlabel('fc', fontsize = 20)\n",
+    "ax[0].set_ylabel('sc', fontsize = 20)\n",
+    "ax[0].set_title('(a) Forward peaks on detector', fontsize = 20)\n",
+    "ax[0].tick_params(width=1.5, length=6, labelsize=14)\n",
+    "ax[0].invert_yaxis()\n",
+    "\n",
+    "sc = ax[1].scatter(fwd_peaks[:, 5], fwd_peaks[:, 6], c=fwd_peaks[:, 23], cmap='viridis', s=8)\n",
+    "ax[1].set_aspect('equal', 'box')\n",
+    "cb = f.colorbar(sc, ax=ax[1])\n",
+    "cb.set_label('Intensity', fontsize = 20)\n",
+    "cb.ax.tick_params(labelsize=14)\n",
+    "ax[1].set_xlabel('X (mm)', fontsize = 20)\n",
+    "ax[1].set_ylabel('Y (mm)', fontsize = 20)\n",
+    "ax[1].set_title('(b) Forward peaks from the sample', fontsize = 20)\n",
+    "ax[1].tick_params(width=1.5, length=6, labelsize=14) \n",
+    "\n",
+    "f.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73e7dbd3-6c50-46f4-a1f2-758cabcc6be3",
+   "metadata": {},
+   "source": [
+    "# Do testings with different omega steps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e677670-9055-4a9b-a12b-d3c0d05283c8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds_max = 1.2\n",
+    "mask = None\n",
+    "\n",
+    "rot_start = -89.975\n",
+    "rot_end = 90.9668\n",
+    "rot_step = 0.25\n",
+    "omega_angles = np.arange(rot_start, rot_end+rot_step/2, rot_step)\n",
+    "print(\"{} rotation angles in one dty position\".format(omega_angles.shape[0]))\n",
+    "\n",
+    "dty = 0.0\n",
+    "fwd_peaks = forward_projector.forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty = dty, mask = None, ds_max = 1.2, plot_peaks=True, verbose = 1)\n",
+    "print(fwd_peaks.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c8bc866-95e0-456d-989d-b92dced3a282",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "intensity_map = forward_projector.make_intensity_map(fwd_peaks[:, 5], fwd_peaks[:, 6], fwd_peaks[:, 23],\n",
+    "                                     x_range=[-0.18, 0.18], y_range=[-0.18, 0.18], pixel_size=1e-3)\n",
+    "print(intensity_map.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01b5646b-b698-408d-b268-245347812f5d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds_max = 1.2\n",
+    "mask = None\n",
+    "\n",
+    "rot_start = -89.975\n",
+    "rot_end = 90.9668\n",
+    "rot_step = 0.05\n",
+    "omega_angles = np.arange(rot_start, rot_end+rot_step/2, rot_step)\n",
+    "print(\"{} rotation angles in one dty position\".format(omega_angles.shape[0]))\n",
+    "\n",
+    "dty = 0.0\n",
+    "fwd_peaks = forward_projector.forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty = dty, mask = None, ds_max = 1.2, plot_peaks=True, verbose = 1)\n",
+    "print(fwd_peaks.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f0f4400-b3bb-446a-a548-8f8a844364f5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "io.write_fwd_peaks(fwd_peaks, output_folder = output_folder, fname_prefix='fpks')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "495a8165-392a-457f-b1ca-22518f2e82b5",
+   "metadata": {},
+   "source": [
+    "# Testing a bigger beam size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "290bb20c-aebd-43ae-bdb4-88c2c0a10699",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "beam.FWHM = [0.002, 0.002]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0425e38-27e6-4621-9b09-16a698268d68",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds_max = 1.2\n",
+    "mask = None\n",
+    "\n",
+    "rot_start = -89.975\n",
+    "rot_end = 90.9668\n",
+    "rot_step = 0.5\n",
+    "omega_angles = np.arange(rot_start, rot_end+rot_step/2, rot_step)\n",
+    "print(\"{} rotation angles in one dty position\".format(omega_angles.shape[0]))\n",
+    "\n",
+    "dty = 0.0\n",
+    "fwd_peaks_bigger_beam = forward_projector.forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty = dty, mask = None, ds_max = 1.2, plot_peaks=True, verbose = 1)\n",
+    "print(fwd_peaks_bigger_beam.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "126319d9-dc2e-425d-9ccb-12b225a0b8cd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fwd_peaks_bigger_beam.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83723c93-70b2-43c6-a582-1c8deb83a289",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "io.write_fwd_peaks(fwd_peaks_bigger_beam, output_folder = output_folder, fname_prefix='fpks_2um_beam')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de67bf01-a68c-4de1-be68-ac6fc5e602d5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "beam.FWHM = [0.003, 0.003]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd492f5d-411d-4d59-a376-a1bb7009d5f9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds_max = 1.2\n",
+    "mask = None\n",
+    "\n",
+    "rot_start = -89.975\n",
+    "rot_end = 90.9668\n",
+    "rot_step = 0.5\n",
+    "omega_angles = np.arange(rot_start, rot_end+rot_step/2, rot_step)\n",
+    "print(\"{} rotation angles in one dty position\".format(omega_angles.shape[0]))\n",
+    "\n",
+    "dty = 0.0\n",
+    "fwd_peaks_bigger_beam = forward_projector.forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty = dty, mask = None, ds_max = 1.2, plot_peaks=True, verbose = 1)\n",
+    "print(fwd_peaks_bigger_beam.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e331253-a8a5-4326-b425-d7392d042f8d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "beam.FWHM = [0.05, 0.05]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0373ce35-81f5-4756-9fc6-5544d77c9677",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds_max = 1.2\n",
+    "mask = None\n",
+    "\n",
+    "rot_start = -89.975\n",
+    "rot_end = 90.9668\n",
+    "rot_step = 0.5\n",
+    "omega_angles = np.arange(rot_start, rot_end+rot_step/2, rot_step)\n",
+    "print(\"{} rotation angles in one dty position\".format(omega_angles.shape[0]))\n",
+    "\n",
+    "dty = 0.0\n",
+    "fwd_peaks_bigger_beam = forward_projector.forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty = dty, mask = None, ds_max = 1.2, plot_peaks=True, verbose = 1)\n",
+    "print(fwd_peaks_bigger_beam.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63466bfc-b5e8-408f-a9db-b73137259d6f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fwd_peaks_bigger_beam.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2355d32c-ded4-4493-b192-dc739b600cea",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "io.write_fwd_peaks(fwd_peaks_bigger_beam, output_folder = output_folder, fname_prefix='fpks_50um_beam')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a569f05-3aae-4768-8d61-b8a8888e3c10",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "beam.FWHM = [2, 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c87efe4-222f-405e-967e-ab8b503a742e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds_max = 1.2\n",
+    "mask = None\n",
+    "\n",
+    "rot_start = -89.975\n",
+    "rot_end = 90.9668\n",
+    "rot_step = 0.5\n",
+    "omega_angles = np.arange(rot_start, rot_end+rot_step/2, rot_step)\n",
+    "print(\"{} rotation angles in one dty position\".format(omega_angles.shape[0]))\n",
+    "\n",
+    "dty = 0.0\n",
+    "fwd_peaks_bigger_beam = forward_projector.forward_peaks_voxels(beam, sample, omega_angles, ucell, pars, dty = dty, mask = None, ds_max = 1.2, plot_peaks=True, verbose = 1)\n",
+    "print(fwd_peaks_bigger_beam.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5d9cb41-bb33-4174-b8f0-8b84703fbef3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "io.write_fwd_peaks(fwd_peaks_bigger_beam, output_folder = output_folder, fname_prefix='fpks_2000um_beam')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18e48dc1-2e12-45eb-b75f-0cf0796052c9",
+   "metadata": {},
+   "source": [
+    "# Create projections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17d025e7-527e-4513-9276-89434b4036e2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "rot_angle = -11.5282\n",
+    "t0 = time.time()\n",
+    "im1 = forward_projector.make_one_projection_with_psf(fwd_peaks, rot_angle, rot_step = 0.05, image_size=(2162, 2068), detector = 'frelon', int_factors = (0.1065, 0.7807, 0.1065))\n",
+    "print('It takes {}'.format(time.time() - t0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "858b50cd-ee36-4182-a931-a810eaf46fb5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t0 = time.time()\n",
+    "im2 = forward_projector.make_one_projection_with_psf(fwd_peaks, rot_angle, rot_step = 0.05, image_size=(2162, 2068), detector = 'eiger', int_factors = (0.1065, 0.7807, 0.1065))\n",
+    "print('It takes {}'.format(time.time() - t0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a3b90ae-1728-48d9-b683-c139f8aae236",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f, a = plt.subplots(1, 2, figsize=(12, 6), sharex=True, sharey=True)\n",
+    "a[0].imshow(im1>0)\n",
+    "a[0].set_title('frelon')\n",
+    "a[1].imshow(im2>0)\n",
+    "a[1].set_title('eiger')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7226a80-3b35-4f13-a31e-e08545d9e45e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t0 = time.time()\n",
+    "projs, _ = forward_projector.make_projections_with_psf(fwd_peaks, omega_angles, image_size=(2162, 2068),\n",
+    "                                                       detector = 'eiger', int_factors=(0.1065, 0.7807, 0.1065),\n",
+    "                                                      sum_flag=False)\n",
+    "print('It takes {}'.format(time.time() - t0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b481b640-88cf-46c5-8ad8-ae3de2c35a99",
+   "metadata": {},
+   "source": [
+    "# Make a forward_projector class and run calculations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eda0bdfd-9ef7-4e79-b9a0-33859f0c9bd6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "phase_name = 'Al'\n",
+    "opts = {\n",
+    "        \"energy\": 43.56,                 # [keV]\n",
+    "        \"beam_size\": [1e-3, 1e-3],       # [mm]\n",
+    "        \"beam_profile\": \"gaussian\",      # [-]\n",
+    "        \"flux\": 5e14,                    # [photons/s]\n",
+    "        \"Lss\": 0.0,                      # [mm]\n",
+    "        \"min_misori\": 3.0,               # [deg]\n",
+    "        \"crystal_system\": 'cubic',\n",
+    "        \"remove_small_grains\": True,\n",
+    "        \"min_vol\": 3,                    # [voxel]\n",
+    "        \"rou\": 2.7,                      # [g/cm^3]\n",
+    "        \"mass_abs\": 0.56685,             # [cm^2/g]\n",
+    "        \"y0_offset\": 0.0,                # [um]\n",
+    "        \"exp_time\": 0.002,               # [s]\n",
+    "        \"rot_start\": -89.975,            # [deg]\n",
+    "        \"rot_end\": 90.9668,              # [deg]\n",
+    "        \"rot_step\": 0.05,                # [deg]\n",
+    "        \"sparse_omega\": True,\n",
+    "        \"halfy\": 182.0,                  # [um]\n",
+    "        \"dty_step\": 1.0,                 # [um]\n",
+    "        \"ds_max\": 1.2,                   # [1/angstrom]\n",
+    "        \"plot_peaks\": False,\n",
+    "        \"plot_flag\": False,\n",
+    "        \"detector\": \"eiger\",\n",
+    "        \"int_factors\": (0.1065, 0.7807, 0.1065),\n",
+    "        \"slurm_folder\": \"slurm_fwd_proj_Al\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "797075ac-906b-463c-9ebe-172f9dfbb562",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fp = forward_projector.forward_projector(sample_filename, pars_filename, phase_name, output_folder=output_folder, detector_mask = None, to_sparse = False, **opts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4d36185-7c78-457f-99a3-3806ee9e21b6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t0 = time.time()\n",
+    "fp.run_single_dty(dty = 0.0)\n",
+    "t1 = time.time()\n",
+    "print('It takes {}'.format(t1 - t0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "feb0a2ac-1ba7-4136-a478-ab9c451b3f4f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fp.read_fwd_peaks_from_file = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27f8840a-1b23-40e1-afa9-fe5262ed8fb4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# allows overwrite by setting fp.read_fwd_peaks_from_file = False\n",
+    "t0 = time.time()\n",
+    "fp.run_single_dty(dty = 0.0)\n",
+    "t1 = time.time()\n",
+    "print('It takes {}'.format(t1 - t0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b1b6f26-0c11-4cb2-b5b5-405861ee7f41",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# run again, should be faster wit numba compiled\n",
+    "t0 = time.time()\n",
+    "fp.run_single_dty(dty = -120.0)\n",
+    "t1 = time.time()\n",
+    "print('It takes {}'.format(t1 - t0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbdb4d08-275d-45c4-8bb6-762afd50f161",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dty_select = -120\n",
+    "if dty_select == 0:\n",
+    "    fwd_peaks = io.read_fwd_peaks(f'{output_folder}/fpks_dty_0p0.h5')\n",
+    "    fwd_peaks_3d = io.read_fwd_peaks(f'{output_folder}/fpks_3d_dty_0p0.h5')\n",
+    "else:\n",
+    "    fwd_peaks = io.read_fwd_peaks(f'{output_folder}/fpks_dty_-120p0.h5')\n",
+    "    fwd_peaks_3d = io.read_fwd_peaks(f'{output_folder}/fpks_3d_dty_-120p0.h5')\n",
+    "print(fwd_peaks.shape)\n",
+    "print(fwd_peaks_3d.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cd2b3fe-63c1-458b-abf7-6bf804db3a55",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "forward_projector.plot_fwd_peaks(fwd_peaks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd83e00d-2d69-4ec7-b7a4-f25992d07a37",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "intensity_map = forward_projector.make_intensity_map(fwd_peaks[:, 5], fwd_peaks[:, 6], fwd_peaks[:, 23],\n",
+    "                                     x_range=[-0.18, 0.18], y_range=[-0.18, 0.18], pixel_size=1e-3)\n",
+    "print(intensity_map.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "052a6517-5ddf-4f45-95ac-dea31d6c0f45",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "intensity_map = forward_projector.make_intensity_map(fwd_peaks[:, 18], fwd_peaks[:, 19], fwd_peaks[:, 23],\n",
+    "                                     x_range = [0, 2162], y_range = [0, 2068], pixel_size=1,)\n",
+    "print(intensity_map.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6159118-91ec-44a4-ada4-02eca286aec1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "omega_angles = np.arange(opts[\"rot_start\"], opts[\"rot_end\"] + opts[\"rot_step\"]/2, np.max([opts[\"rot_step\"], 0.5]))\n",
+    "print(omega_angles.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bc10f8d-9caf-4bda-afa6-5a579f09b588",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "projs, projs_sum = forward_projector.make_projections_with_psf(\n",
+    "    fwd_peaks,\n",
+    "    omega_angles,\n",
+    "    image_size=(2162, 2068),\n",
+    "    detector='eiger',\n",
+    "    int_factors=(0.1065, 0.7807, 0.1065),\n",
+    "    sum_flag = True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f44842c-f1c1-485a-a764-1c2551ed0178",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f, a = plt.subplots(1,2, sharex=True, sharey=True, figsize=(16, 8))\n",
+    "\n",
+    "a[0].imshow(intensity_map, origin=\"lower\", norm=LogNorm(vmin=10, vmax=1e4), interpolation=\"nearest\")\n",
+    "a[0].set_title('(a) Sum of intensities without psf')\n",
+    "\n",
+    "a[1].imshow(projs_sum, origin=\"lower\", norm=LogNorm(vmin=10, vmax=1e4), interpolation=\"nearest\")\n",
+    "a[1].set_title('(b) Sum of projections with psf')\n",
+    "\n",
+    "a[1].set_xlim([200, 600])\n",
+    "a[1].set_ylim([200, 600])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07c00866-dc85-46ba-846e-6acf28977d33",
+   "metadata": {},
+   "source": [
+    "# Compare with the experimental projections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05851bd6-4141-4018-bd97-c80136313b84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# experimental raw data\n",
+    "raw_h5 = '/data/visitor/ma6288/id11/20241119/RAW_DATA/A2050_DN_W340_nscope_5pct_strained/A2050_DN_W340_nscope_5pct_strained_full_slice/A2050_DN_W340_nscope_5pct_strained_full_slice.h5'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a7ddc5d-a714-4a48-9355-55f4e3a25125",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# from -11.7282 to -11.4282 deg\n",
+    "# StartIndex=1565\n",
+    "# EndIndex=1571\n",
+    "\n",
+    "# from -2.47853 to 2.5213 deg\n",
+    "StartIndex=1750\n",
+    "EndIndex=1850"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edb2de0b-2065-4217-bdcb-7f0f930f4de5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "scan = f'{dty_select + 182 + 1}.1'\n",
+    "print(scan)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a318796-6ce5-44b6-a9d2-ebd568292780",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# 183.1, dty = 0\n",
+    "# 63.1, dty = -120\n",
+    "projs_exp = io.read_images_from_h5(raw_h5, scan = scan, StartIndex=StartIndex, EndIndex=EndIndex)\n",
+    "print(projs_exp.shape)\n",
+    "projs_exp_sum = np.sum(projs_exp, axis = 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ced6a481-cb0a-424a-b020-4a0d4e87d11f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "omega_angles = np.arange(opts[\"rot_start\"], opts[\"rot_end\"] + opts[\"rot_step\"]/2, opts[\"rot_step\"])\n",
+    "print(omega_angles.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42392976-cbb4-4c74-9e9b-ffa40ece9b60",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "projs_simu, projs_simu_sum = forward_projector.make_projections_with_psf(\n",
+    "    fwd_peaks,\n",
+    "    omega_angles[StartIndex:EndIndex],\n",
+    "    image_size=(2162, 2068),\n",
+    "    detector='eiger',\n",
+    "    int_factors=(0.1065, 0.7807, 0.1065),\n",
+    "    sum_flag=True\n",
+    ")\n",
+    "print(projs_simu.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85df9a87-1672-4b09-8b65-14bd405653e4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f, a = plt.subplots(1,2, sharex=True, sharey=True, figsize=(12, 6))\n",
+    "\n",
+    "a[0].imshow(projs_exp_sum, origin=\"lower\", norm=LogNorm(vmin=1, vmax=1000), interpolation=\"nearest\")\n",
+    "a[0].set_title('(a) Exp')\n",
+    "\n",
+    "a[1].imshow(projs_simu_sum, origin=\"lower\", norm=LogNorm(vmin=1, vmax=1e4), interpolation=\"nearest\")\n",
+    "a[1].set_title('(b) Simu')\n",
+    "\n",
+    "if dty_select == 0:\n",
+    "    a[1].set_xlim([200, 350])\n",
+    "    a[1].set_ylim([1150, 1400])\n",
+    "else:\n",
+    "    a[1].set_xlim([200, 400])\n",
+    "    a[1].set_ylim([1300, 1500])\n",
+    "f.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be9533bd-d5f9-4906-864d-2696ccc7875b",
+   "metadata": {},
+   "source": [
+    "# Convert fwd_peaks to sparse file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7627f127-5304-41eb-80cf-1817e8346032",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "opts_seg = forward_projector.get_opts_seg()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43644ed-7652-4d0e-ad83-988061c48a4f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "opts_seg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c92e318-f0f8-4884-aaef-6946ba240c73",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t0 = time.time()\n",
+    "projs, _ = forward_projector.make_projections_with_psf(\n",
+    "    fwd_peaks,\n",
+    "    omega_angles,\n",
+    "    image_size=(2162, 2068),\n",
+    "    detector='eiger',\n",
+    "    int_factors=(0.1065, 0.7807, 0.1065),\n",
+    "    sum_flag = False\n",
+    ")\n",
+    "t1 = time.time()\n",
+    "print('It takes {}'.format(t1 - t0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70a6f7b5-8a1f-4880-9a01-72af021b46d4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dty = fwd_peaks[0, 8]\n",
+    "destname = os.path.join(output_folder, 'fsparse_dty_' + str(round(dty, 2)).replace('.', 'p') + '.h5')\n",
+    "print(destname)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f330f1d5-c6fc-409f-9dc3-f77c7cda8afd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(fwd_peaks.shape, omega_angles.shape, projs.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "711c4995-b5c4-495e-9b7f-5679f20277e9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t0 = time.time()\n",
+    "forward_projector.make_projs_and_sparse_file(fwd_peaks, destname, omega_angles, opts_seg, detector='eiger',\n",
+    "                                             image_size=(2162, 2068), int_factors=(0.1065, 0.7807, 0.1065))\n",
+    "t1 = time.time()\n",
+    "print('It takes {}'.format(t1 - t0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4714464-5736-4fc9-b7ad-b1477ae5ae25",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# filename for segmented sparse\n",
+    "destname = os.path.join(output_folder, 'fsparse_dty_' + str(round(dty, 2)).replace('.', 'p') + '_seg.h5')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ce54907-4ec6-405f-afbf-b24c3f6d75dc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "t0 = time.time()\n",
+    "forward_projector.segment_frms(projs, destname, detector='eiger', opts_seg = opts_seg)\n",
+    "t1 = time.time()\n",
+    "print('It takes {}'.format(t1 - t0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58028951-be04-4bb4-a173-81778cd28913",
+   "metadata": {},
+   "source": [
+    "# Assemble and label the peaks from the sparse file\n",
+    "# Note: this is only to illustrate the peak assembling, it is however recommended not to do so because of the speed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "607f0937-7cfb-4adf-ac36-825be4372dce",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "forward_projector.assemble_sparsefiles(fp.output_folder, fp.dtys,\n",
+    "                                       outname_sparse=f'{output_folder}/fwd_sparse.h5',image_size=(2162, 2068))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa7feddf-feb1-4684-a8c9-7ce7c86e33a1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ImageD11/forward_model/test_forward_projector_to_cf.ipynb
+++ b/ImageD11/forward_model/test_forward_projector_to_cf.ipynb
@@ -1,0 +1,580 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "14f04ebd-cfdf-4d5f-90b2-d6976e1f729b",
+   "metadata": {},
+   "source": [
+    "# Test forward_projector.py\n",
+    "## Test to generate peaks forward computed from an experimentally reconstructed grain map and convert peaks to cf\n",
+    "## Haixing Fang\n",
+    "## Jan 2025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bff7f14c-1716-4902-87f6-2bccbb9198e6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['OMP_NUM_THREADS'] = '1'\n",
+    "os.environ['OPENBLAS_NUM_THREADS'] = '1'\n",
+    "os.environ['MKL_NUM_THREADS'] = '1'\n",
+    "\n",
+    "exec(open('/data/id11/nanoscope/install_ImageD11_from_git.py').read())\n",
+    "PYTHONPATH = setup_ImageD11_from_git( ) # ( os.path.join( os.environ['HOME'],'Code'), 'ImageD11_git' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32f07e6f-62fd-45a1-8635-3d343dcf5abd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import functions we need\n",
+    "\n",
+    "import concurrent.futures\n",
+    "\n",
+    "# %matplotlib ipympl\n",
+    "\n",
+    "import h5py\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e6c878a-f658-49a7-83f5-b9f72306cc68",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import ImageD11.parameters\n",
+    "import ImageD11.unitcell\n",
+    "import time\n",
+    "from joblib import Parallel, delayed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e619ec2-4f43-49f7-8fa2-2c6f63deb5e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ImageD11.forward_model import forward_projector\n",
+    "from ImageD11.forward_model import io\n",
+    "from ImageD11.forward_model import forward_model\n",
+    "from ImageD11.forward_model import pars_conversion\n",
+    "from ImageD11.forward_model import grainmaps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2c167e6-1a31-4507-803b-3955160e3b32",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "from tqdm import tqdm\n",
+    "import numba"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "247c1b20-37ba-4a55-a0ad-159954c3659a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# sample_filename can be xx_grains.h5, pbp_tensormap_refined.h5, in which the regional voxels would be merged to generate 'labels'\n",
+    "# DS.h5 stores the grain map after merging regions and identifying grain IDs\n",
+    "# sample_filename = 'A2050_DN_W340_nscope_full_slice_grains.h5'\n",
+    "# sample_filename = 'pbp_tensormap_refined.h5'\n",
+    "sample_filename = 'DS.h5'\n",
+    "pars_filename = '/data/visitor/ma6288/id11/20241119/PROCESSED_DATA/nscope_pars/pars.json'\n",
+    "phase_name = 'Al'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34b9572d-a9b8-4045-8898-743f1bb9e627",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "opts = {\n",
+    "        \"energy\": 43.56,                 # [keV]\n",
+    "        \"beam_size\": [1e-3, 1e-3],       # [mm]\n",
+    "        \"beam_profile\": \"gaussian\",      # [-]\n",
+    "        \"flux\": 5e14,                    # [photons/s]\n",
+    "        \"Lss\": 0.0,                      # [mm]\n",
+    "        \"min_misori\": 3.0,               # [deg]\n",
+    "        \"crystal_system\": 'cubic',\n",
+    "        \"remove_small_grains\": True,\n",
+    "        \"min_vol\": 3,                    # [voxel]\n",
+    "        \"rou\": 2.7,                      # [g/cm^3]\n",
+    "        \"mass_abs\": 0.56685,             # [cm^2/g]\n",
+    "        \"y0_offset\": 0.0,                # [um]\n",
+    "        \"exp_time\": 0.002,               # [s]\n",
+    "        \"rot_start\": -89.975,            # [deg]\n",
+    "        \"rot_end\": 90.9668,              # [deg]\n",
+    "        \"rot_step\": 0.05,                # [deg]\n",
+    "        \"sparse_omega\": True,\n",
+    "        \"halfy\": 182.0,                  # [um]\n",
+    "        \"dty_step\": 1.0,                 # [um]\n",
+    "        \"ds_max\": 1.2,                   # [1/angstrom]\n",
+    "        \"plot_peaks\": False,\n",
+    "        \"plot_flag\": False,\n",
+    "        \"detector\": \"eiger\",\n",
+    "        \"int_factors\": (0.1065, 0.7807, 0.1065),\n",
+    "        \"slurm_folder\": \"slurm_fwd_proj_Al\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f61b035-021b-487b-9fa3-895f9d9a7e9e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fp = forward_projector.forward_projector(sample_filename, pars_filename, phase_name, detector_mask = None, to_sparse = False, **opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9eebd1ac-27ce-409b-9cc0-1b8c106f8eab",
+   "metadata": {},
+   "source": [
+    "# Run all dty calculations on cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c62a0a1-3c70-440a-b670-a6449f8656d3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# No need to produce sparse files\n",
+    "fp.to_sparse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98f25127-2332-47de-aeb7-957a386661a0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# send jobs to the cluster\n",
+    "fp.args['use_cluster']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1640b539-fd06-4957-80e6-4bc4a23c3489",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# run jobs for all dty positions, if the output peaks file is already existed, it would skip\n",
+    "t0 = time.time()\n",
+    "fp.run_all()\n",
+    "t1 = time.time()\n",
+    "print('It takes {} s'.format(t1 - t0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88de0c28-4b16-4a95-bb79-5fd0fecbcb98",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# the peaks are stored in two types:\n",
+    "# 1) cf_2d, cf_3d, cf_4d like cf object in ImageD11\n",
+    "# 2) peaks_2d, peaks_3d, peaks_4d in numpy array with a shape of N*25\n",
+    "fp.read_cf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6408f1a4-3b7a-43d0-a7b3-3022fab260ae",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# merge 3D peaks to 4D peaks\n",
+    "fp.get_cf_4d()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c38a311-5801-4b4c-bdaf-7d09be1aa5cb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fp.write_cf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b70ec9d-ac32-4321-98ad-9138461613b9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "forward_projector.plot_fwd_peaks(fp.peaks_3d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "517268d9-7b0c-4cc7-b8c7-19037360e333",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "forward_projector.plot_fwd_peaks(fp.peaks_4d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fbe0cc7-6a28-4c4e-83b1-00312e066a35",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# plot sino for 2D peaks\n",
+    "fp.plot_cf(cf_type = '2d', m = None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "538d72de-05e5-4408-9779-8df7ee228be3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "forward_model.cf_plot_sino(fp.cf_3d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b78b0b6-f7c8-48e6-93d3-58d6651a06a0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "forward_model.cf_plot_sino(fp.cf_4d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8aae4be-a309-45aa-96b9-8b055de7e3e2",
+   "metadata": {},
+   "source": [
+    "# Plot 2D peaks from a specific grainID or a specific range of ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5554105-e116-4409-b711-745f4477ef0b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# specific grainID\n",
+    "fp.plot_cf(cf_type = '2d', m = fp.cf_2d.grainID == 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a379fec-1cf1-44ef-a6ee-05ad0319ee63",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# specific grainID\n",
+    "fp.plot_cf(cf_type = '2d', m = fp.cf_2d.grainID == 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7b9df7b-2f19-4e5b-b445-ff456c19b74d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# specific ds range\n",
+    "fp.plot_cf(cf_type = '2d', m = (fp.cf_2d.ds > 0.4) & (fp.cf_2d.ds < 0.5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddafc004-7dee-48eb-a069-357e6ff9d514",
+   "metadata": {},
+   "source": [
+    "# Compare with experimental peaks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74c643ab-64c5-44b1-8b4c-e383ab4651cd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dset_file = '/data/visitor/ma6288/id11/20241119/PROCESSED_DATA/A2050_DN_W340_nscope_5pct_strained/A2050_DN_W340_nscope_5pct_strained_full_slice_tomo/A2050_DN_W340_nscope_5pct_strained_full_slice_dataset.h5'\n",
+    "\n",
+    "ds = ImageD11.sinograms.dataset.load(dset_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "139a6a39-efa8-4497-a962-c5ad389899d5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Import 4D peaks\n",
+    "\n",
+    "cf_4d = ds.get_cf_4d_from_disk()\n",
+    "\n",
+    "ds.update_colfile_pars(cf_4d, phase_name='Al')\n",
+    "\n",
+    "print(f\"Read {cf_4d.nrows} 4D peaks\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "465f70bc-4a85-4152-8777-737089afc60f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cf_2d = ds.get_cf_2d()\n",
+    "ds.update_colfile_pars( cf_2d )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed51a3ae-123b-4caa-a6b8-b0475a68ec87",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.hist2d( cf_2d.ds, cf_2d.eta, weights= np.log(cf_2d.sum_intensity), bins = (2000, 360), norm='log')\n",
+    "# plt.plot( dssa, np.zeros_like(dssa), '|', ms = 20, lw=1);\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6daa8d2f-9eb3-4c0c-94f3-05cc247dda85",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# make a copy of fp.cf_2d\n",
+    "cf_2d_fwd = fp.cf_2d.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56c66eab-8c4b-4bd0-896b-e6745c5e9a5e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f, a = plt.subplots(1,2,figsize=(14,6), sharex=True, sharey=True)\n",
+    "\n",
+    "# simu\n",
+    "m200 = (cf_2d_fwd.ds < 0.5)&(cf_2d_fwd.ds > 0.4)\n",
+    "h0 = a[0].hist2d( cf_2d_fwd.omega[m200], cf_2d_fwd.dty[m200], weights= np.log(cf_2d_fwd.sum_intensity[m200]),\n",
+    "           bins = (fp.omega_angles.shape[0], fp.dtys.shape[0]), norm='log')\n",
+    "# plt.colorbar(label=\"Log Intensity\")\n",
+    "a[0].set_xlabel(\"Omega ($^{o}$)\")\n",
+    "a[0].set_ylabel(\"dty ($\\mu$m)\")\n",
+    "a[0].set_title('(a) Simu, {002}')\n",
+    "\n",
+    "cbar0 = f.colorbar(h0[3], ax=a[0])\n",
+    "# cbar0.set_label(\"Log Intensity\")\n",
+    "\n",
+    "# exp\n",
+    "m200 = (cf_2d.ds < 0.5)&(cf_2d.ds > 0.49)\n",
+    "h1 = a[1].hist2d( cf_2d.omega[m200], cf_2d.dty[ m200], weights=cf_2d.sum_intensity[m200], bins=(ds.obinedges, ds.ybinedges), norm='log')\n",
+    "a[1].set_xlabel(\"Omega ($^{o}$)\")\n",
+    "a[1].set_ylabel(\"dty ($\\mu$m)\")\n",
+    "a[1].set_title('(b) Exp, {002}')\n",
+    "\n",
+    "cbar1 = f.colorbar(h1[3], ax=a[1])\n",
+    "# cbar1.set_label(\"Log Intensity\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "210c80fa-a21c-41fa-976f-387ca31bcea5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f, a = plt.subplots(1,2,figsize=(14,6), sharex=True, sharey=True)\n",
+    "\n",
+    "# simu\n",
+    "m311 = (cf_2d_fwd.ds < 0.83)&(cf_2d_fwd.ds > 0.76)\n",
+    "h0 = a[0].hist2d( cf_2d_fwd.omega[m311], cf_2d_fwd.dty[m311], weights= np.log(cf_2d_fwd.sum_intensity[m311]),\n",
+    "           bins = (fp.omega_angles.shape[0], fp.dtys.shape[0]), norm='log')\n",
+    "cbar0 = f.colorbar(h0[3], ax=a[0])\n",
+    "a[0].set_xlabel(\"Omega ($^{o}$)\")\n",
+    "a[0].set_ylabel(\"dty ($\\mu$m)\")\n",
+    "a[0].set_title('(a) Simu, {113}')\n",
+    "\n",
+    "\n",
+    "# exp\n",
+    "m311 = (cf_2d.ds < 0.83)&(cf_2d.ds > 0.81)\n",
+    "h1 = a[1].hist2d( cf_2d.omega[m311], cf_2d.dty[ m311], weights=cf_2d.sum_intensity[m311], bins=(ds.obinedges, ds.ybinedges), norm='log')\n",
+    "cbar1 = f.colorbar(h1[3], ax=a[1])\n",
+    "a[1].set_xlabel(\"Omega ($^{o}$)\")\n",
+    "a[1].set_ylabel(\"dty ($\\mu$m)\")\n",
+    "a[1].set_title('(b) Exp, {113}')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eeeeb8c9-8992-4f1b-821d-323d1e21d899",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m311 = (cf_2d.ds < 0.83)&(cf_2d.ds > 0.81)\n",
+    "# color as dstar\n",
+    "sI = np.histogram2d( cf_2d.omega[m311], cf_2d.dty[ m311], weights=cf_2d.sum_intensity[m311], \n",
+    "                bins = (ds.obinedges, ds.ybinedges))\n",
+    "sId = np.histogram2d( cf_2d.omega[m311], cf_2d.dty[ m311], weights=cf_2d.sum_intensity[m311] * cf_2d.ds[m311],\n",
+    "                bins = (ds.obinedges, ds.ybinedges))\n",
+    "ds200 = (sId[0] / sI[0]).T\n",
+    "x0 = 0.82\n",
+    "strain = (ds200 - x0)/x0\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.pcolormesh( ds.obinedges, ds.ybinedges, strain , cmap = 'RdBu', vmin=-3e-3, vmax=3e-3);\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2bef5b9-b092-4c5c-a7b4-b90ef9506d71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot 4D peaks, simu and exp\n",
+    "forward_model.cf_plot_sino([fp.cf_4d, cf_4d])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7be0041f-7f5b-4a9b-899f-bfb1a0fc5540",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ImageD11/forward_model/test_grainmaps.ipynb
+++ b/ImageD11/forward_model/test_grainmaps.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test grainmaps.py\n",
+    "## Mainly to test reading tensor maps and merging voxels that have close misorientations, thus to generate 'labels'\n",
+    "## Jan 2025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['OMP_NUM_THREADS'] = '1'\n",
+    "os.environ['OPENBLAS_NUM_THREADS'] = '1'\n",
+    "os.environ['MKL_NUM_THREADS'] = '1'\n",
+    "\n",
+    "exec(open('/data/id11/nanoscope/install_ImageD11_from_git.py').read())\n",
+    "PYTHONPATH = setup_ImageD11_from_git( ) # ( os.path.join( os.environ['HOME'],'Code'), 'ImageD11_git' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import functions we need\n",
+    "\n",
+    "import concurrent.futures\n",
+    "\n",
+    "# %matplotlib ipympl\n",
+    "\n",
+    "import h5py\n",
+    "from tqdm.notebook import tqdm\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from skimage.filters import threshold_otsu\n",
+    "from skimage.morphology import convex_hull_image\n",
+    "\n",
+    "import ImageD11.columnfile\n",
+    "from ImageD11.grain import grain\n",
+    "from ImageD11.peakselect import select_ring_peaks_by_intensity\n",
+    "from ImageD11.sinograms.sinogram import GrainSinogram, build_slice_arrays, write_slice_recon, read_h5, write_h5, get_2d_peaks_from_4d_peaks\n",
+    "from ImageD11.sinograms.roi_iradon import run_iradon\n",
+    "from ImageD11.sinograms.tensor_map import TensorMap\n",
+    "import ImageD11.sinograms.dataset\n",
+    "import ImageD11.nbGui.nb_utils as utils\n",
+    "\n",
+    "import ipywidgets as widgets\n",
+    "from ipywidgets import interact"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# test reading the pbp_tensormap_refined.h5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ImageD11.forward_model import io"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ImageD11.forward_model import grainmaps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# filename='/data/visitor/ma6288/id11/20241119/PROCESSED_DATA/A2050_DN_W340_nscope/A2050_DN_W340_nscope_full_slice/A2050_DN_W340_nscope_full_slice_grains.h5'\n",
+    "# filename = '/data/visitor/ma6288/id11/20241119/PROCESSED_DATA/A2050_W370_nscope/A2050_W370_nscope_full_slice/pbp_tensormap_refined.h5'\n",
+    "filename = '/data/visitor/ma6288/id11/20241119/PROCESSED_DATA/A2050_DN_W340_nscope_5pct_strained/A2050_DN_W340_nscope_5pct_strained_full_slice/pbp_tensormap_refined.h5'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gm = grainmaps.grainmap(filename = filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# check the 'labels' before merging\n",
+    "plt.figure()\n",
+    "plt.imshow(gm.DS['labels'][0,:,:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Do merging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# merging regions using default settings, i.e. min_misori = 3, dis_tol = np.sqrt(2)\n",
+    "gm.merge_and_identify_grains()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "img = plt.imshow(gm.DS['labels'][0, :, :], cmap='viridis')  # You can specify a colormap\n",
+    "plt.colorbar(img, label='grain ID')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# further merge with a bigger mis_misori and dis_tol\n",
+    "gm.min_misori = 5\n",
+    "gm.merge_and_identify_grains(dis_tol=np.sqrt(3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "img = plt.imshow(gm.DS['labels'][0, :, :], cmap='viridis')  # You can specify a colormap\n",
+    "plt.colorbar(img, label='grain ID')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# remove small grains that are considered as noise\n",
+    "DS_new = grainmaps.DS_remove_small_grains(gm.DS, min_vol=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "img = plt.imshow(DS_new['labels'][0, :, :], cmap='viridis')  # You can specify a colormap\n",
+    "plt.colorbar(img, label='grain ID')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# update the DS in gm class\n",
+    "gm.DS = DS_new"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gm.outname"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# to save the DS as gm.outname, by default DS.h5\n",
+    "gm.write_DS()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# to read the newly merged grain map file\n",
+    "DS0 = io.read_h5_file(gm.outname)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "img = plt.imshow(DS0['labels'][0, :, :], cmap='viridis')  # You can specify a colormap\n",
+    "plt.colorbar(img, label='grain ID')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ImageD11/forward_model/test_iterative_indexing.ipynb
+++ b/ImageD11/forward_model/test_iterative_indexing.ipynb
@@ -1,0 +1,844 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test indexing_iterative in grainmaps.py\n",
+    "## Mainly to test indexing_iterative that iteratively indexing grains, matching peaks with already-indexed grains and continue new indexing with the unmatched peaks\n",
+    "## Normally it is used as a supplementary for tomo_1_index.ipynb or or tomo_1_index_minor_phase.ipynb\n",
+    "## Jan 2025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exec(open('/data/id11/nanoscope/install_ImageD11_from_git.py').read())\n",
+    "PYTHONPATH = setup_ImageD11_from_git( ) # ( os.path.join( os.environ['HOME'],'Code'), 'ImageD11_git' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import functions we need\n",
+    "\n",
+    "import h5py\n",
+    "import numpy as np\n",
+    "\n",
+    "import matplotlib\n",
+    "# %matplotlib ipympl\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "import ImageD11.nbGui.nb_utils as utils\n",
+    "\n",
+    "import ImageD11.grain\n",
+    "import ImageD11.indexing\n",
+    "import ImageD11.columnfile\n",
+    "from ImageD11.unitcell import Phases\n",
+    "from ImageD11.peakselect import select_ring_peaks_by_intensity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: Pass path to dataset file\n",
+    "\n",
+    "dset_file = '/data/visitor/ihmi1549/id11/20240305/PROCESSED_DATA/FeAu_No1_interrupted/FeAu_No1_interrupted_s3DXRD_z5/FeAu_No1_interrupted_s3DXRD_z5_dataset.h5'\n",
+    "\n",
+    "ds = ImageD11.sinograms.dataset.load(dset_file)\n",
+    "   \n",
+    "sample = ds.sample\n",
+    "dataset = ds.dsname\n",
+    "rawdata_path = ds.dataroot\n",
+    "processed_data_root_dir = ds.analysisroot\n",
+    "\n",
+    "print(ds)\n",
+    "print(ds.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: specify the path to the parameter file\n",
+    "# you can find an example json in the same folder as this notebook\n",
+    "\n",
+    "par_file = '/data/visitor/ihmi1549/id11/20240305/SCRIPTS/HF/S3DXRD/pars.json'\n",
+    "\n",
+    "# add them to the dataset\n",
+    "\n",
+    "ds.parfile = par_file\n",
+    "\n",
+    "ds.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load phases from parameter file\n",
+    "\n",
+    "ds.phases = ds.get_phases_from_disk()\n",
+    "ds.phases.unitcells"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now let's select a phase to index from our parameters json\n",
+    "phase_str = 'Fe_bcc'\n",
+    "\n",
+    "ucell = ds.phases.unitcells[phase_str]\n",
+    "\n",
+    "print(ucell.lattice_parameters, ucell.spacegroup)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# We will now generate a cf (columnfile) object for the 4D peaks.\n",
+    "# Will be corrected for detector spatial distortion\n",
+    "\n",
+    "cf_4d = ds.get_cf_4d()\n",
+    "ds.update_colfile_pars(cf_4d, phase_name=phase_str)\n",
+    "\n",
+    "if not os.path.exists(ds.col4dfile):\n",
+    "    # save the 4D peaks to file so we don't have to spatially correct them again\n",
+    "    ImageD11.columnfile.colfile_to_hdf(cf_4d, ds.col4dfile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Generate a mask that selects only 4D peaks greater than 25 pixels in size\n",
+    "\n",
+    "m = cf_4d['Number_of_pixels'] > 25\n",
+    "\n",
+    "# then plot omega vs dty for all peaks - should look sinusoidal\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "counts, xedges, yedges, im = ax.hist2d(cf_4d['omega'][m], cf_4d['dty'][m], weights=np.sqrt(cf_4d['sum_intensity'][m]), bins=(ds.obinedges, ds.ybinedges), norm=matplotlib.colors.LogNorm())\n",
+    "ax.set_xlabel(\"Omega angle\")\n",
+    "ax.set_ylabel(\"dty\")\n",
+    "\n",
+    "fig.colorbar(im, ax=ax)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# plot the 4D peaks (fewer of them) as a cake (two-theta vs eta)\n",
+    "# if the parameters in the par file are good, these should look like straight lines\n",
+    "\n",
+    "ucell.makerings(cf_4d.ds.max())\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10,5), layout='constrained')\n",
+    "\n",
+    "ax.scatter(cf_4d.ds, cf_4d.eta, s=1)\n",
+    "ax.plot( ucell.ringds, [0,]*len(ucell.ringds), '|', ms=90, c=\"red\")\n",
+    "ax.set_xlabel(\"dstar\")\n",
+    "ax.set_ylabel(\"eta\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# OPTIONAL: export CF to an flt so we can play with it with ImageD11_gui\n",
+    "# uncomment the below line\n",
+    "\n",
+    "# cf_4d.writefile(f'{sample}_{dataset}_4d_peaks.flt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# here we are filtering our peaks (cf_4d) to select only the strongest ones for indexing purposes only!\n",
+    "# dsmax is being set to limit rings given to the indexer - 6-8 rings is normally good\n",
+    "\n",
+    "# USER: modify the \"frac\" parameter below and re-run the cell until the orange dot sits nicely on the \"elbow\" of the blue line\n",
+    "# this indicates the fractional intensity cutoff we will select\n",
+    "# if the blue line does not look elbow-shaped in the logscale plot, try changing the \"doplot\" parameter (the y scale of the logscale plot) until it does\n",
+    "\n",
+    "cf_strong_frac = 0.985\n",
+    "cf_strong_dsmax = 1.594\n",
+    "cf_strong_dstol = 0.005\n",
+    "\n",
+    "cf_strong = select_ring_peaks_by_intensity(cf_4d, frac=cf_strong_frac, dsmax=cf_strong_dsmax, dstol=cf_strong_dstol, doplot=0.97)\n",
+    "print(cf_4d.nrows)\n",
+    "print(cf_strong.nrows)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# OPTIONAL: export CF to an flt so we can play with it with ImageD11_gui\n",
+    "# uncomment the below line\n",
+    "\n",
+    "# cf_strong.writefile(f'{sample}_{dataset}_strong_4d_peaks.flt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we can take a look at the intensities of the remaining peaks\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 5), constrained_layout=True)\n",
+    "\n",
+    "ax.plot(cf_4d.ds, cf_4d.sum_intensity,',', label='cf_4d')\n",
+    "ax.plot(cf_strong.ds, cf_strong.sum_intensity,',', label='cf_strong')\n",
+    "ax.plot( ucell.ringds, [1e4,]*len(ucell.ringds), '|', ms=90, c=\"red\")\n",
+    "\n",
+    "ax.semilogy()\n",
+    "\n",
+    "ax.set_xlabel(\"Dstar\")\n",
+    "ax.set_ylabel(\"Intensity\")\n",
+    "ax.legend()\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we can take a look at the intensities of the remaining peaks\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 5), constrained_layout=True)\n",
+    "\n",
+    "# ax.plot(cf_4d.ds, cf_4d.sum_intensity,',', label='cf_4d')\n",
+    "ax.plot(cf_strong.ds, cf_strong.sum_intensity,',', label='cf_strong')\n",
+    "ax.plot( ucell.ringds, [1e4,]*len(ucell.ringds), '|', ms=90, c=\"red\")\n",
+    "\n",
+    "ax.semilogy()\n",
+    "\n",
+    "ax.set_xlabel(\"Dstar\")\n",
+    "ax.set_ylabel(\"Intensity\")\n",
+    "ax.legend()\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# specify our ImageD11 indexer with these peaks\n",
+    "\n",
+    "indexer = ImageD11.indexing.indexer_from_colfile(cf_strong)\n",
+    "\n",
+    "print(f\"Indexing {cf_strong.nrows} peaks\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: set a tolerance in d-space (for assigning peaks to powder rings)\n",
+    "\n",
+    "indexer_ds_tol = 0.006\n",
+    "indexer.ds_tol = indexer_ds_tol\n",
+    "\n",
+    "# change the log level so we can see what the ring assigments look like\n",
+    "\n",
+    "ImageD11.indexing.loglevel = 1\n",
+    "\n",
+    "# assign peaks to powder rings\n",
+    "\n",
+    "indexer.assigntorings()\n",
+    "\n",
+    "# change log level back again\n",
+    "\n",
+    "ImageD11.indexing.loglevel = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# let's plot the assigned peaks\n",
+    "\n",
+    "fig, ax = plt.subplots(layout='constrained', figsize=(10,5))\n",
+    "\n",
+    "# indexer.ra is the ring assignments\n",
+    "\n",
+    "ax.scatter(cf_strong.ds, cf_strong.eta, c=indexer.ra, cmap='tab20', s=1)\n",
+    "ax.plot( ucell.ringds, [0,]*len(ucell.ringds), '|', ms=90, c=\"red\")\n",
+    "ax.set_xlim(cf_strong.ds.min()-0.05, cf_strong.ds.max()+0.05)\n",
+    "ax.set_xlabel(\"d-star\")\n",
+    "ax.set_ylabel(\"eta\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we are indexing!\n",
+    "# we have to choose which rings we want to generate orientations on\n",
+    "# generally we want two or three low-multiplicity rings that are isolated from other phases\n",
+    "# take a look at the ring assignment output from a few cells above, and choose two or three\n",
+    "rings_for_gen = [0, 1, 3, 5]\n",
+    "\n",
+    "# now we want to decide which rings to score our found orientations against\n",
+    "# generally we can just exclude dodgy rings (close to other phases, only a few peaks in etc)\n",
+    "rings_for_scoring = [0, 1, 2, 3, 4, 5]\n",
+    "\n",
+    "# the sequence of hkl tolerances the indexer will iterate through\n",
+    "# hkl_tols_seq = [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.075]\n",
+    "hkl_tols_seq = [0.01, 0.02, 0.03, 0.04, 0.05]\n",
+    "# the sequence of minpks fractions the indexer will iterate through\n",
+    "fracs = [0.9, 0.7]\n",
+    "# fracs = [0.9,]\n",
+    "# the tolerance in g-vector angle\n",
+    "cosine_tol = np.cos(np.radians(90 - ds.ostep))\n",
+    "# the max number of UBIs we can find per pair of rings\n",
+    "max_grains = 1000\n",
+    "\n",
+    "grains, indexer = utils.do_index(cf=cf_strong,\n",
+    "                                 unitcell=ds.phases.unitcells[phase_str],\n",
+    "                                 dstol=indexer_ds_tol,\n",
+    "                                 forgen=rings_for_gen,\n",
+    "                                 foridx=rings_for_scoring,\n",
+    "                                 hkl_tols=hkl_tols_seq,\n",
+    "                                 fracs=fracs,\n",
+    "                                 cosine_tol=cosine_tol,\n",
+    "                                 max_grains=max_grains,\n",
+    "                                \n",
+    ")\n",
+    "print(f'Found {len(grains)} grains!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# add temporary grain IDs to the grains\n",
+    "\n",
+    "for ginc, g in enumerate(grains):\n",
+    "    g.gid = ginc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "mean_unit_cell_lengths = [np.cbrt(np.linalg.det(g.ubi)) for g in grains]\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(mean_unit_cell_lengths)\n",
+    "ax.set_xlabel(\"Grain ID\")\n",
+    "ax.set_ylabel(\"Unit cell length\")\n",
+    "plt.show()\n",
+    "\n",
+    "a0 = np.median(mean_unit_cell_lengths)\n",
+    "    \n",
+    "print(a0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# assign peaks to grains\n",
+    "\n",
+    "peak_assign_tol = 0.05\n",
+    "\n",
+    "utils.assign_peaks_to_grains(grains, cf_strong, tol=peak_assign_tol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "utils.plot_index_results(indexer, cf_strong, 'First attempt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "utils.plot_grain_sinograms(grains, cf_strong, min(len(grains), 25))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Note that the operations with deleting grains group and saving newly indexed grains have been commented out\n",
+    "## You may need to uncomment these lines in your own data processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # if you would like to overwrite the grains, you have to delete the existing grains group in grainsfile\n",
+    "# from ImageD11.forward_model import io\n",
+    "# io.delete_group_from_h5(ds.grainsfile, phase_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # save grain data\n",
+    "\n",
+    "# ds.save_grains_to_disk(grains, phase_name=phase_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # save new things to the dataset\n",
+    "\n",
+    "# ds.save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use \"indexing_iterative\" in grainmaps.py to remove all the indexed peaks and using the left peaks to further index new grains\n",
+    "# Main steps:\n",
+    "## 1) match peaks with already-indexed grains\n",
+    "## 2) find the remaining peaks that are unmatched\n",
+    "## 3) use the remaining peaks for indexing new grains\n",
+    "## 4) new grains must be compared with the previously indexed grains and merge the duplicate ones\n",
+    "## 5) generate a new grains object that has been merged\n",
+    "## These steps can be looped iteratively until the indexing is satisfied, e.g. percentage of peaks used for indexing has reached to a certain level "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ImageD11.forward_model import grainmaps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pars = ImageD11.parameters.read_par_file(ds.parfile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# the first iterative indexing\n",
+    "grains_new = grainmaps.indexing_iterative(cf_strong, grains, ds, ucell, pars, ds_max = 1.6, tol_angle = 0.25, tol_pixel =3,\n",
+    "                                          peak_assign_tol = 0.25,\n",
+    "                                          tol_misori = 3,\n",
+    "                                          crystal_sytem='cubic',\n",
+    "                                          indexer_ds_tol = indexer_ds_tol,\n",
+    "                                          rings_for_ge = rings_for_gen,\n",
+    "                                          rings_for_scoring = rings_for_scoring,\n",
+    "                                          hkl_tols_seq = hkl_tols_seq,\n",
+    "                                          fracs = fracs,\n",
+    "                                          cosine_tol = cosine_tol,\n",
+    "                                          max_grains = max_grains)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# assign peaks to grains\n",
+    "\n",
+    "peak_assign_tol = 0.05\n",
+    "\n",
+    "utils.assign_peaks_to_grains(grains_new, cf_strong, tol=peak_assign_tol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "utils.plot_grain_sinograms(grains_new, cf_strong, min(len(grains_new), 20))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# a second indexing with a looser criterion for matching peaks, i.e. bigger tol_angle and tol_pixel\n",
+    "grains_new2 = grainmaps.indexing_iterative(cf_strong, grains_new, ds, ucell, pars, ds_max = 1.2, tol_angle = 0.5, tol_pixel =5,\n",
+    "                                          peak_assign_tol = 0.25,\n",
+    "                                          tol_misori = 3,\n",
+    "                                          crystal_sytem='cubic',\n",
+    "                                          indexer_ds_tol = indexer_ds_tol,\n",
+    "                                          rings_for_ge = rings_for_gen,\n",
+    "                                          rings_for_scoring = rings_for_scoring,\n",
+    "                                          hkl_tols_seq = hkl_tols_seq,\n",
+    "                                          fracs = fracs,\n",
+    "                                          cosine_tol = cosine_tol,\n",
+    "                                          max_grains = max_grains)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assign peaks to grains\n",
+    "\n",
+    "peak_assign_tol = 0.05\n",
+    "\n",
+    "utils.assign_peaks_to_grains(grains_new2, cf_strong, tol=peak_assign_tol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "utils.plot_grain_sinograms(grains_new2, cf_strong, min(len(grains_new2), 20))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Now I can see more and more grains indexed with iterative_indexing\n",
+    "len(grains), len(grains_new), len(grains_new2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compute completeness for each grain and remove those that have relatively low completeness (considered to be non-trustable)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ImageD11.forward_model import forward_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cf_matched_all, Comp_all = forward_model.forward_match_peaks(cf_strong, grains_new2, ds, ucell, pars,\n",
+    "                                  ds_max = 1.2,\n",
+    "                                  tol_angle=0.5,\n",
+    "                                  tol_pixel=5,\n",
+    "                                  thres_int=None,\n",
+    "                                  verbose=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "Comp_all = np.array(Comp_all, dtype = 'float')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# plot the completeness\n",
+    "plt.figure()\n",
+    "plt.plot(np.arange(0, len(grains_new2),1), Comp_all[:,1], 'r.')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# remove grains with a completeness threshold\n",
+    "thres_comp = 0.35\n",
+    "gid_to_remove = np.argwhere(Comp_all[:,1] < thres_comp)\n",
+    "print(f'Originally there are {len(grains_new2)} grains')\n",
+    "print(f'Now I am going to remove {gid_to_remove.shape[0]} grains with completeness < {thres_comp}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "grains_new3 = grainmaps.remove_gid_from_grains(grains_new2, gid_to_remove=gid_to_remove)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# re-assign peaks to grains\n",
+    "utils.assign_peaks_to_grains(grains_new3, cf_strong, tol=peak_assign_tol)\n",
+    "utils.plot_grain_sinograms(grains_new3, cf_strong, min(len(grains_new3), 20))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# There is a potential problem that assign_peaks_to_grains assigned 0 peaks to grains, whereas these grains have acceptable completeness"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Save the new results to ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Note that the operations with deleting grains group and saving newly indexed grains have been commented out\n",
+    "### You may need to uncomment these lines in your own data processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# io.delete_group_from_h5(ds.grainsfile, phase_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # save grain data\n",
+    "\n",
+    "# ds.save_grains_to_disk(grains_new3, phase_name=phase_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # save new things to the dataset\n",
+    "\n",
+    "# ds.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ImageD11/forward_model/test_pars_conversion.ipynb
+++ b/ImageD11/forward_model/test_pars_conversion.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "95c6ec53-4040-4336-b157-a318778de4a2",
+   "metadata": {},
+   "source": [
+    "# Test pars_conversion.py\n",
+    "## 1) testing build_poni_from_ImageD11par\n",
+    "## 2) testing build_ImageD11par_from_poni\n",
+    "## 3) testing convert_ImageD11pars2p\n",
+    "## 4) testing convert_DCTpars2p\n",
+    "### Note that p is a parameter dictionary that is compatible with fwd-DCT parameter and bridges different conventions of parameters defined in different software packages\n",
+    "### Jan 2025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8957011c-726a-48f0-9e93-c589d6f6ee61",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['OMP_NUM_THREADS'] = '1'\n",
+    "os.environ['OPENBLAS_NUM_THREADS'] = '1'\n",
+    "os.environ['MKL_NUM_THREADS'] = '1'\n",
+    "\n",
+    "exec(open('/data/id11/nanoscope/install_ImageD11_from_git.py').read())\n",
+    "PYTHONPATH = setup_ImageD11_from_git( ) # ( os.path.join( os.environ['HOME'],'Code'), 'ImageD11_git' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cd40ba0-a55d-433d-891f-2850a5bcedc8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import ImageD11.parameters\n",
+    "from ImageD11.forward_model import pars_conversion\n",
+    "from ImageD11.forward_model import io"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e600f4f-7245-46a7-8832-f82d79d95167",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# set some inputs\n",
+    "par_file = 'si.par'\n",
+    "poni_path = 'test.poni'\n",
+    "detector = 'Eiger'\n",
+    "\n",
+    "lattice_par = [5.43094, 5.43094, 5.43094, 90, 90, 90] # Si cube\n",
+    "sgno = 227"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6c9586f-f497-4147-b1e3-b9237fc5b042",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# build a poni file from si.par, output 'test.poni'\n",
+    "pars_conversion.build_poni_from_ImageD11par(par_file, poni_path = poni_path, detector=detector)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab52a50f-de67-47f1-8aab-bae419ea8c74",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# build an ImageD11 par file from test.poni, output 'test.pars'\n",
+    "pars_conversion.build_ImageD11par_from_poni(lattice_par, sgno, poni_path, 'test.pars', detector = detector, verify=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcd2f2ff-c59a-4399-9776-19c86d8640e9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pars = ImageD11.parameters.read_par_file('test.pars')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58935698-8b63-4f5d-a64c-1e70fcb2a04e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pars.parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0b3a279-4d8f-4481-8d44-7453cf4d22b6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# convert ImageD11 .par to p\n",
+    "p = pars_conversion.convert_ImageD11pars2p(pars)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aec0d45e-8a13-4fcd-944c-4dfea7906652",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fd34c44-1a72-4653-ab81-af92db672fb6",
+   "metadata": {},
+   "source": [
+    "# Test conversion of matlab DCT parameters containing single phase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c18d944e-9dda-4493-81fa-5404c807ebfe",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "DCT_par_path = '/data/visitor/ma6298/id11/20241023/PROCESSED_DATA/OC4/OC4_bot_dct1/parameters.mat'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c93d40bd-cf10-48d0-a2be-587a7cdf1c8e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "parameters = io.read_matlab_file(DCT_par_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "590250f4-4952-4d85-8764-302e88f1943b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "p = pars_conversion.convert_DCTpars2p(DCT_par_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39fa9956-2be3-4403-a952-f223cba37e18",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed698a0a-110c-465e-9704-396a6777cf79",
+   "metadata": {},
+   "source": [
+    "# Test conversion of matlab DCT parameters containing multi-phase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1664cbd-1d33-42e5-83df-e0d4978886f3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "DCT_par_path = '/data/id11/3dxrd/ihma242/id11/DCT_Analysis/sample_dct_0003/parameters.mat'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59ce8d02-f000-40df-96e2-9b2e5f7e9fec",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "parameters = io.read_matlab_file(DCT_par_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04e5e3dd-2c90-4579-a7b8-d076edb4f4ed",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "p = pars_conversion.convert_DCTpars2p(DCT_par_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3f5917a-cf60-4519-a10a-e953774fd21e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "p"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The main changes are:
1) add forward_projector.py, take the experimentally reconstructed tensor map (from pbp_tensor_refined or tensor map in xx_grains.h5), define the beam profile and forward compute peaks and output them as cf_2d, cf_3d and cf_4d, which have the same formats as ImageD11 column file. The goal is to check the peaks difference and bridge with DCT, and hopefully helps to develop iterative forward and back projections;
2) add grainmaps.py, main features are i) merge regions when the voxels have similar orientations, 'similar' is defined by calculating the misorientation to the mean orientation of the region, therefore a min_misorientation is defined by the user to identify grain IDs (called 'labels'); ii) indexing_iterative for match peaks with already-indexed grains, then use the remaining peaks to index new grains and the obtained new grains will be merged with already-indexed grains to remove duplication
3) updates with forward_model etc, to add logging, improve computational speed etc and add testing notebooks