### PR TITLE
readthedocs: exclude sandbox and depreciated from apidoc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ build:
   jobs:
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python setup.py build_ext --inplace
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python -m sphinx.ext.apidoc -o docs/sphx ImageD11
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python -m sphinx.ext.apidoc -o docs/sphx ImageD11 ImageD11/sandbox ImageD11/depreciated
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
Fixes #491. sphinx-apidoc was scanning the whole ImageD11 package, including ImageD11/sandbox, which has modules doing top-level 'import PyTango' / 'import minuit' / 'import PyQt4' (none of them real dependencies, all listed under setup.py's 'rare' extra and absent from docs/sphx/requirements.txt). Autodoc importing those modules hung the build indefinitely rather than failing cleanly (reproduced locally: with sandbox included the build never returned; excluding it, the same build completes: "build succeeded, 149 warnings"). depreciated is excluded too since it has the same PyTango-import problem and is already excluded from the flake8 CI step for the same kind of reason.

Note: getting the readthedocs project itself re-enabled after this is a support request only the project owner can make, not a code change.