### PR TITLE
Fix a bug in rod2quat when r=[0,0,0], njit fails with np.linalg maybe ?

### DIFF
--- a/ImageD11/forward_model/ori_converter.py
+++ b/ImageD11/forward_model/ori_converter.py
@@ -109,9 +109,14 @@ def quat2u(q):
 
 @njit
 def rod2quat(r):
-
-	s = 1 / np.sqrt(1 + np.linalg.norm(r)**2)
-	return np.array([s, s * r[0], s * r[1], s * r[2]])
+	norm_sq = r[0]**2 + r[1]**2 + r[2]**2
+	s = 1 / np.sqrt(1 + norm_sq)
+	q = np.empty(4, dtype = np.float64)
+	q[0] = s
+	q[1] = s*r[0]
+	q[2] = s*r[1]
+	q[3] = s*r[2]
+	return q
 
 
 @njit


### PR DESCRIPTION
Error : 
```
TypingError: Failed in nopython mode pipeline (step: nopython frontend)
No implementation of function Function(<function norm at 0x14c0143dd760>) found for signature:
 >>> norm(array(int64, 1d, C))
```

Reproduce example : 
```
r = np.array([0,0,0])
ori_converter.rod2quat(r)
```