### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
@@ -51,6 +51,10 @@ jobs:
 
           # Use silx wheelhouse: needed for ppc64le
           CIBW_ENVIRONMENT_LINUX: "PIP_FIND_LINKS=https://www.silx.org/pub/wheelhouse/ PIP_TRUSTED_HOST=www.silx.org"
+
+          # Build without isolation needed to use older wheels for ppc64le
+          CIBW_BEFORE_BUILD: "pip install setuptools six wheel numpy --only-binary :all:"
+          CIBW_BUILD_FRONTEND: "build; args: --no-isolation"
 
           CIBW_BEFORE_TEST: "pip install --only-binary :all: fabio PyQt5 pyFAI"
           CIBW_TEST_EXTRAS: full

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: "PIP_FIND_LINKS=https://www.silx.org/pub/wheelhouse/ PIP_TRUSTED_HOST=www.silx.org"
 
           # Build without isolation needed to use older wheels for ppc64le
-          CIBW_BEFORE_BUILD: "pip install setuptools six wheel numpy --only-binary :all:"
+          CIBW_BEFORE_BUILD: "pip install setuptools wheel numpy --only-binary :all:"
           CIBW_BUILD_FRONTEND: "build; args: --no-isolation"
 
           CIBW_BEFORE_TEST: "pip install --only-binary :all: fabio PyQt5 pyFAI"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             cibw_archs: "auto64"
           #- os: windows-2019
           #  cibw_archs: "auto32"
-          - os: macos-13
+          - os: macos-14
             cibw_archs: "universal2"
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
           CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
-          # Do not build for pypy, muslinux and python3.12 on ppc64le
-          CIBW_SKIP: pp* *-musllinux_* cp312-*linux_ppc64le cp313-*linux_ppc64le
+          # Do not build for muslinux and python>=3.12 on ppc64le
+          CIBW_SKIP: "*-musllinux_* cp312-*linux_ppc64le cp313-*linux_ppc64le"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
           # Use silx wheelhouse: needed for ppc64le
@@ -59,8 +59,8 @@ jobs:
           CIBW_BEFORE_TEST: "pip install --only-binary :all: fabio PyQt5 pyFAI"
           CIBW_TEST_EXTRAS: full
           CIBW_TEST_COMMAND: pytest {project}/test
-          # Skip tests for 32bits and emulated architectures, arm64 macos and on Windows
-          CIBW_TEST_SKIP: "*-*linux_i686 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-win_amd64"
+          # Skip tests for 32bits, emulated architectures, on Windows and on macos python313 (missing siphash wheel)
+          CIBW_TEST_SKIP: "*-*linux_i686 *-*linux_{aarch64,ppc64le,s390x} *-win32 *-win_amd64 cp313-macosx_universal2"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: "PIP_FIND_LINKS=https://www.silx.org/pub/wheelhouse/ PIP_TRUSTED_HOST=www.silx.org"
 
           # Build without isolation needed to use older wheels for ppc64le
-          CIBW_BEFORE_BUILD: "pip install setuptools wheel numpy --only-binary :all:"
+          CIBW_BEFORE_BUILD: pip install setuptools wheel "numpy; python_version >= '3.9'" "oldest-supported-numpy; python_version < '3.9'" --only-binary numpy
           CIBW_BUILD_FRONTEND: "build; args: --no-isolation"
 
           CIBW_BEFORE_TEST: "pip install --only-binary :all: fabio PyQt5 pyFAI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = ["setuptools",
-            "six",
             "wheel",
             "numpy; python_version=='2.7'",
 	    "oldest-supported-numpy; python_version >='3.0' and python_version <'3.9'",

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,6 @@ scripts = ["ImageD11/rsv_mapper.py",
 # sfood -I ImageD11/depreciated -I build/ -v -u >sfood.out 2>sfood.err
 
 minimal = [  # can't compile without this
-    "six",
     'numpy',
     "setuptools",
     ]


### PR DESCRIPTION
This PR updates the release workflow to use `numpy` wheels for all platforms.

It also remove `six` from build dependencies since it is apparently not used for building the package.

closes #500