### PR TITLE
4D segmentation for S3DXRD scans with Frelon

### DIFF
--- a/ImageD11/columnfile.py
+++ b/ImageD11/columnfile.py
@@ -74,6 +74,7 @@ INTS = [
     "Min_s",
     "Max_s",
     "spot3d_id",
+    "spot4d_id",
     "h", "k", "l",
     "onfirst", "onlast", "labels",
     "labels",

--- a/ImageD11/nbGui/S3DXRD/0_segment_frelon.ipynb
+++ b/ImageD11/nbGui/S3DXRD/0_segment_frelon.ipynb
@@ -1,0 +1,385 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8deabe5b",
+   "metadata": {},
+   "source": [
+    "# 3DXRD segmentation notebook for Frelon-ish detectors  \n",
+    "__Written by Haixing Fang, Jon Wright and James Ball__  \n",
+    "__Date: 21/02/2025__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6835a47c-a552-4d1d-b605-1867dd631b2a",
+   "metadata": {},
+   "source": [
+    "This notebook will help you to extract the locations of diffraction peaks on your detector images.  \n",
+    "It will also merge together your 2D spots (on a stack of detector images with different omega angles).  \n",
+    "We merge across omega because we often see the same spot twice on multiple detector images.  \n",
+    "The results are saved to the PROCESSED_DATA folder of the experiment, inside the sample and dataset folders that you select within this notebook\n",
+    "\n",
+    "__NOTE: These notebooks are under active development\n",
+    "They require the latest version of ImageD11 from Git to run.__  \n",
+    "If you don't have this set up yet, you can run the below cell.  \n",
+    "It will automatically download and install ImageD11 to your home directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2402147c-5513-4907-8ca9-76e3e252df0c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exec(open('/data/id11/nanoscope/install_ImageD11_from_git.py').read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a943975-9dc1-4b89-af44-4283350def66",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# this cell is tagged with 'parameters'\n",
+    "# to view the tag, select the cell, then find the settings gear icon (right or left sidebar) and look for Cell Tags\n",
+    "\n",
+    "PYTHONPATH = setup_ImageD11_from_git( ) # ( os.path.join( os.environ['HOME'],'Code'), 'ImageD11_git' )\n",
+    "\n",
+    "# Experts : update these files for your detector if you need to\n",
+    "\n",
+    "# give dx/dy as tuple instead of spline\n",
+    "# Since 2024: there is no good spline for a detector at ID11. You probably want to use an e2dx, e2dy file\n",
+    "# You can provide this as a simple string:\n",
+    "# splinefile = '/path/to/spline.spline'\n",
+    "# or as a tuple of strings for e2dx/e2dy files\n",
+    "splinefile = ('/data/id11/3dxrd/inhouse/Frelon36/frelon36_spline_20240604_dx.edf','/data/id11/3dxrd/inhouse/Frelon36/frelon36_spline_20240604_dy.edf')\n",
+    "bgfile = None\n",
+    "maskfile = '/data/id11/inhouse1/ewoks/detectors/files/Frelon2k_C36/mask.edf'\n",
+    "darkfile = \"/data/id11/inhouse1/ewoks/detectors/files/Frelon2k_C36/dark_20240416.edf\"\n",
+    "flatfile = \"/data/id11/inhouse1/ewoks/detectors/files/Frelon2k_C36/F36_Nov2023.edf\"\n",
+    "\n",
+    "detector = \"frelon3\"  # fixme - guess this from masterfile + scan\n",
+    "omegamotor = \"diffrz\"\n",
+    "dtymotor = \"diffty\"\n",
+    "\n",
+    "# Default segmentation options\n",
+    "options = {\n",
+    "    \"bgfile\":bgfile,\n",
+    "    \"maskfile\":maskfile,\n",
+    "    \"darkfile\":darkfile,\n",
+    "    \"flatfile\":flatfile,\n",
+    "    \"threshold\":70,\n",
+    "    \"smoothsigma\":1.0,\n",
+    "    \"bgc\":0.9,\n",
+    "    \"minpx\":3,\n",
+    "    \"m_offset_thresh\":100,\n",
+    "    \"m_ratio_thresh\":150,\n",
+    "}\n",
+    "\n",
+    "# EXPERTS: These can be provided as papermill parameters. Users, leave these as None for now...\n",
+    "dataroot = None\n",
+    "analysisroot = None\n",
+    "sample = None\n",
+    "dataset = None\n",
+    "scans = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b5c1db6-5a32-4294-abef-cfc2150d24de",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import fabio\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import ImageD11.sinograms.dataset\n",
+    "import ImageD11.sinograms.lima_segmenter\n",
+    "import ImageD11.sinograms.assemble_label\n",
+    "import ImageD11.sinograms.properties\n",
+    "from ImageD11.nbGui import nb_utils as utils\n",
+    "from ImageD11.nbGui import segmenter_gui\n",
+    "from ImageD11.frelon_peaksearch import worker, segment_dataset, guess_bg\n",
+    "\n",
+    "%matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5560db3e-720d-440e-954d-6dc313f6c460",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Set up the file paths. Edit this if you are not at ESRF or not using the latest data policy.\n",
+    "if dataroot is None:\n",
+    "    dataroot, analysisroot = segmenter_gui.guess_ESRF_paths() \n",
+    "\n",
+    "if len(dataroot)==0:\n",
+    "    print(\"Please fix in the dataroot and analysisroot folder names above!!\")\n",
+    "print('dataroot =',repr(dataroot))\n",
+    "print('analysisroot =',repr(analysisroot))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de77981e-c3bf-4a29-8944-95286831ac34",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# List the samples available:\n",
+    "segmenter_gui.printsamples(dataroot)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "187950bd-18b5-4bd4-80da-2a0c7a984b11",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: Decide which sample\n",
+    "if sample is None:\n",
+    "    sample = 'sample'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b2a72fa-ff6d-4e45-89b7-fa64adb62214",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# List the datasets for that sample:\n",
+    "segmenter_gui.printdatasets( dataroot, sample )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90e2aeb5-8893-4f0f-bf4f-de2c541a83df",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# USER: Decide which dataset\n",
+    "if dataset is None:\n",
+    "    dataset = \"dataset\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad077c4b-39cc-4b90-9637-33c32f12e364",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# create ImageD11 dataset object\n",
+    "\n",
+    "ds = ImageD11.sinograms.dataset.DataSet(dataroot=dataroot,\n",
+    "                                        analysisroot=analysisroot,\n",
+    "                                        sample=sample,\n",
+    "                                        dset=dataset,\n",
+    "                                        detector=detector,\n",
+    "                                        omegamotor=omegamotor,\n",
+    "                                        dtymotor=dtymotor)\n",
+    "ds.import_all(scans=scans)\n",
+    "if isinstance(splinefile, (tuple, list)) and len(splinefile) == 1:\n",
+    "    # we have (\"splinefile\", )\n",
+    "    ds.splinefile = splinefile[0]  # take the splinefile out of the tuple\n",
+    "elif isinstance(splinefile, (tuple, list)):\n",
+    "    # we have (e2dx, e2dy)\n",
+    "    ds.e2dxfile, ds.e2dyfile = splinefile\n",
+    "else:\n",
+    "    # we have \"splinefile\"\n",
+    "    ds.splinefile = splinefile\n",
+    "ds.maskfile = maskfile\n",
+    "ds.bgfile = bgfile\n",
+    "ds.darkfile = darkfile\n",
+    "ds.flatfile = flatfile\n",
+    "ds.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8822b96c-a33b-4bf2-9d95-e42d6d90e55b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# normally not needed:\n",
+    "\n",
+    "# bg = guess_bg( ds )\n",
+    "# plt.imshow(bg)\n",
+    "# fabio.edfimage.edfimage(bg).save('bg.edf')\n",
+    "# plt.colorbar()\n",
+    "# ds.bgfile = 'bg.edf'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68b22a6a-9325-40f4-af9d-945c0187ffae",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ui = segmenter_gui.FrelonSegmenterGui(ds, worker, segment_dataset, **options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eee00548-3a48-44d0-b4ad-e71b71de95ca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "options = ui.getopts()\n",
+    "print(options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87e56bf0-0cdd-4881-a975-a10d879d6054",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we run the segmenter on all our data\n",
+    "\n",
+    "cf_2d, cf_4d = segment_dataset(ds, options, scan_number=range(len(ds.scans)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fa07e53-93f4-4ce9-b0e5-1da5e6a5d511",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# display some peaks\n",
+    "f,a=plt.subplots(1,2,figsize=(12,6), layout='constrained')\n",
+    "a[0].plot(cf_4d.f_raw,cf_4d.s_raw,'.',ms=1)\n",
+    "a[0].set(xlabel='fast index', ylabel='slow index',aspect='equal', title='peaks on detector')\n",
+    "a[1].plot(cf_4d.omega,cf_4d.sum_intensity,'.',ms=1)\n",
+    "a[1].set(xlabel=r'$\\omega~(\\degree)$',ylabel='sum intensity',yscale='log',title='peaks vs omega')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f6fb626-a1bc-493c-b00b-d508311af0a4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# display some peaks\n",
+    "f,a=plt.subplots(1,2,figsize=(12,6), layout='constrained')\n",
+    "a[0].plot(cf_4d.f_raw,cf_4d.s_raw,'.',ms=1)\n",
+    "a[0].set(xlabel='fast index', ylabel='slow index',aspect='equal', title='peaks on detector')\n",
+    "a[1].plot(cf_4d.dty,cf_4d.sum_intensity,'.',ms=1)\n",
+    "a[1].set(xlabel=r'$dty$',ylabel='sum intensity',yscale='log',title='peaks vs dty')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9dafe51-b5a5-42d3-94d2-c0cdf4449bbd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(layout='constrained')\n",
+    "im, om_edges, dty_edges = ds.sinohist(np.log(cf_4d.sum_intensity),cf_4d.omega, cf_4d.dty, return_edges=True)\n",
+    "pcm = ax.pcolormesh(om_edges, dty_edges, im.T, norm='log')\n",
+    "ax.set(xlabel=r'$\\omega~(\\degree)$', ylabel='dty', title='Sinogram of all peaks')\n",
+    "cax = fig.colorbar(pcm, ax=ax, label='log(intensity)')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "197e8418-030b-4901-8e8f-9f8b1df7c017",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ImageD11.columnfile.colfile_to_hdf(cf_2d, ds.col2dfile)\n",
+    "ImageD11.columnfile.colfile_to_hdf(cf_4d, ds.col4dfile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7085183c-1991-49b3-af09-abe119542166",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds.save()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (main)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ImageD11/nbGui/S3DXRD/tomo_2_map.ipynb
+++ b/ImageD11/nbGui/S3DXRD/tomo_2_map.ipynb
@@ -473,6 +473,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ^ if you segmented frelon data for scanning, the above cell won't work, because we don't have a 2d peaks table\n",
+    "# you can instead try the below to prepare the peaks from the 2D peaks:\n",
+    "\n",
+    "# cf_2d = ds.get_cf_2d_from_disk()\n",
+    "# ds.update_colfile_pars(cf_2d, phase_str)\n",
+    "# for grain_label, gs in enumerate(tqdm(grainsinos)):\n",
+    "#     gs.prepare_peaks_from_2d(cf_2d, grain_label, hkltol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -838,7 +853,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (main)",
    "language": "python",
    "name": "python3"
   },
@@ -852,7 +867,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/ImageD11/nbGui/S3DXRD/tomo_2_map_minor_phase.ipynb
+++ b/ImageD11/nbGui/S3DXRD/tomo_2_map_minor_phase.ipynb
@@ -426,6 +426,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ^ if you segmented frelon data for scanning, the above cell won't work, because we don't have a 2d peaks table\n",
+    "# you can instead try the below to prepare the peaks from the 2D peaks:\n",
+    "\n",
+    "# cf_2d = ds.get_cf_2d_from_disk()\n",
+    "# ds.update_colfile_pars(cf_2d, phase_str)\n",
+    "# for grain_label, gs in enumerate(tqdm(grainsinos)):\n",
+    "#     gs.prepare_peaks_from_2d(cf_2d, grain_label, hkltol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -907,7 +922,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (main)",
    "language": "python",
    "name": "python3"
   },
@@ -921,7 +936,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/ImageD11/nbGui/TDXRD/0_segment_frelon.ipynb
+++ b/ImageD11/nbGui/TDXRD/0_segment_frelon.ipynb
@@ -62,8 +62,10 @@
     "# splinefile = '/path/to/spline.spline'\n",
     "# or as a tuple of strings for e2dx/e2dy files\n",
     "splinefile = ('/data/id11/3dxrd/inhouse/Frelon36/frelon36_spline_20240604_dx.edf','/data/id11/3dxrd/inhouse/Frelon36/frelon36_spline_20240604_dy.edf')\n",
-    "bgfile = None     #  'bg.edf'\n",
+    "bgfile = None\n",
     "maskfile = '/data/id11/inhouse1/ewoks/detectors/files/Frelon2k_C36/mask.edf'\n",
+    "darkfile = \"/data/id11/inhouse1/ewoks/detectors/files/Frelon2k_C36/dark_20240416.edf\"\n",
+    "flatfile = \"/data/id11/inhouse1/ewoks/detectors/files/Frelon2k_C36/F36_Nov2023.edf\"\n",
     "\n",
     "detector = \"frelon3\"  # fixme - guess this from masterfile + scan\n",
     "omegamotor = \"diffrz\"\n",
@@ -73,6 +75,8 @@
     "options = {\n",
     "    \"bgfile\":bgfile,\n",
     "    \"maskfile\":maskfile,\n",
+    "    \"darkfile\":darkfile,\n",
+    "    \"flatfile\":flatfile,\n",
     "    \"threshold\":70,\n",
     "    \"smoothsigma\":1.0,\n",
     "    \"bgc\":0.9,\n",
@@ -86,9 +90,7 @@
     "analysisroot = None\n",
     "sample = None\n",
     "dataset = None\n",
-    "scans = [\"1.1\",]\n",
-    "\n",
-    "dset_prefix = \"top_\"  # some common string in the names of the datasets if processing multiple scans"
+    "scans = [\"1.1\",]"
    ]
   },
   {
@@ -218,8 +220,9 @@
     "    ds.splinefile = splinefile\n",
     "ds.maskfile = maskfile\n",
     "ds.bgfile = bgfile\n",
-    "ds.save()\n",
-    "rawdata_path = ds.dataroot"
+    "ds.darkfile = darkfile\n",
+    "ds.flatfile = flatfile\n",
+    "ds.save()"
    ]
   },
   {

--- a/ImageD11/nbGui/segmenter_gui.py
+++ b/ImageD11/nbGui/segmenter_gui.py
@@ -175,6 +175,6 @@ class FrelonSegmenterGui:
 
     def getopts(self):
         opts = {name: self.options[name] for name in
-                ('bgfile', 'maskfile', 'threshold', 'smoothsigma', 'bgc', 'minpx', 'm_offset_thresh', 'm_ratio_thresh')}
+                ('bgfile', 'maskfile', 'flatfile', 'darkfile', 'threshold', 'smoothsigma', 'bgc', 'minpx', 'm_offset_thresh', 'm_ratio_thresh') if name in self.options.keys()}
         print("options = ", repr(opts))
         return opts

