### PR TITLE
Store pbp peak index as a group inside the icolf file

### DIFF
--- a/ImageD11/nbGui/S3DXRD/run_pbp_recon_chunk.py
+++ b/ImageD11/nbGui/S3DXRD/run_pbp_recon_chunk.py
@@ -20,7 +20,7 @@ def load_config(config_path):
             elif key in {'minpks', 'nprocs', 'hmax'}:
                 val = int(val)
             else:
-                val = val  # parfile, phase_name, symmetry, icolf_filename, index_filename
+                val = val  # parfile, phase_name, symmetry, icolf_filename
             config[key] = val
     return config
 
@@ -60,7 +60,6 @@ def run_chunk(config_path, indices_path, grains_file):
     pbp.point_by_point(
         grains_filename=grains_file,
         icolf_filename=config['icolf_filename'],
-        index_filename=config['index_filename'],
         nprocs=config['nprocs'],
         debugpoints=points
     )

--- a/ImageD11/sinograms/point_by_point.py
+++ b/ImageD11/sinograms/point_by_point.py
@@ -39,7 +39,6 @@ from ImageD11.peakselect import mask_rings_by_ifrac
 from ImageD11.sinograms import geometry
 from ImageD11.sinograms.voxel_mask import (
     VoxelSinoMasker, fill_voxel_idx, max_candidates as vm_max_candidates,
-    default_index_filename,
     save_peak_index_cache, load_peak_index_cache,
     choose_omega_bins,
     _CACHE_VERSION)
@@ -509,7 +508,7 @@ colglobal = None
 partglobal = None
 bufglobal = None
 
-def initializer(parfile, phase_name, symmetry, colfile, index_filename, loglevel=3):
+def initializer(parfile, phase_name, symmetry, colfile, loglevel=3):
     global ucglobal, symglobal, parglobal, colglobal, partglobal, bufglobal
     try:
         if threadpoolctl is not None:
@@ -521,18 +520,19 @@ def initializer(parfile, phase_name, symmetry, colfile, index_filename, loglevel
         ImageD11.indexing.loglevel = loglevel
  
         # mmap, not read: identical and read-only in every worker, so one
-        # mapping through the page cache replaces one copy per process
-        partglobal = load_peak_index_cache(index_filename, mmap=True)
+        # mapping through the page cache replaces one copy per process.
+        # The peak index lives in the PBPPeakIndex group of the icolf file.
+        partglobal = load_peak_index_cache(colfile, mmap=True)
         if partglobal is None:
             raise RuntimeError(
                 "peak index %s is missing or stale -- rerun setpeaks()"
-                % index_filename)
+                % colfile)
  
         n = partglobal["maxlocal"]
         if n is None:
             raise RuntimeError(
                 "peak index %s has no maxlocal -- it predates _CACHE_VERSION "
-                "%d. Rerun setpeaks()." % (index_filename, _CACHE_VERSION))
+                "%d. Rerun setpeaks()." % (colfile, _CACHE_VERSION))
 
         bufglobal = {
             "idx": np.empty(n, np.int64),
@@ -597,14 +597,15 @@ class PBP:
         self.phase_name = phase_name
 
         self.icolf_filename = None      # set by setpeaks
-        self.index_filename = None      # set by setpeaks
 
     def _build_index(self, verbose=True):
         """Take the partition setpeaks built, size the buffers with
         max_candidates, and write it to disk ready for mmap in the workers.
         Returns the partition dictionary.
         """
-        self.index_filename = default_index_filename(self)
+        # The partition is written into the PBPPeakIndex group of the icolf
+        # file (which setpeaks already wrote the peaks group into).
+        icolf_filename = self.icolf_filename
  
         # The partition is already built in self._masker; we only need to
         # size the buffers and write it out for the workers.
@@ -647,9 +648,9 @@ class PBP:
                       "sparse and traversal will dominate. Check whether the "
                       "frm decode ran; the heuristic over-refines without it.")
         try:
-            save_peak_index_cache(idx, self.index_filename)
+            save_peak_index_cache(idx, icolf_filename)
             if verbose:
-                print("saved peak index to %s" % self.index_filename)
+                print("saved peak index to %s" % icolf_filename)
         except OSError as e:
             print("could not write index cache (%s), continuing" % e)
         return idx
@@ -733,13 +734,10 @@ class PBP:
 
         self.icolf_filename = icolf_filename
 
-        # Delete existing partition if present
-        index_filename = default_index_filename(self)
-        if os.path.exists(index_filename):
-            os.remove(index_filename)
-
         # Prepare the partition index for memory mapping in the workers
-        # It is actually mem-mapped in the initializer
+        # It is actually mem-mapped in the initializer.
+        # The partition is stored in the PBPPeakIndex group of the icolf file
+        # (just written above), so there is no separate sidecar to delete.
         self._build_index()
 
 
@@ -778,7 +776,6 @@ class PBP:
             f.write("phase_name={}\n".format(self.phase_name))
             f.write("symmetry={}\n".format(self.symmetry))
             f.write("icolf_filename={}\n".format(self.icolf_filename))
