### PR TITLE
sparseframe: add optional smoothing to sparse_localmax

### DIFF
--- a/ImageD11/sparseframe.py
+++ b/ImageD11/sparseframe.py
@@ -633,12 +633,19 @@ def sparse_connected_pixels(
     return nlabel
 
 
-def sparse_localmax(frame, label_name="localmax", data_name="intensity"):
+def sparse_localmax(frame, label_name="localmax", data_name="intensity", smooth=False):
+    """smooth=True applies the same cImageD11.sparse_smooth pre-filter that
+    SparseScan.lmlabel already applies before localmax labelling.
+    Default is False to keep existing behaviour/output unchanged."""
     labels = np.zeros(frame.nnz, "i")
     vmx = np.zeros(frame.nnz, np.float32)
     imx = np.zeros(frame.nnz, "i")
+    if smooth:
+        signal = sparse_smooth(frame, data_name=data_name)
+    else:
+        signal = frame.pixels[data_name].astype(np.float32, copy=False)
     nlabel = cImageD11.sparse_localmaxlabel(
-        frame.pixels[data_name].astype(np.float32, copy=False),
+        signal,
         frame.row,
         frame.col,
         vmx,

--- a/test/test_sparse_localmax_smooth.py
+++ b/test/test_sparse_localmax_smooth.py
@@ -1,0 +1,54 @@
+"""
+Checks that sparseframe.sparse_localmax(frame, smooth=...) reproduces the
+per-frame labelling that SparseScan.lmlabel(smooth=...) already does
+internally, for both the smoothed and unsmoothed paths.
+"""
+from __future__ import print_function
+
+import os
+import unittest
+
+import numpy as np
+
+from ImageD11 import sparseframe
+
+SPARSEFILE = os.path.join(
+    os.path.dirname(__file__), "pixelmapper", "silicon_fullscan_strong_sparse.h5"
+)
+
+
+class TestSparseLocalmaxSmooth(unittest.TestCase):
+    def setUp(self):
+        self.scan = sparseframe.SparseScan(SPARSEFILE, "1.1")
+        # a handful of frames with plenty of pixels, so localmax has real work to do
+        self.frame_ids = np.argsort(self.scan.nnz)[-5:]
+        for i in self.frame_ids:
+            self.assertGreater(self.scan.nnz[i], 0)
+
+    def check_smooth_option(self, smooth):
+        # path A: label the whole scan with SparseScan.lmlabel (countall=False
+        # so labels restart from 1 on each frame, matching a single sparse_frame)
+        scan = sparseframe.SparseScan(SPARSEFILE, "1.1")
+        scan.lmlabel(smooth=smooth, countall=False)
+
+        for i in self.frame_ids:
+            # path B: pull out a single frame and label it with sparse_localmax
+            frame = self.scan.getframe(int(i))
+            nlabel = sparseframe.sparse_localmax(frame, smooth=smooth)
+
+            labels_a = scan.labels[scan.ipt[i] : scan.ipt[i + 1]]
+            labels_b = frame.pixels["localmax"]
+
+            self.assertGreater(nlabel, 0)
+            self.assertEqual(scan.nlabels[i], nlabel)
+            np.testing.assert_array_equal(labels_a, labels_b)
+
+    def test_smooth_true(self):
+        self.check_smooth_option(True)
+
+    def test_smooth_false(self):
+        self.check_smooth_option(False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #159. SparseScan.lmlabel already smooths via cImageD11.sparse_smooth before localmax labelling, but the frame-level equivalent sparse_localmax() had no way to do the same. Adds a smooth=False kwarg (default keeps existing behaviour/output unchanged) that reuses the existing sparse_smooth helper, same as SparseScan.lmlabel already does.