### PR TITLE
setup.py: add jupyter to the full/more extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,7 @@ more = [
     "lmfit",       # in sandbox
     "sympy",       # for maths
     'ipywidgets ; python_version >= "3"',  # for notebook nbGui
+    'jupyter ; python_version >= "3"',  # so users can open/run the nbGui notebooks
     'pyopencl; python_version >= "3"',    # (was?) in sandbox
     'numexpr <= 2.7.0; python_version < "3" ',
     'pyFAI ; python_version >= "3" ',   # pypi problematic


### PR DESCRIPTION
Fixes #605. A standard ImageD11 install has no way to open/run the nbGui notebooks; ipywidgets was already there but not the jupyter front-end itself. Gated to python_version >= 3, matching ipywidgets just above it.