### PR TITLE
CI: prefer binary wheels for extras to avoid pyFAI building from source

### DIFF
--- a/.github/workflows/build_flake_pytest_ubuntu2004.yml
+++ b/.github/workflows/build_flake_pytest_ubuntu2004.yml
@@ -39,7 +39,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
-        python -m pip install .[full]
+        python -m pip install --prefer-binary .[full]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Fixes #559. ImageD11 itself still builds from source (local path installs are never resolved against an index), only PyPI-resolved extras like pyFAI are affected.