-            f.write("index_filename={}\n".format(self.index_filename))
             f.write("y0={}\n".format(self.y0))
             f.write("hkl_tol={}\n".format(self.hkl_tol))
             f.write("ds_tol={}\n".format(self.ds_tol))
@@ -865,7 +862,6 @@ OMP_NUM_THREADS=1 PYTHONPATH={id11_code_path} python {python_script_path} \
             self,
             grains_filename,
             icolf_filename=None,  # use self
-            index_filename=None,  # use self
             nprocs=None,
             gridstep=1,
             debugpoints=None,
@@ -873,14 +869,11 @@ OMP_NUM_THREADS=1 PYTHONPATH={id11_code_path} python {python_script_path} \
     ):
         """
         grains_filename = output file
-        icolf_filename = hdf5file to write. Allows mmap to be used.
-        index_filename = hdf5file for voxel_mask index to mmap
+        icolf_filename = hdf5 file to read. Allows mmap to be used. The
+            voxel_mask peak index is read from its PBPPeakIndex group.
         """
         if icolf_filename is not None:
             self.icolf_filename = icolf_filename
-
-        if index_filename is not None:
-            self.index_filename = index_filename
         
         self.loglevel = loglevel
         
@@ -921,11 +914,11 @@ OMP_NUM_THREADS=1 PYTHONPATH={id11_code_path} python {python_script_path} \
         # worker passes: a read-only memmap is a distinct numba type from a
         # writable array, so this loads the index and columns the same way
         # initializer does rather than using dummy arrays.
-        _part = load_peak_index_cache(self.index_filename, mmap=True)
+        _part = load_peak_index_cache(self.icolf_filename, mmap=True)
         if _part is None:
             raise RuntimeError(
                 "peak index %s is missing or the wrong version -- rerun "
-                "setpeaks()" % self.index_filename)
+                "setpeaks()" % self.icolf_filename)
 
         _sm = ImageD11.columnfile.mmap_h5colf(self.icolf_filename)
         _n = _part["maxlocal"]
@@ -968,7 +961,6 @@ OMP_NUM_THREADS=1 PYTHONPATH={id11_code_path} python {python_script_path} \
                             self.phase_name,
                             self.symmetry,
                             self.icolf_filename,
-                            self.index_filename,
                             self.loglevel,
                     ),
             ) as p:

--- a/ImageD11/sinograms/voxel_mask.py
+++ b/ImageD11/sinograms/voxel_mask.py
@@ -56,38 +56,20 @@ _CACHE_VERSION = 7
 _PEAK_H5GROUP = "PBPPeakIndex"
 
 
-def default_index_filename(manager):
-    """Generate a default filename for the peak + gve index.
-
-    Parameters
-    ----------
-    manager
-        PBP or PBPRefine object
-
-    Returns
-    -------
-        Filename to save/load peak index/gve caches
-
-    Raises
-    ------
-    ValueError
-        If no icolf_filename on the manager object
-    """
-    base = getattr(manager, "icolf_filename", None)
-    if base is None:
-        raise ValueError("no icolf_filename to derive an index cache path from")
-    return os.path.splitext(base)[0] + "_pbpindex.h5"
-
-
 def save_peak_index_cache(idx, filename):
-    """Save peak index to an on-disk H5 cache, with versioning.
+    """Save peak index into an HDF5 group in the icolf file, with versioning.
+
+    The peak index is a lookup/partition table FOR the icolf it accompanies,
+    so it is stored as the "PBPPeakIndex" group inside the same HDF5 file as
+    the icolf's "peaks" group rather than as a separate sidecar file. The
+    columns group is left untouched; only the peak index group is replaced.
 
     Parameters
     ----------
     idx
         Peak index to cache
     filename
-        Filename to save to
+        icolf HDF5 file to store the index group in
 
     """
     with h5py.File(filename, "a") as hout:
@@ -110,7 +92,10 @@ def save_peak_index_cache(idx, filename):
 
 
 def load_peak_index_cache(filename, mmap=False, verbose=True):
-    """Load peak index from an on-disk H5 cache, with optional mem-map.
+    """Load peak index from the icolf HDF5 file, with optional mem-map.
+
+    Reads the "PBPPeakIndex" group written by save_peak_index_cache from the
+    icolf HDF5 file.
 
     Use it from multiprocessing workers: the arrays are identical in every
     worker and never written, so one mapping shared through the page cache
@@ -120,7 +105,7 @@ def load_peak_index_cache(filename, mmap=False, verbose=True):
     Parameters
     ----------
     filename
-        Filename to load from
+        icolf HDF5 file to load the index group from
     mmap, optional
         returns read-only np.memmap views instead of copies. by default False
     verbose, optional


### PR DESCRIPTION
TEST THIS BEFORE MERGING: AI WRITTEN CODE


The voxel_mask peak index is a lookup/partition table for the icolf it accompanies, so store it as the PBPPeakIndex group in the same HDF5 file instead of a sibling _pbpindex.h5 sidecar file. The peaks group is left untouched; mmap_h5colf and colfile_from_hdf find columns by ImageD11_type, so the extra group does not confuse them.

Remove default_index_filename and the PBP.index_filename attribute / point_by_point index_filename parameter; the partition is now always read from the icolf file in the initializer, warm-up and SLURM chunk worker.