### PR TITLE
Fix error when saving grain with no translation

### DIFF
--- a/ImageD11/grain.py
+++ b/ImageD11/grain.py
@@ -316,7 +316,8 @@ def write_grain_file(filename, list_of_grains):
     f = open(filename, "w")
     for g in list_of_grains:
         t = g.translation
-        f.write("#translation: %g %g %g\n" % (t[0], t[1], t[2]))
+        if t is not None:
+            f.write("#translation: %g %g %g\n" % (t[0], t[1], t[2]))
         if hasattr(g, "name"):
             f.write("#name %s\n" % (g.name.rstrip()))
         if hasattr(g, "intensity_info"):


### PR DESCRIPTION
`grain.translation` can be `None`: https://github.com/FABLE-3DXRD/ImageD11/blob/0daa4f1e629a47de707aa7ce0344e1d09ae83cdc/ImageD11/grain.py#L55