### PR TITLE
bugfix forfrelon segmenter when intensity normalization is active

### DIFF
--- a/ImageD11/frelon_peaksearch.py
+++ b/ImageD11/frelon_peaksearch.py
@@ -621,8 +621,8 @@ def segment_dataset(
             else:
                 all_frames_peaks_list = segment_master_file(
                     dataset.masterfile,
-                    "%s/measurement/%s"%(dataset.scans[scan_number], dataset.detector),
-                    dataset.omega_for_bins[scan_number],
+                    "%s/measurement/%s"%(dataset.scans[sn], dataset.detector),
+                    dataset.omega_for_bins[sn],
                     worker_args,
                     num_cpus,
                     scale_factor[sn],


### PR DESCRIPTION
Zombie code has awaken! :zombie: 

When iterating multiple scans for frelon segmentation with intensity normalisation active, there is a bug :bug:  in the indexation that causes a hard crash regradless of input. The typo has been fixed.

This implies that the template `0_segment_frelon.ipynb` is broken before this patch. With respet to this template, please also note that some of the defult frelon files (such as the dark) is not setup for user permission :see_no_evil: 

Cheers
Axel

