### PR TITLE
unitcell: raise clear error from makerings() when no peaks found

### DIFF
--- a/ImageD11/unitcell.py
+++ b/ImageD11/unitcell.py
@@ -559,6 +559,10 @@ class unitcell:
                 and getattr(self, "ringds", None) is not None):
             return
         self.peaks = self.gethkls(limit + tol)  # [ ds, [hkl] ]
+        if len(self.peaks) == 0:
+            raise ValueError(
+                "No peaks found for limit=%s; try increasing limit" % (limit,)
+            )
         self.ringds = []  # a list of floats
         self.ringhkls = {}  # a dict of lists of integer hkl
         # Append first peak


### PR DESCRIPTION
Fixes #538. gethkls(limit+tol) legitimately returns an empty list for some lattice parameter / limit combinations (e.g. a large unit cell with a small limit), which made makerings() crash with a bare IndexError on self.peaks[0]. ringtths() already guards the equivalent empty-list case with a clear ValueError; makerings() gets the same treatment.