### PR TITLE
Fix wrong frelon flat/dark correction

### DIFF
--- a/ImageD11/frelon_peaksearch.py
+++ b/ImageD11/frelon_peaksearch.py
@@ -304,7 +304,7 @@ class worker:
         if self.dark is not None:
             np.subtract(cor, self.dark, cor)
         if self.flat is not None:
-            np.divide(img, self.flat, cor)
+            np.divide(cor, self.flat, cor)
         return cor
 
     def bgsub(self, img, scale_factor=None):


### PR DESCRIPTION
It seems flat was overwriting dark rather than chaining the correction?