### PR TITLE
PandasColumnfile: enforce FLOATS/INTS column dtypes when reading CSV

### DIFF
--- a/ImageD11/columnfile.py
+++ b/ImageD11/columnfile.py
@@ -930,7 +930,13 @@ try:
             column_titles = raw[first_data_row - 1].replace("# ", "").lstrip(" ").split()
             # print(f"Column titles are {column_titles}")
 
-            self._df = pd.read_csv(filename, skiprows=range(first_data_row), sep=r'\s+', header=None, names=column_titles)
+            dtype = {}
+            for name in column_titles:
+                if name in FLOATS:
+                    dtype[name] = float
+                elif name in INTS:
+                    dtype[name] = int
+            self._df = pd.read_csv(filename, skiprows=range(first_data_row), sep=r'\s+', header=None, names=column_titles, dtype=dtype)
 
             self.parameters.dumbtypecheck()
             # self.set_attributes()


### PR DESCRIPTION
pd.read_csv auto-infers dtypes, so integer-valued columns like sc, fc, omega end up as int64 arrays. These propagate to cImageD11 functions that expect float64, causing copies (f2py) or ValueError on strict type checks in the new c2ImageD11. The base columnfile class already defines FLOATS and INTS lists — use them as dtype hints so PandasColumnfile respects the usual column type conventions.

Future ToDo will be deciding overall if we go for float32 or float64 in various columns. This PR has float64, so no change.