### PR TITLE
Add run_c2_tests.py migration test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# c2ImageD11 migration test: pip --target dir
+test/c2ImageD11_migration/c2_git/

--- a/test/c2ImageD11_migration/run_c2_tests.py
+++ b/test/c2ImageD11_migration/run_c2_tests.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import subprocess, sys, os
+
+test_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.dirname(os.path.dirname(test_dir))
+c2_target = os.path.join(test_dir, "c2_git")
+
+env = os.environ.copy()
+
+# Ensure c2ImageD11 is available
+try:
+    import c2ImageD11
+    print("c2ImageD11 found in Python path")
+except ImportError:
+    print("Installing c2ImageD11 from GitHub...")
+    subprocess.check_call([
+        sys.executable, "-m", "pip", "install",
+        "https://github.com/jonwright/c2ImageD11.git",
+        "--upgrade",
+        f"--target={c2_target}",
+    ])
+    pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = c2_target + (os.pathsep + pythonpath if pythonpath else "")
+
+# Run test suite with f2py backend
+print("\n=== Test suite: f2py backend ===")
+r1 = subprocess.run(
+    [sys.executable, "-m", "pytest", "test/", "-v"],
+    cwd=repo_root, env=env,
+)
+
+# Run test suite with c2ImageD11 backend
+env["IMAGED11_USE_C2"] = "1"
+print("\n=== Test suite: c2ImageD11 backend ===")
+r2 = subprocess.run(
+    [sys.executable, "-m", "pytest", "test/", "-v"],
+    cwd=repo_root, env=env,
+)
+
+# Summary
+print("\n" + "=" * 50)
+print(f"f2py backend:      {'PASS' if r1.returncode == 0 else 'FAIL'} ({r1.returncode})")
+print(f"c2ImageD11 backend: {'PASS' if r2.returncode == 0 else 'FAIL'} ({r2.returncode})")
+sys.exit(0 if r1.returncode == 0 and r2.returncode == 0 else 1)

--- a/test/c2ImageD11_migration/run_c2_tests.py
+++ b/test/c2ImageD11_migration/run_c2_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import subprocess, sys, os
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -17,7 +17,7 @@ except ImportError:
         sys.executable, "-m", "pip", "install",
         "https://github.com/jonwright/c2ImageD11.git",
         "--upgrade",
-        f"--target={c2_target}",
+        "--target={}".format(c2_target),
     ])
     pythonpath = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = c2_target + (os.pathsep + pythonpath if pythonpath else "")
@@ -39,6 +39,8 @@ r2 = subprocess.run(
 
 # Summary
 print("\n" + "=" * 50)
-print(f"f2py backend:      {'PASS' if r1.returncode == 0 else 'FAIL'} ({r1.returncode})")
-print(f"c2ImageD11 backend: {'PASS' if r2.returncode == 0 else 'FAIL'} ({r2.returncode})")
+print("f2py backend:      {} ({})".format(
+    'PASS' if r1.returncode == 0 else 'FAIL', r1.returncode))
+print("c2ImageD11 backend: {} ({})".format(
+    'PASS' if r2.returncode == 0 else 'FAIL', r2.returncode))
 sys.exit(0 if r1.returncode == 0 and r2.returncode == 0 else 1)


### PR DESCRIPTION
Script to run pytest with the new c2ImageD11 which might eventually replace the f2py wrappers in here now. More testing needed, at least the pytest runs with 0.4.1 on c2ImageD11.