### PR TITLE
update on indexer_from_colfile_and_ucell function

### DIFF
--- a/ImageD11/indexing.py
+++ b/ImageD11/indexing.py
@@ -297,8 +297,8 @@ def indexer_from_colfile_and_ucell(colfile, ucell, **kwds):
     if w is None:
         try:
             w = colfile.parameters.get("wavelength")
-        except ValueError:
-            raise ValueError("Wavelength must be provided either in kwds or colfile.parameters")
+        except KeyError:
+            raise KeyError("Wavelength must be provided either in kwds or colfile.parameters")
 
     gv = np.array((colfile.gx, colfile.gy, colfile.gz), float)
     kwds.update({"unitcell": ucell, "wavelength": float(w), "gv": gv.T})

--- a/ImageD11/indexing.py
+++ b/ImageD11/indexing.py
@@ -295,8 +295,9 @@ def indexer_from_colfile_and_ucell(colfile, ucell, **kwds):
     # Try to get the wavelength from kwds, then colfile.parameters, otherwise raise an error
     w = kwds.get("wavelength")
     if w is None:
-        w = colfile.parameters.get("wavelength")
-        if w is None:
+        try:
+            w = colfile.parameters.get("wavelength")
+        except ValueError:
             raise ValueError("Wavelength must be provided either in kwds or colfile.parameters")
 
     gv = np.array((colfile.gx, colfile.gy, colfile.gz), float)

--- a/ImageD11/indexing.py
+++ b/ImageD11/indexing.py
@@ -293,9 +293,11 @@ def indexer_from_colfile_and_ucell(colfile, ucell, **kwds):
     ensuring a wavelength is provided."""
 
     # Try to get the wavelength from kwds, then colfile.parameters, otherwise raise an error
-    w = kwds.get("wavelength", float(colfile.parameters.get("wavelength")))
+    w = kwds.get("wavelength")
     if w is None:
-        raise ValueError("Wavelength must be provided either in kwds or colfile.parameters")
+        w = colfile.parameters.get("wavelength")
+        if w is None:
+            raise ValueError("Wavelength must be provided either in kwds or colfile.parameters")
 
     gv = np.array((colfile.gx, colfile.gy, colfile.gz), float)
     kwds.update({"unitcell": ucell, "wavelength": float(w), "gv": gv.T})


### PR DESCRIPTION
@jonwright, @jadball, @loichuder 
even if wavelength is present in kwds, Python evaluates float(colfile.parameters.get("wavelength")) before calling kwds.get().

This happens for some reason, and produces an error, so I had to rewrite the logic like this 

```
    w = kwds.get("wavelength")
    if w is None:
        w = colfile.parameters.get("wavelength")
        if w is None:
            raise ValueError("Wavelength must be provided either in kwds or colfile.parameters")
```

