### PR TITLE
dataset.obincens

### DIFF
--- a/ImageD11/sinograms/dataset.py
+++ b/ImageD11/sinograms/dataset.py
@@ -502,25 +502,25 @@ class DataSet:
 
     def guessbins(self):
         ny, nomega = self.shape
-        if self.obincens is not None:
-            self.omin = self.obincens[0]
-            self.omax = self.obincens[-1]
-        else:
+        if self.obincens is None:
             self.omin = self.omega.min()
             self.omax = self.omega.max()
+            if (self.omax - self.omin) > 360:
+                # multi-turn scan...
+                self.omin = 0.0
+                self.omax = 360.0
+                self.omega_for_bins = self.omega % 360
+            else:
+                self.omega_for_bins = self.omega
             self.obincens = np.linspace(self.omin, self.omax, nomega)
+        else:
+            self.omin = self.obincens[0]
+            self.omax = self.obincens[-1]
         self.ostep = (self.omax - self.omin) / (nomega - 1)
         if self.obinedges is None:
             self.obinedges = np.linspace(
                self.omin - self.ostep / 2, self.omax + self.ostep / 2, nomega + 1
             )
-        if (self.omax - self.omin) > 360:
-            # multi-turn scan...
-            self.omin = 0.0
-            self.omax = 360.0
-            self.omega_for_bins = self.omega % 360
-        else:
-            self.omega_for_bins = self.omega
         # values 0, 1, 2
         # shape = 3
         # step = 1

--- a/ImageD11/sinograms/lima_segmenter.py
+++ b/ImageD11/sinograms/lima_segmenter.py
@@ -470,7 +470,7 @@ def setup(
     pixels_in_spot=3,
     maskfile="",
     bgfile="",
-    cores_per_job=8,
+    cores_per_job=1,
     files_per_core=8,
     pythonpath=None,
 ):


### PR DESCRIPTION
Please do not merge yet. 

ds.ostep is still wrong.

We have:
```
1.1 : fast_start_pos = -119.55, fast_step_size = 0.05, fast_npoints = 7220
2.1 : fast_start_pos =  263.15, fast_step_size = 0.05, fast_npoints = 7220
...
10.1 : fast_start_pos =  3324.75, fast_step_size = 0.05, fast_npoints = 7220
```

We could pick up ds.ostep from master -> scan/instrument/fscan_parameters. 

Or we could leave it as a manual fix for this kind of case.

Or we could fit the slope omega vs frame number slope (interlaced?) for each row of the sinogram.