--- a/test/papermill_test_notebooks.py
+++ b/test/papermill_test_notebooks.py
@@ -13,18 +13,16 @@ This file will add its parent folder (../) to the system path so it can be impor
 So you get local ImageD11 and local papermill
 """
 import sys
+
 sys.path.insert(0, '../')
 
 import os
+
 os.environ['PYDEVD_DISABLE_FILE_VALIDATION'] = '1'  # ignore papermill debugger warnings
 
-import nbformat
-import pytest
 import papermill
-from nbconvert.preprocessors import ExecutePreprocessor
 
-
-from ImageD11.nbGui.nb_utils import notebook_exec_pmill, find_datasets_to_process, prepare_notebooks_for_datasets, notebook_exec_pmill
+from ImageD11.nbGui.nb_utils import find_datasets_to_process, prepare_notebooks_for_datasets, notebook_exec_pmill
 
 nb_base_prefix = os.path.join('..', 'ImageD11', 'nbGui')
 scan_nb_prefix = os.path.join(nb_base_prefix, 'S3DXRD')
@@ -49,8 +47,10 @@ def notebook_route(base_dir, notebook_paths, notebook_param_dicts, notebook_out_
     if not os.path.exists(notebook_out_dir):
         os.mkdir(notebook_out_dir)
     for notebook_in_path, notebook_param_dict in zip(notebook_paths, notebook_param_dicts):
-        notebook_out_path = os.path.join(notebook_out_dir, os.path.split(notebook_in_path)[1].replace('.ipynb', '_out.ipynb'))
+        notebook_out_path = os.path.join(notebook_out_dir,
+                                         os.path.split(notebook_in_path)[1].replace('.ipynb', '_out.ipynb'))
         notebook_exec_pmill(notebook_in_path, notebook_out_path, notebook_param_dict, rename_colliding=True)
+
 
 # there are two levels of testing
 # does the notebook work without errors?
@@ -68,69 +68,69 @@ def test_tomographic_route():
     dataset = 'S3DXRD_nt_moves_dty'
     samples_dict = {sample: [dataset]}
     # first, run the import_test_data.ipynb notebook to set up the file structure
-    notebook_route(tomo_dir, [os.path.join(scan_nb_prefix, 'import_test_data.ipynb')], [{'download_dir': tomo_dir, 'PYTHONPATH':PYTHONPATH}])
-    
+    notebook_route(tomo_dir, [os.path.join(scan_nb_prefix, 'import_test_data.ipynb')],
+                   [{'download_dir': tomo_dir, 'PYTHONPATH': PYTHONPATH}])
+
     nb_params = [
-       ('tomo_1_index.ipynb',
-        {'phase_str': 'Si',
-         'min_frames_per_peak': 0,
-         'cf_strong_frac': 0.9939,
-         'cf_strong_dsmax': 1.594,
-         'cf_strong_dstol': 0.005,
-         'rings_for_gen': [0, 1, 3],
-         'rings_for_scoring': [0, 1, 2, 3, 4],
-         'hkl_tols_seq': [0.01, 0.02, 0.03, 0.04],
-         'fracs': [0.9, 0.7],
-         'max_grains': 1000,
-         'peak_assign_tol': 0.025,
-        }
-       ),
-       ('tomo_2_map.ipynb',
-        {'phase_str': 'Si',
-         'cf_strong_frac': 0.9939,
-         'cf_strong_dstol': 0.005,
-         'is_half_scan': False,
-         'halfmask_radius': 25,
-         'peak_assign_tol': 0.25,
-         'draw_mask_interactive': False,
-         'manual_threshold': None,
-         'hkltol': 0.25,
-         'correct_sinos_with_ring_current': False,
-         'first_tmap_cutoff_level': 0.4,
-         'niter': 500,
-         'second_tmap_cutoff_level': 0.05
-        }
-       ),
-       ('tomo_3_refinement.ipynb',
-        {'phase_str': 'Si',
-         'default_npks': 20,
-         'default_nuniq': 20,
-         'hkl_tol_origins': 0.05,
-         'hkl_tol_refine': 0.1,
-         'hkl_tol_refine_merged': 0.05,
-         'ds_tol': 0.004,
-         'ifrac': 7e-3,
-         'rings_to_refine': None,
-         'use_cluster': False
-        }
-       ),
-       ('4_visualise.ipynb',
-        {'phase_str': 'Si',
-         'min_unique': 400,
-        }
-       )
+        ('tomo_1_index.ipynb',
+         {'phase_str': 'Si',
+          'min_frames_per_peak': 0,
+          'cf_strong_frac': 0.9939,
+          'cf_strong_dsmax': 1.594,
+          'cf_strong_dstol': 0.005,
+          'rings_for_gen': [0, 1, 3],
+          'rings_for_scoring': [0, 1, 2, 3, 4],
+          'hkl_tols_seq': [0.01, 0.02, 0.03, 0.04],
+          'fracs': [0.9, 0.7],
+          'max_grains': 1000,
+          'peak_assign_tol': 0.025,
+          }
+         ),
+        ('tomo_2_map.ipynb',
+         {'phase_str': 'Si',
+          'cf_strong_frac': 0.9939,
+          'cf_strong_dstol': 0.005,
+          'is_half_scan': False,
+          'halfmask_radius': 25,
+          'peak_assign_tol': 0.25,
+          'draw_mask_interactive': False,
+          'manual_threshold': None,
+          'hkltol': 0.25,
+          'correct_sinos_with_ring_current': False,
+          'first_tmap_cutoff_level': 0.4,
+          'niter': 500,
+          'second_tmap_cutoff_level': 0.05
+          }
+         ),
+        ('tomo_3_refinement.ipynb',
+         {'phase_str': 'Si',
+          'default_npks': 20,
+          'default_nuniq': 20,
+          'hkl_tol_origins': 0.05,
+          'hkl_tol_refine': 0.1,
+          'hkl_tol_refine_merged': 0.05,
+          'ds_tol': 0.004,
+          'ifrac': 7e-3,
+          'rings_to_refine': None,
+          'use_cluster': False
+          }
+         ),
+        ('4_visualise.ipynb',
+         {'phase_str': 'Si',
+          'min_unique': 400,
+          }
+         )
     ]
-    
+
     notebooks_to_execute = prepare_notebooks_for_datasets(samples_dict,
                                                           nb_params,
                                                           dataroot,
                                                           analysisroot,
                                                           PYTHONPATH=PYTHONPATH,
                                                           notebook_parent_dir=scan_nb_prefix)
-    
+
     for nb_path in notebooks_to_execute:
         notebook_exec_pmill(nb_path, nb_path, None)
-    
 
 
 # test the full point-by-point route from start to finish
@@ -144,59 +144,60 @@ def test_pbp_route():
     dataset = 'S3DXRD_nt_moves_dty'
     samples_dict = {sample: [dataset]}
     # first, run the import_test_data.ipynb notebook to set up the file structure
-    notebook_route(tomo_dir, [os.path.join(scan_nb_prefix, 'import_test_data.ipynb')], [{'download_dir': tomo_dir, 'PYTHONPATH':PYTHONPATH}])
-    
+    notebook_route(tomo_dir, [os.path.join(scan_nb_prefix, 'import_test_data.ipynb')],
+                   [{'download_dir': tomo_dir, 'PYTHONPATH': PYTHONPATH}])
+
     nb_params = [
-       ('pbp_1_indexing.ipynb',
-        {'phase_str': 'Si',
-         'minpkint': 0,
-         'hkl_tol':  0.025,
-         'fpks': 0.9,
-         'ds_tol': 0.004,
-         'etacut': 0.1,
-         'ifrac': 5e-3,
-         'y0': 24.24,
-         'symmetry': "cubic",
-         'foridx': [0, 1, 3, 5, 7],
-         'forgen': [1, 5, 7],
-         'uniqcut': 0.85,
-         'use_cluster': False
-        }
-       ),
-       ('pbp_2_visualise.ipynb',
-        {'phase_str': 'Si',
-         'min_unique': 20
-        }
-       ),
-       ('pbp_3_refinement.ipynb',
-        {'phase_str': 'Si',
-         'min_unique': 20,
-         'manual_threshold': None,
-         'y0': 24.24,
-         'hkl_tol_origins': 0.05,
-         'hkl_tol_refine': 0.1,
-         'hkl_tol_refine_merged': 0.05,
-         'ds_tol': 0.004,
-         'ifrac': 7e-3,
-         'rings_to_refine': None,
-         'set_mask_from_input': False,
-         'use_cluster': False
-        }
-       ),
-       ('4_visualise.ipynb',
-        {'phase_str': 'Si',
-         'min_unique': 400,
-        }
-       )
+        ('pbp_1_indexing.ipynb',
+         {'phase_str': 'Si',
+          'minpkint': 0,
+          'hkl_tol': 0.025,
+          'fpks': 0.9,
+          'ds_tol': 0.004,
+          'etacut': 0.1,
+          'ifrac': 5e-3,
+          'y0': 24.24,
+          'symmetry': "cubic",
+          'foridx': [0, 1, 3, 5, 7],
+          'forgen': [1, 5, 7],
+          'uniqcut': 0.85,
+          'use_cluster': False
+          }
+         ),
+        ('pbp_2_visualise.ipynb',
+         {'phase_str': 'Si',
+          'min_unique': 20
+          }
+         ),
+        ('pbp_3_refinement.ipynb',
+         {'phase_str': 'Si',
+          'min_unique': 20,
+          'manual_threshold': None,
+          'y0': 24.24,
+          'hkl_tol_origins': 0.05,
+          'hkl_tol_refine': 0.1,
+          'hkl_tol_refine_merged': 0.05,
+          'ds_tol': 0.004,
+          'ifrac': 7e-3,
+          'rings_to_refine': None,
+          'set_mask_from_input': False,
+          'use_cluster': False
+          }
+         ),
+        ('4_visualise.ipynb',
+         {'phase_str': 'Si',
+          'min_unique': 400,
+          }
+         )
     ]
-    
+
     notebooks_to_execute = prepare_notebooks_for_datasets(samples_dict,
                                                           nb_params,
                                                           dataroot,
                                                           analysisroot,
                                                           PYTHONPATH=PYTHONPATH,
                                                           notebook_parent_dir=scan_nb_prefix)
-    
+
     for nb_path in notebooks_to_execute:
         notebook_exec_pmill(nb_path, nb_path, None)
 
@@ -204,7 +205,7 @@ def test_pbp_route():
 def test_FeAu_JADB_tomo():
     # where is the data?
     dataroot = '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/RAW_DATA'
-    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/PROCESSED_DATA/20250221_JADB/tomo_route'
+    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/PROCESSED_DATA/20250228_JADB/tomo_route'
     PYTHONPATH = sys.path[0]
     # find layers to process
     sample = 'FeAu_0p5_tR_nscope'
@@ -213,7 +214,7 @@ def test_FeAu_JADB_tomo():
     skips_dict = {sample: []}
     sample_list = [sample]
     samples_dict = find_datasets_to_process(dataroot, skips_dict, dset_prefix, sample_list)
-    
+
     nb_params = [
         ('0_segment_and_label.ipynb',
          {'maskfile': '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/pars/mask_with_gaps_E-08-0173.edf',
@@ -222,9 +223,9 @@ def test_FeAu_JADB_tomo():
           'detector': 'eiger',
           'omegamotor': 'rot_center',
           'dtymotor': 'dty',
-          'options': { 'cut' : 1, 'pixels_in_spot' : 3, 'howmany' : 100000 },
-         },
-        ),
+          'options': {'cut': 1, 'pixels_in_spot': 3, 'howmany': 100000},
+          },
+         ),
         ('tomo_1_index.ipynb',
          {'par_file': '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/pars/pars.json',
           'phase_str': 'Fe',
@@ -238,8 +239,8 @@ def test_FeAu_JADB_tomo():
           'fracs': [0.9, 0.7],
           'max_grains': 1000,
           'peak_assign_tol': 0.05,
-         }
-        ),
+          }
+         ),
         ('tomo_1_index_minor_phase.ipynb',
          {'major_phase_strs': ['Fe'],
           'minor_phase_str': 'Au',
@@ -255,8 +256,8 @@ def test_FeAu_JADB_tomo():
           'fracs': [0.9, 0.7],
           'max_grains': 1000,
           'peak_assign_tol': 0.05,
-         }
-        ),
+          }
+         ),
         ('tomo_2_map.ipynb',
          {'phase_str': 'Fe',
           'cf_strong_frac': 0.9975,
@@ -271,8 +272,8 @@ def test_FeAu_JADB_tomo():
           'first_tmap_cutoff_level': 0.4,
           'niter': 500,
           'second_tmap_cutoff_level': 0.05,
-         }
-        ),
+          }
+         ),
         ('tomo_2_map_minor_phase.ipynb',
          {'major_phase_strs': ['Fe'],
           'minor_phase_str': 'Au',
@@ -289,8 +290,8 @@ def test_FeAu_JADB_tomo():
           'niter': 500,
           'second_tmap_cutoff_level': 0.5,
           'grain_too_many_px': 10,
-         }
-        ),
+          }
+         ),
         ('tomo_3_refinement.ipynb',
          {'phase_str': 'Fe',
           'default_npks': 20,
@@ -302,8 +303,8 @@ def test_FeAu_JADB_tomo():
           'ifrac': 7e-3,
           'rings_to_refine': None,
           'use_cluster': False,
-         }
-        ),
+          }
+         ),
         ('tomo_3_refinement.ipynb',
          {'phase_str': 'Au',
           'default_npks': 20,
@@ -315,23 +316,23 @@ def test_FeAu_JADB_tomo():
           'ifrac': 1e-3,
           'rings_to_refine': [0, 2, 3, 4, 5, 6, 7, 8, 10, 12, 13],
           'use_cluster': False,
-         }
-        ),
+          }
+         ),
         ('4_visualise.ipynb',
          {'phase_str': 'Fe',
           'min_unique': 250,
-         }
-        ),
+          }
+         ),
         ('4_visualise.ipynb',
          {'phase_str': 'Au',
           'min_unique': 0,
-         }
-        ),
+          }
+         ),
         ('5_combine_phases.ipynb',
          {'phase_strs': ['Fe', 'Au'],
           'combine_refined': True,
-         }
-        ),
+          }
+         ),
     ]
 
     notebooks_to_execute = prepare_notebooks_for_datasets(samples_dict,
@@ -340,21 +341,21 @@ def test_FeAu_JADB_tomo():
                                                           analysisroot,
                                                           PYTHONPATH=PYTHONPATH,
                                                           notebook_parent_dir=scan_nb_prefix)
-    
+
     for nb_path in notebooks_to_execute:
         notebook_exec_pmill(nb_path, nb_path, None)
-        
+
     # now run the final notebook to merge slices together
     # work out the path to the first dataset
     dset_path = os.path.join(analysisroot, sample, f'{sample}_{first_dataset}', f'{sample}_{first_dataset}_dataset.h5')
     nb_param = {'PYTHONPATH': PYTHONPATH,  # 7_stack_layers.ipynb
-                 'dset_path': dset_path,
-                 'dset_prefix': dset_prefix,
-                 'stack_combined': True,
-                 'stack_refined': True,
-                 'zstep': 50.0,
+                'dset_path': dset_path,
+                'dset_prefix': dset_prefix,
+                'stack_combined': True,
+                'stack_refined': True,
+                'zstep': 50.0,
                 }
-    
+
     nb_path = os.path.join(scan_nb_prefix, '7_stack_layers.ipynb')
     notebook_route(analysisroot, [nb_path], [nb_param], skip_dir_check=True)
 
@@ -362,7 +363,7 @@ def test_FeAu_JADB_tomo():
 def test_FeAu_JADB_pbp():
     # where is the data?
     dataroot = '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/RAW_DATA'
-    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/PROCESSED_DATA/20250221_JADB/pbp_route'
+    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/PROCESSED_DATA/20250228_JADB/pbp_route'
     PYTHONPATH = sys.path[0]
     # find layers to process
     sample = 'FeAu_0p5_tR_nscope'
@@ -371,8 +372,7 @@ def test_FeAu_JADB_pbp():
     skips_dict = {sample: []}
     sample_list = [sample]
     samples_dict = find_datasets_to_process(dataroot, skips_dict, dset_prefix, sample_list)
-    
-    
+
     nb_params = [
         ('0_segment_and_label.ipynb',
          {'maskfile': '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/pars/mask_with_gaps_E-08-0173.edf',
@@ -381,9 +381,9 @@ def test_FeAu_JADB_pbp():
           'detector': 'eiger',
           'omegamotor': 'rot_center',
           'dtymotor': 'dty',
-          'options': { 'cut' : 1, 'pixels_in_spot' : 3, 'howmany' : 100000 },
-         },
-        ),
+          'options': {'cut': 1, 'pixels_in_spot': 3, 'howmany': 100000},
+          },
+         ),
         ('pbp_1_indexing.ipynb',
          {'par_file': '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/pars/pars.json',
           'phase_str': 'Fe',
@@ -395,12 +395,12 @@ def test_FeAu_JADB_pbp():
           'ifrac': 2e-3,
           'y0': -16.0,
           'symmetry': 'cubic',
-          'foridx': [0, 1, 3,  5, 7],
+          'foridx': [0, 1, 3, 5, 7],
           'forgen': [1, 5, 7],
           'uniqcut': 0.85,
           'use_cluster': False,
-         }
-        ),
+          }
+         ),
         ('pbp_1_indexing.ipynb',
          {'par_file': '/data/id11/inhouse2/test_data_3DXRD/S3DXRD/FeAu/pars/pars.json',
           'phase_str': 'Au',
@@ -412,22 +412,22 @@ def test_FeAu_JADB_pbp():
           'ifrac': 2e-3,
           'y0': -16.0,
           'symmetry': 'cubic',
-          'foridx': [0, 1, 3,  5, 7],
-          'forgen': [1, 5, 7],
+          'foridx': [0, 3, 5, 7],
+          'forgen': [0, 5, 7],
           'uniqcut': 0.85,
           'use_cluster': False,
-         }
-        ),
+          }
+         ),
         ('pbp_2_visualise.ipynb',
          {'phase_str': 'Fe',
           'min_unique': 20,
-         }
-        ),
+          }
+         ),
         ('pbp_2_visualise.ipynb',
          {'phase_str': 'Au',
           'min_unique': 10,
-         }
-        ),
+          }
+         ),
         ('pbp_3_refinement.ipynb',
          {'phase_str': 'Fe',
           'min_unique': 20,
@@ -441,8 +441,8 @@ def test_FeAu_JADB_pbp():
           'rings_to_refine': None,
           'set_mask_from_input': True,
           'use_cluster': False,
-         }
-        ),
+          }
+         ),
         ('pbp_3_refinement.ipynb',
          {'phase_str': 'Au',
           'min_unique': 10,
@@ -456,46 +456,46 @@ def test_FeAu_JADB_pbp():
           'rings_to_refine': None,
           'set_mask_from_input': True,
           'use_cluster': False,
-         }
-        ),
+          }
+         ),
         ('4_visualise.ipynb',
          {'phase_str': 'Fe',
           'min_unique': 250,
-         }
-        ),
+          }
+         ),
         ('4_visualise.ipynb',
          {'phase_str': 'Au',
           'min_unique': 100,
-         }
-        ),
+          }
+         ),
         ('5_combine_phases.ipynb',
          {'phase_strs': ['Fe', 'Au'],
           'combine_refined': True,
-         }
-        ),
+          }
+         ),
     ]
-    
+
     notebooks_to_execute = prepare_notebooks_for_datasets(samples_dict,
                                                           nb_params,
                                                           dataroot,
                                                           analysisroot,
                                                           PYTHONPATH=PYTHONPATH,
                                                           notebook_parent_dir=scan_nb_prefix)
-    
+
     for nb_path in notebooks_to_execute:
         notebook_exec_pmill(nb_path, nb_path, None)
-        
+
     # now run the final notebook to merge slices together
     # work out the path to the first dataset
     dset_path = os.path.join(analysisroot, sample, f'{sample}_{first_dataset}', f'{sample}_{first_dataset}_dataset.h5')
     nb_param = {'PYTHONPATH': PYTHONPATH,  # 7_stack_layers.ipynb
-                 'dset_path': dset_path,
-                 'dset_prefix': dset_prefix,
-                 'stack_combined': True,
-                 'stack_refined': True,
-                 'zstep': 50.0,
+                'dset_path': dset_path,
+                'dset_prefix': dset_prefix,
+                'stack_combined': True,
+                'stack_refined': True,
+                'zstep': 50.0,
                 }
-    
+
     nb_path = os.path.join(scan_nb_prefix, '7_stack_layers.ipynb')
     notebook_route(analysisroot, [nb_path], [nb_param], skip_dir_check=True)
 
@@ -503,7 +503,7 @@ def test_FeAu_JADB_pbp():
 def test_FeAu_JADB_bb():
     # where is the data?
     dataroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/RAW_DATA/'
-    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/PROCESSED_DATA/20250221_JADB/default'
+    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/PROCESSED_DATA/20250228_JADB/default'
     PYTHONPATH = sys.path[0]
     # find layers to process
     sample = 'FeAu_0p5_tR'
@@ -512,73 +512,80 @@ def test_FeAu_JADB_bb():
     skips_dict = {sample: []}
     sample_list = [sample]
     samples_dict = find_datasets_to_process(dataroot, skips_dict, dset_prefix, sample_list)
-    
+
     # some extra stuff for notebook 0
     bgfile = None
+    darkfile = None
+    flatfile = None
     maskfile = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/mask.edf'
-    
+
     nb_params = [
         ('0_segment_frelon.ipynb',
          {
-         'splinefile': ['/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dx.edf','/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dy.edf'],
-         'bgfile': bgfile,
-         'maskfile': maskfile,
-         'detector': 'frelon3',
-         'omegamotor': 'diffrz',
-         'dtymotor': 'diffty',
-         'options': {
-            "bgfile":bgfile,
-            "maskfile":maskfile,
-            "threshold":70,
-            "smoothsigma":1.0,
-            "bgc":0.9,
-            "minpx":3,
-            "m_offset_thresh":100,
-            "m_ratio_thresh":150,
-          }
+             'splinefile': ['/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dx.edf',
+                            '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dy.edf'],
+             'bgfile': bgfile,
+             'maskfile': maskfile,
+             'darkfile': darkfile,
+             'flatfile': flatfile,
+             'detector': 'frelon3',
+             'omegamotor': 'diffrz',
+             'dtymotor': 'diffty',
+             'options': {
+                 "bgfile": bgfile,
+                 "maskfile": maskfile,
+                 "darkfile": darkfile,
+                 "flatfile": flatfile,
+                 "threshold": 70,
+                 "smoothsigma": 1.0,
+                 "bgc": 0.9,
+                 "minpx": 3,
+                 "m_offset_thresh": 100,
+                 "m_ratio_thresh": 150,
+             }
          }  # end this dict
-        ),  # end this tuple for this notebook
+         ),  # end this tuple for this notebook
         ('1_index_default.ipynb',
          {
-         'phase_str': 'Fe',
-         'parfile': '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/pars_tdxrd.json',
-         'cf_strong_frac': 0.9837,
-         'cf_strong_dsmax': 1.01,
-         'cf_strong_dstol': 0.01,
-         'rings_for_gen': [0, 1],
-         'rings_for_scoring': [0, 1, 2, 3],
-         'hkl_tols_seq': [0.01, 0.02, 0.03, 0.04],
-         'fracs': [0.9, 9.75],
-         'max_grains': 1000,
-         'makemap_hkl_tol_seq': [0.05, 0.025, 0.01],
-         'symmetry': 'cubic',
-         'absolute_minpks': 120,
-         'dset_prefix': "ff"
-        }
-        )
+             'phase_str': 'Fe',
+             'parfile': '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/pars_tdxrd.json',
+             'cf_strong_frac': 0.9837,
+             'cf_strong_dsmax': 1.01,
+             'cf_strong_dstol': 0.01,
+             'rings_for_gen': [0, 1],
+             'rings_for_scoring': [0, 1, 2, 3],
+             'hkl_tols_seq': [0.01, 0.02, 0.03, 0.04],
+             'fracs': [0.9, 9.75],
+             'max_grains': 1000,
+             'makemap_hkl_tol_seq': [0.05, 0.025, 0.01],
+             'symmetry': 'cubic',
+             'absolute_minpks': 120,
+             'dset_prefix': "ff"
+         }
+         )
     ]
-    
+
     notebooks_to_execute = prepare_notebooks_for_datasets(samples_dict,
-                                                           nb_params,
-                                                           dataroot,
-                                                           analysisroot,
-                                                           PYTHONPATH=PYTHONPATH,
-                                                           notebook_parent_dir=bb_nb_prefix)
-    
+                                                          nb_params,
+                                                          dataroot,
+                                                          analysisroot,
+                                                          PYTHONPATH=PYTHONPATH,
+                                                          notebook_parent_dir=bb_nb_prefix)
+
     for nb_path in notebooks_to_execute:
         notebook_exec_pmill(nb_path, nb_path, None)
-    
+
     # now run the final notebook to merge slices together
     # work out the path to the first dataset
     dset_path = os.path.join(analysisroot, sample, f'{sample}_{first_dataset}', f'{sample}_{first_dataset}_dataset.h5')
-    nb_param = { # 3_merge_slices.ipynb
-         'PYTHONPATH': PYTHONPATH,
-         'dset_path': dset_path,
-         'phase_str': 'Fe',
-         'z_translation_motor': 'samtz',
-         'dset_prefix': "ff"
-        }
-    
+    nb_param = {  # 3_merge_slices.ipynb
+        'PYTHONPATH': PYTHONPATH,
+        'dset_path': dset_path,
+        'phase_str': 'Fe',
+        'z_translation_motor': 'samtz',
+        'dset_prefix': "ff"
+    }
+
     nb_path = os.path.join(bb_nb_prefix, '3_merge_slices.ipynb')
     notebook_route(analysisroot, [nb_path], [nb_param], skip_dir_check=True)
 
@@ -586,7 +593,7 @@ def test_FeAu_JADB_bb():
 def test_FeAu_JADB_bb_grid():
     # where is the data?
     dataroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/RAW_DATA/'
-    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/PROCESSED_DATA/20250221_JADB/grid'
+    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/PROCESSED_DATA/20250228_JADB/grid'
     PYTHONPATH = sys.path[0]
     # find layers to process
     sample = 'FeAu_0p5_tR'
@@ -595,90 +602,98 @@ def test_FeAu_JADB_bb_grid():
     skips_dict = {sample: []}
     sample_list = [sample]
     samples_dict = find_datasets_to_process(dataroot, skips_dict, dset_prefix, sample_list)
-    
+
     # some extra stuff for notebook 0
     bgfile = None
+    darkfile = None
+    flatfile = None
     maskfile = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/mask.edf'
-    
+
     nb_params = [
         ('0_segment_frelon.ipynb',
          {
-         'splinefile': ['/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dx.edf','/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dy.edf'],
-         'bgfile': bgfile,
-         'maskfile': maskfile,
-         'detector': 'frelon3',
-         'omegamotor': 'diffrz',
-         'dtymotor': 'diffty',
-         'options': {
-            "bgfile":bgfile,
-            "maskfile":maskfile,
-            "threshold":70,
-            "smoothsigma":1.0,
-            "bgc":0.9,
-            "minpx":3,
-            "m_offset_thresh":100,
-            "m_ratio_thresh":150,
-          }
+             'splinefile': ['/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dx.edf',
+                            '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dy.edf'],
+             'bgfile': bgfile,
+             'maskfile': maskfile,
+             'darkfile': darkfile,
+             'flatfile': flatfile,
+             'detector': 'frelon3',
+             'omegamotor': 'diffrz',
+             'dtymotor': 'diffty',
+             'options': {
+                 "bgfile": bgfile,
+                 "maskfile": maskfile,
+                 "darkfile": darkfile,
+                 "flatfile": flatfile,
+                 "threshold": 70,
+                 "smoothsigma": 1.0,
+                 "bgc": 0.9,
+                 "minpx": 3,
+                 "m_offset_thresh": 100,
+                 "m_ratio_thresh": 150,
+             }
          }  # end this dict
-        ),
+         ),  # end this tuple for this notebook
         ('1_index_grid.ipynb',
          {
-         'phase_str': 'Fe',
-         'parfile': '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/pars_tdxrd.json',
-         'cf_strong_frac': 0.9837,
-         'cf_strong_dsmax': 1.01,
-         'cf_strong_dstol': 0.01,
-         'rings_to_use': [0, 1, 3],
-         'symmetry': 'cubic',
-         'makemap_tol_seq': [0.02, 0.015, 0.01],
-         'gridpars': {
-                'DSTOL' : 0.004,
-                'RING1'  : [1,0,],
-                'RING2' : [0,],
-                'NUL' : True,
-                'FITPOS' : True,
-                'tolangle' : 0.50,
-                'toldist' : 100.,
-                'NTHREAD' : 1 ,
-         },
-         'grid_xlim': 600,
-         'grid_ylim': 600,
-         'grid_zlim': 200,
-         'grid_step': 100,
-         'frac': 0.85,
-         'absolute_minpks': 56,
-        }
-        )
+             'phase_str': 'Fe',
+             'parfile': '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/pars_tdxrd.json',
+             'cf_strong_frac': 0.9837,
+             'cf_strong_dsmax': 1.01,
+             'cf_strong_dstol': 0.01,
+             'rings_to_use': [0, 1, 3],
+             'symmetry': 'cubic',
+             'makemap_tol_seq': [0.02, 0.015, 0.01],
+             'gridpars': {
+                 'DSTOL': 0.004,
+                 'RING1': [1, 0, ],
+                 'RING2': [0, ],
+                 'NUL': True,
+                 'FITPOS': True,
+                 'tolangle': 0.50,
+                 'toldist': 100.,
+                 'NTHREAD': 1,
+             },
+             'grid_xlim': 600,
+             'grid_ylim': 600,
+             'grid_zlim': 200,
+             'grid_step': 100,
+             'frac': 0.85,
+             'absolute_minpks': 56,
+         }
+         )
     ]
-    
+
     notebooks_to_execute = prepare_notebooks_for_datasets(samples_dict,
-                                                           nb_params,
-                                                           dataroot,
-                                                           analysisroot,
-                                                           PYTHONPATH=PYTHONPATH,
-                                                           notebook_parent_dir=bb_nb_prefix)
-    
+                                                          nb_params,
+                                                          dataroot,
+                                                          analysisroot,
+                                                          PYTHONPATH=PYTHONPATH,
+                                                          notebook_parent_dir=bb_nb_prefix)
+
     for nb_path in notebooks_to_execute:
         notebook_exec_pmill(nb_path, nb_path, None)
-    
+
     # now run the final notebook to merge slices together
     # work out the path to the first dataset
     dset_path = os.path.join(analysisroot, sample, f'{sample}_{first_dataset}', f'{sample}_{first_dataset}_dataset.h5')
-    nb_param = { # 3_merge_slices.ipynb
-         'PYTHONPATH': PYTHONPATH,
-         'dset_path': dset_path,
-         'phase_str': 'Fe',
-         'z_translation_motor': 'samtz',
-         'dset_prefix': "ff"
-        }
-    
+    nb_param = {  # 3_merge_slices.ipynb
+        'PYTHONPATH': PYTHONPATH,
+        'dset_path': dset_path,
+        'phase_str': 'Fe',
+        'z_translation_motor': 'samtz',
+        'dset_prefix': "ff"
+    }
+
     nb_path = os.path.join(bb_nb_prefix, '3_merge_slices.ipynb')
     notebook_route(analysisroot, [nb_path], [nb_param], skip_dir_check=True)
+
 
 def test_FeAu_JADB_bb_friedel():
     # where is the data?
     dataroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/RAW_DATA/'
-    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/PROCESSED_DATA/20250221_JADB/friedel'
+    analysisroot = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/PROCESSED_DATA/20250228_JADB/friedel'
     PYTHONPATH = sys.path[0]
     # find layers to process
     sample = 'FeAu_0p5_tR'
@@ -687,94 +702,101 @@ def test_FeAu_JADB_bb_friedel():
     skips_dict = {sample: []}
     sample_list = [sample]
     samples_dict = find_datasets_to_process(dataroot, skips_dict, dset_prefix, sample_list)
-    
+
     # some extra stuff for notebook 0
     bgfile = None
+    darkfile = None
+    flatfile = None
     maskfile = '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/mask.edf'
-    
+
     nb_params = [
-        ('0_segment_frelon.ipynb',
+         ('0_segment_frelon.ipynb',
          {
-         'splinefile': ['/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dx.edf','/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dy.edf'],
-         'bgfile': bgfile,
-         'maskfile': maskfile,
-         'detector': 'frelon3',
-         'omegamotor': 'diffrz',
-         'dtymotor': 'diffty',
-         'options': {
-            "bgfile":bgfile,
-            "maskfile":maskfile,
-            "threshold":70,
-            "smoothsigma":1.0,
-            "bgc":0.9,
-            "minpx":3,
-            "m_offset_thresh":100,
-            "m_ratio_thresh":150,
-          }
+             'splinefile': ['/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dx.edf',
+                            '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/frelon36_spline_20240604_dy.edf'],
+             'bgfile': bgfile,
+             'maskfile': maskfile,
+             'darkfile': darkfile,
+             'flatfile': flatfile,
+             'detector': 'frelon3',
+             'omegamotor': 'diffrz',
+             'dtymotor': 'diffty',
+             'options': {
+                 "bgfile": bgfile,
+                 "maskfile": maskfile,
+                 "darkfile": darkfile,
+                 "flatfile": flatfile,
+                 "threshold": 70,
+                 "smoothsigma": 1.0,
+                 "bgc": 0.9,
+                 "minpx": 3,
+                 "m_offset_thresh": 100,
+                 "m_ratio_thresh": 150,
+             }
          }  # end this dict
-        ),
+         ),  # end this tuple for this notebook
         ('1_index_friedel.ipynb',
          {'phase_str': 'Fe',
-         'parfile': '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/pars_tdxrd.json',
-         'cf_strong_frac': 0.991,
-         'cf_strong_dsmax': 1.01,
-         'cf_strong_dstol': 0.01,
-         'womega': 1.0,
-         'weta': 1.0,
-         'wtth': 1.5,
-         'wI': 0.5,
-         'indexer_ds_tol': 0.003,
-         'rings_for_gen': [1, 3],
-         'rings_for_scoring': [0, 1, 2, 3],
-         'hkl_tols_seq': [0.01, 0.02],
-         'fracs': [0.9, 0.6],
-         'max_grains': 1000,
-         'symmetry': 'cubic',
-         'gridpars': {
-                'DSTOL' : 0.004,
-                'NUL' : True,
-                'FITPOS' : True,
-                'tolangle' : 0.25,
-                'toldist' : 100.,
-                'NTHREAD' : 1 ,
-                'NPKS': 25
-         },
-         'absolute_minpks': 25,
-        },
-        )
+          'parfile': '/data/id11/inhouse2/test_data_3DXRD/TDXRD/FeAu/pars/pars_tdxrd.json',
+          'cf_strong_frac': 0.991,
+          'cf_strong_dsmax': 1.01,
+          'cf_strong_dstol': 0.01,
+          'womega': 1.0,
+          'weta': 1.0,
+          'wtth': 1.5,
+          'wI': 0.5,
+          'indexer_ds_tol': 0.003,
+          'rings_for_gen': [1, 3],
+          'rings_for_scoring': [0, 1, 2, 3],
+          'hkl_tols_seq': [0.01, 0.02],
+          'fracs': [0.9, 0.6],
+          'max_grains': 1000,
+          'symmetry': 'cubic',
+          'gridpars': {
+              'DSTOL': 0.004,
+              'NUL': True,
+              'FITPOS': True,
+              'tolangle': 0.25,
+              'toldist': 100.,
+              'NTHREAD': 1,
+              'NPKS': 25
+          },
+          'absolute_minpks': 25,
+          },
+         )
     ]
-    
+
     notebooks_to_execute = prepare_notebooks_for_datasets(samples_dict,
-                                                           nb_params,
-                                                           dataroot,
-                                                           analysisroot,
-                                                           PYTHONPATH=PYTHONPATH,
-                                                           notebook_parent_dir=bb_nb_prefix)
-    
+                                                          nb_params,
+                                                          dataroot,
+                                                          analysisroot,
+                                                          PYTHONPATH=PYTHONPATH,
+                                                          notebook_parent_dir=bb_nb_prefix)
+
     for nb_path in notebooks_to_execute:
         notebook_exec_pmill(nb_path, nb_path, None)
-    
+
     # now run the final notebook to merge slices together
     # work out the path to the first dataset
     dset_path = os.path.join(analysisroot, sample, f'{sample}_{first_dataset}', f'{sample}_{first_dataset}_dataset.h5')
-    nb_param = { # 3_merge_slices.ipynb
-         'PYTHONPATH': PYTHONPATH,
-         'dset_path': dset_path,
-         'phase_str': 'Fe',
-         'z_translation_motor': 'samtz',
-         'dset_prefix': "ff"
-        }
-    
+    nb_param = {  # 3_merge_slices.ipynb
+        'PYTHONPATH': PYTHONPATH,
+        'dset_path': dset_path,
+        'phase_str': 'Fe',
+        'z_translation_motor': 'samtz',
+        'dset_prefix': "ff"
+    }
+
     nb_path = os.path.join(bb_nb_prefix, '3_merge_slices.ipynb')
     notebook_route(analysisroot, [nb_path], [nb_param], skip_dir_check=True)
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     print(papermill.__path__)
     # test_tomographic_route()
     # test_pbp_route()
-    test_FeAu_JADB_tomo()
+    # test_FeAu_JADB_tomo()
     # test_FeAu_JADB_pbp()
-    # test_FeAu_JADB_bb()
-    # test_FeAu_JADB_bb_grid()
-    # test_FeAu_JADB_bb_friedel()
+    test_FeAu_JADB_bb()
+    test_FeAu_JADB_bb_grid()
+    test_FeAu_JADB_bb_friedel()


### PR DESCRIPTION
Moderately hacky approach to segment multi-scan Frelon data, then perform a 4D merge, if you did S3DXRD with the Frelon. See `S3DXRD/0_segment_frelon.ipynb` for usage guidelines - basically just pass `scan_number=[0, 1, 2, 3]` or any iterable to trigger the 4D merging over `(dty, omega)` rather than the 3D merging over `omega`. We are due for a major refactor of segmentation and merging soon to conceptually separate them and give users more freedom of what to do...